### PR TITLE
Add class to manually validate rest data transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add iconStyle + onClick option and story shot for icon component ([#1100](https://github.com/scm-manager/scm-manager/pull/1100))
 - Making WebElements (Servlet or Filter) optional by using the `@Requires` annotation ([#1101](https://github.com/scm-manager/scm-manager/pull/1101))
+- Add class to manually validate rest data transfer objects with javax validation annotations ([#1114](https://github.com/scm-manager/scm-manager/pull/1114))
 
 ### Changed
 - Removed the `requires` attribute on the `@Extension` annotation and instead create a new `@Requires` annotation ([#1097](https://github.com/scm-manager/scm-manager/pull/1097))

--- a/scm-core/pom.xml
+++ b/scm-core/pom.xml
@@ -205,6 +205,7 @@
       <groupId>org.glassfish</groupId>
       <artifactId>javax.el</artifactId>
       <version>3.0.1-b11</version>
+      <scope>test</scope>
     </dependency>
 
     <!-- util -->

--- a/scm-core/pom.xml
+++ b/scm-core/pom.xml
@@ -194,6 +194,19 @@
       <artifactId>hibernate-validator</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>javax.el</groupId>
+      <artifactId>javax.el-api</artifactId>
+      <version>3.0.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>javax.el</artifactId>
+      <version>3.0.1-b11</version>
+    </dependency>
+
     <!-- util -->
 
     <dependency>

--- a/scm-core/src/main/java/sonia/scm/web/api/DtoValidator.java
+++ b/scm-core/src/main/java/sonia/scm/web/api/DtoValidator.java
@@ -1,0 +1,43 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.web.api;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import java.util.Set;
+
+public class DtoValidator {
+  void validate(Object configuration) {
+    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    Validator validator = factory.getValidator();
+    Set<ConstraintViolation<Object>> violations = validator.validate(configuration);
+    if (!violations.isEmpty()) {
+      throw new ConstraintViolationException(violations);
+    }
+  }
+}

--- a/scm-core/src/test/java/sonia/scm/web/api/DtoValidatorTest.java
+++ b/scm-core/src/test/java/sonia/scm/web/api/DtoValidatorTest.java
@@ -24,24 +24,36 @@
 
 package sonia.scm.web.api;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
-import java.util.Set;
+import org.junit.jupiter.api.Test;
 
-public final class DtoValidator {
+import javax.validation.ValidationException;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 
-  private DtoValidator() {
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DtoValidatorTest {
+
+  @Test
+  void shouldValidateInvalidBean() {
+    assertThrows(
+      ValidationException.class,
+      () -> DtoValidator.validate(new AnyQuestion(43))
+    );
   }
 
-  public static void validate(Object configuration) {
-    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
-    Validator validator = factory.getValidator();
-    Set<ConstraintViolation<Object>> violations = validator.validate(configuration);
-    if (!violations.isEmpty()) {
-      throw new ConstraintViolationException(violations);
+  @Test
+  void shouldValidateValidBean() {
+    DtoValidator.validate(new AnyQuestion(42));
+  }
+
+  static class AnyQuestion {
+    @Min(42)
+    @Max(42)
+    int answer;
+
+    public AnyQuestion(int answer) {
+      this.answer = answer;
     }
   }
 }

--- a/scm-core/src/test/resources/META-INF/validation.xml
+++ b/scm-core/src/test/resources/META-INF/validation.xml
@@ -1,0 +1,34 @@
+<!--
+
+    MIT License
+
+    Copyright (c) 2020-present Cloudogu GmbH and Contributors
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+
+-->
+<validation-config
+  xmlns="http://jboss.org/xml/ns/javax/validation/configuration"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://jboss.org/xml/ns/javax/validation/configuration"
+  version="1.1">
+
+  <parameter-name-provider>org.hibernate.validator.parameternameprovider.ReflectionParameterNameProvider</parameter-name-provider>
+
+</validation-config>

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/JavaxValidationExceptionMapper.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/JavaxValidationExceptionMapper.java
@@ -21,30 +21,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.api.v2;
 
-import org.jboss.resteasy.api.validation.ResteasyViolationException;
 import sonia.scm.api.v2.resources.ResteasyViolationExceptionToErrorDtoMapper;
 import sonia.scm.web.VndMediaType;
 
 import javax.inject.Inject;
+import javax.validation.ConstraintViolationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
 @Provider
-public class ResteasyValidationExceptionMapper implements ExceptionMapper<ResteasyViolationException> {
+public class JavaxValidationExceptionMapper implements ExceptionMapper<ConstraintViolationException> {
 
   private final ResteasyViolationExceptionToErrorDtoMapper mapper;
 
   @Inject
-  public ResteasyValidationExceptionMapper(ResteasyViolationExceptionToErrorDtoMapper mapper) {
+  public JavaxValidationExceptionMapper(ResteasyViolationExceptionToErrorDtoMapper mapper) {
     this.mapper = mapper;
   }
 
   @Override
-  public Response toResponse(ResteasyViolationException exception) {
+  public Response toResponse(ConstraintViolationException exception) {
     return Response
       .status(Response.Status.BAD_REQUEST)
       .type(VndMediaType.ERROR_TYPE)

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/ResteasyViolationExceptionToErrorDtoMapper.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/ResteasyViolationExceptionToErrorDtoMapper.java
@@ -21,10 +21,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.api.v2.resources;
 
-import org.jboss.resteasy.api.validation.ResteasyViolationException;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -32,6 +31,7 @@ import org.mapstruct.MappingTarget;
 import org.slf4j.MDC;
 
 import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -42,7 +42,8 @@ public abstract class ResteasyViolationExceptionToErrorDtoMapper {
   @Mapping(target = "transactionId", ignore = true)
   @Mapping(target = "context", ignore = true)
   @Mapping(target = "url", ignore = true)
-  public abstract ErrorDto map(ResteasyViolationException exception);
+  @Mapping(target = "violations", ignore = true)
+  public abstract ErrorDto map(ConstraintViolationException exception);
 
   @AfterMapping
   void setTransactionId(@MappingTarget ErrorDto dto) {
@@ -50,7 +51,7 @@ public abstract class ResteasyViolationExceptionToErrorDtoMapper {
   }
 
   @AfterMapping
-  void mapViolations(ResteasyViolationException exception, @MappingTarget ErrorDto dto) {
+  void mapViolations(ConstraintViolationException exception, @MappingTarget ErrorDto dto) {
     List<ErrorDto.ConstraintViolationDto> violations =
       exception.getConstraintViolations()
         .stream()


### PR DESCRIPTION
## Proposed changes

It may be necessary to validate objects annotated wit javax validation
tags, that could not be validated using the internal resteasy validation
mechanism, eg. objects created manually. This new class makes this
possible by simply calling validate(dto).

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
