### PR TITLE
Add possibility to set jgit nfs related config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added footer extension points for links and avatar
 - Create OpenAPI specification during build
 - Extension point entries with supplied extensionName are sorted ascending
+- Possibility to configure git core config entries for jgit like core.trustfolderstat and core.supportsatomicfilecreation
 
 ### Changed
 - New footer design

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ node('docker') {
       }
 
       stage('Integration Test') {
-        mvn 'verify -Pit -pl :scm-webapp,:scm-it -Dmaven.test.failure.ignore=true'
+        mvn 'verify -Pit -pl :scm-webapp,:scm-it -Dmaven.test.failure.ignore=true -Dscm.git.core.supportsatomicfilecreation=false'
       }
 
       stage('SonarQube') {

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitConfigContextListener.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitConfigContextListener.java
@@ -1,0 +1,41 @@
+package sonia.scm.repository.spi;
+
+import org.eclipse.jgit.util.SystemReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sonia.scm.plugin.Extension;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import java.util.Map;
+
+@Extension
+public class GitConfigContextListener implements ServletContextListener {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GitConfigContextListener.class);
+  private static final String SCM_JGIT_CORE = "scm.git.core.";
+
+  @Override
+  public void contextInitialized(ServletContextEvent sce) {
+    System.getProperties()
+      .entrySet().stream()
+      .filter(e -> e.getKey().toString().startsWith(SCM_JGIT_CORE))
+      .forEach(this::setConfig);
+  }
+
+  private void setConfig(Map.Entry<Object, Object> property) {
+    String key = property.getKey().toString().substring(SCM_JGIT_CORE.length());
+    String value = property.getValue().toString();
+    try {
+      SystemReader.getInstance().getSystemConfig().setString("core", null, key, value);
+      LOG.info("set git config core.{} = {}", key,value);
+    } catch (Exception e) {
+      LOG.error("could not set git config core.{} = {}", key,value, e);
+    }
+  }
+
+  @Override
+  public void contextDestroyed(ServletContextEvent sce) {
+    // nothing to do
+  }
+}

--- a/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/GitConfigContextListenerTest.java
+++ b/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/GitConfigContextListenerTest.java
@@ -1,0 +1,21 @@
+package sonia.scm.repository.spi;
+
+import org.eclipse.jgit.errors.ConfigInvalidException;
+import org.eclipse.jgit.util.SystemReader;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GitConfigContextListenerTest {
+
+  @Test
+  void shouldSetGitConfig() throws IOException, ConfigInvalidException {
+    System.setProperty("scm.git.core.someTestKey", "testValue");
+    new GitConfigContextListener().contextInitialized(null);
+    assertThat(
+      SystemReader.getInstance().getSystemConfig().getString("core", null, "someTestKey")
+    ).isEqualTo("testValue");
+  }
+}


### PR DESCRIPTION
It may be necessary for users to configure jgit behaviour related to
file handling. This commit makes the following two configurations
available (among others):

- core.trustfolderstat
- core.supportsatomicfilecreation

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
