### PR TITLE
Let build break on duplicates in classpath

### DIFF
--- a/scm-webapp/pom.xml
+++ b/scm-webapp/pom.xml
@@ -651,11 +651,18 @@
         <groupId>org.basepom.maven</groupId>
         <artifactId>duplicate-finder-maven-plugin</artifactId>
         <version>1.3.0</version>
+        <executions>
+          <execution>
+            <id>default</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
         <configuration>
           <printEqualFiles>false</printEqualFiles>
-          <failBuildInCaseOfDifferentContentConflict>false</failBuildInCaseOfDifferentContentConflict>
-          <failBuildInCaseOfEqualContentConflict>false</failBuildInCaseOfEqualContentConflict>
-          <failBuildInCaseOfConflict>false</failBuildInCaseOfConflict>
+          <failBuildInCaseOfDifferentContentConflict>true</failBuildInCaseOfDifferentContentConflict>
           <checkCompileClasspath>true</checkCompileClasspath>
           <checkRuntimeClasspath>true</checkRuntimeClasspath>
           <checkTestClasspath>false</checkTestClasspath>


### PR DESCRIPTION
## Proposed changes

Let the `duplicate-finder-maven-plugin` break the build when there are duplicated classes on either runtime or compile time classpath (test classpath is ignored for the time being). The check is performed after unit tests are run.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [ ] CHANGELOG.md updated
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
