### PR TITLE
Use AES/GCM/NoPadding instead of AES/CTR/PKCS5PADDING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Protocol URI for git commands under windows ([#1108](https://github.com/scm-manager/scm-manager/pull/1108))
+- Fix usage of invalid cipher algorith on newer java versions ([#1110](https://github.com/scm-manager/scm-manager/issues/1110),[#1112](https://github.com/scm-manager/scm-manager/pull/1112))
 
 ## [2.0.0-rc7] - 2020-04-09
 ### Added


### PR DESCRIPTION
## Proposed changes

Use AES/GCM/NoPadding instead of AES/CTR/PKCS5PADDING to ensure cipher works with newer java versions.

Value are now encoded with a prefix to detect the new format.
Old values are read with the old algorithm to ensure compatibility with older scm homes.
The default key is rewritten if the old format was detected during read.
A warning is logged if the old format is used.

Fixes #1110 

### Your checklist for this pull request

- [X] PR is well described
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests
- [x] CHANGELOG.md updated

### Checklist for branch merge request (not required for forks)

- [x] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [x] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
