### PR TITLE
Bugfix/scrollable menu

### DIFF
--- a/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
+++ b/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
@@ -34615,7 +34615,7 @@ exports[`Storyshots Navigation|Secondary Default 1`] = `
     className="column is-3"
   >
     <aside
-      className="SecondaryNavigation__SectionContainer-sc-8p1rgi-0 bfoGdF menu"
+      className="SecondaryNavigation__SectionContainer-sc-8p1rgi-0 hcDqkI menu"
     >
       <div>
         <p
@@ -34677,7 +34677,7 @@ exports[`Storyshots Navigation|Secondary Extension Point 1`] = `
     className="column is-3"
   >
     <aside
-      className="SecondaryNavigation__SectionContainer-sc-8p1rgi-0 bfoGdF menu"
+      className="SecondaryNavigation__SectionContainer-sc-8p1rgi-0 hcDqkI menu"
     >
       <div>
         <p
@@ -34765,7 +34765,7 @@ exports[`Storyshots Navigation|Secondary Sub Navigation 1`] = `
     className="column is-3"
   >
     <aside
-      className="SecondaryNavigation__SectionContainer-sc-8p1rgi-0 bfoGdF menu"
+      className="SecondaryNavigation__SectionContainer-sc-8p1rgi-0 hcDqkI menu"
     >
       <div>
         <p

--- a/scm-ui/ui-components/src/navigation/SecondaryNavigation.tsx
+++ b/scm-ui/ui-components/src/navigation/SecondaryNavigation.tsx
@@ -38,6 +38,11 @@ const SectionContainer = styled.aside`
   position: sticky;
   position: -webkit-sticky; /* Safari */
   top: 2rem;
+
+  @media (max-height: 900px) {
+    position: relative;
+    top: 0;
+  }
 `;
 
 const Icon = styled.i<CollapsedProps>`


### PR DESCRIPTION
## Proposed changes

Secondary menu no longer scrolls beyond a certain screen size in order to be able to display all elements

### Your checklist for this pull request

- [x] PR is well described
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [ ] CHANGELOG.md updated
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
