### PR TITLE
Fix authentication for repositories with anonymous read access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Authentication for write requests for repositories with anonymous read access ([#108](https://github.com/scm-manager/scm-manager/pull/1081))
+
 ## 2.0.0-rc6 - 2020-03-26
 ### Added
 - Extension point to add links to the repository cards from plug ins ([#1041](https://github.com/scm-manager/scm-manager/pull/1041))

--- a/scm-core/src/main/java/sonia/scm/web/filter/PermissionFilter.java
+++ b/scm-core/src/main/java/sonia/scm/web/filter/PermissionFilter.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.web.filter;
 
 import org.apache.shiro.SecurityUtils;
@@ -35,7 +35,7 @@ import sonia.scm.repository.Repository;
 import sonia.scm.repository.RepositoryPermissions;
 import sonia.scm.repository.spi.ScmProviderHttpServlet;
 import sonia.scm.repository.spi.ScmProviderHttpServletDecorator;
-import sonia.scm.security.Role;
+import sonia.scm.security.Authentications;
 import sonia.scm.security.ScmSecurityException;
 import sonia.scm.util.HttpUtil;
 
@@ -177,7 +177,7 @@ public abstract class PermissionFilter extends ScmProviderHttpServletDecorator
     HttpServletResponse response, Subject subject)
     throws IOException
   {
-    if (subject.hasRole(Role.USER))
+    if (!Authentications.isAuthenticatedSubjectAnonymous())
     {
       sendNotEnoughPrivilegesError(request, response);
     }

--- a/scm-core/src/test/java/sonia/scm/web/filter/PermissionFilterTest.java
+++ b/scm-core/src/test/java/sonia/scm/web/filter/PermissionFilterTest.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.web.filter;
 
 import com.github.sdorra.shiro.ShiroRule;
@@ -78,6 +78,17 @@ public class PermissionFilterTest {
   @Test
   @SubjectAware(username = "reader", password = "secret")
   public void shouldBlockForReaderOnWriteRequest() throws IOException, ServletException {
+    writeRequest = true;
+
+    permissionFilter.service(request, response, REPOSITORY);
+
+    verify(response).sendError(eq(403));
+    verify(delegateServlet, never()).service(request, response, REPOSITORY);
+  }
+
+  @Test
+  @SubjectAware(username = "_anonymous", password = "secret")
+  public void shouldBlockForAnonymousOnWriteRequestWithAuthenticationRequest() throws IOException, ServletException {
     writeRequest = true;
 
     permissionFilter.service(request, response, REPOSITORY);

--- a/scm-core/src/test/resources/sonia/scm/shiro.ini
+++ b/scm-core/src/test/resources/sonia/scm/shiro.ini
@@ -4,6 +4,7 @@ admin = secret, admin
 writer = secret, repo_write
 reader = secret, repo_read
 unpriv = secret
+_anonymous = secret
 
 [roles]
 admin = *


### PR DESCRIPTION
## Proposed changes

Repositories with anonymous read access could not be written any more,
because for write requests there was no authentication request. This
fixes the check for anonymous access and requests username and
password, again.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
