### PR TITLE
Added option to configure jvm parameter of docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
-- Option to configure jvm parameter of docker container with env JAVA_OPTS or with arguments
+- Option to configure jvm parameter of docker container with env JAVA_OPTS or with arguments ([#1175](https://github.com/scm-manager/scm-manager/pull/1175))
 
 ### Fixed
 - Fixes configuration of jetty listener address with system property `jetty.host` ([#1173](https://github.com/scm-manager/scm-manager/pull/1173), [#1174](https://github.com/scm-manager/scm-manager/pull/1174))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Option to configure jvm parameter of docker container with env JAVA_OPTS or with arguments
 
 ### Fixed
 - Fixes configuration of jetty listener address with system property `jetty.host` ([#1173](https://github.com/scm-manager/scm-manager/pull/1173), [#1174](https://github.com/scm-manager/scm-manager/pull/1174))

--- a/docs/en/installation/docker.md
+++ b/docs/en/installation/docker.md
@@ -43,6 +43,24 @@ If you want to use the ssh plugin, keep in mind that this plugin requires an ext
 docker run --name scm -p 2222:2222 -p 8080:8080 -v scm-home:/var/lib/scm scmmanager/scm-manager:<version>
 ```
 
+## JVM Parameters
+
+If it becomes necessary to add JVM parameters to the start, there are two ways to do this:
+
+* As argument e.g.:
+
+```bash
+docker run scmmanager/scm-manager:<version> -Dsome.property=value
+```
+
+* Or as JAVA_OPTS environment variable e.g.:
+
+```bash
+docker run -e JAVA_OPTS="-Dsome.property=value" scmmanager/scm-manager:<version>
+
+```
+
+
 ## Docker Compose
 
 If you want to use the image with docker-compose have a look at the example below. 

--- a/docs/en/installation/docker.md
+++ b/docs/en/installation/docker.md
@@ -47,7 +47,7 @@ docker run --name scm -p 2222:2222 -p 8080:8080 -v scm-home:/var/lib/scm scmmana
 
 If it becomes necessary to add JVM parameters to the start, there are two ways to do this:
 
-* As argument e.g.:
+* As arguments e.g.:
 
 ```bash
 docker run scmmanager/scm-manager:<version> -Dsome.property=value

--- a/scm-packaging/docker/Dockerfile
+++ b/scm-packaging/docker/Dockerfile
@@ -47,6 +47,7 @@ RUN set -x \
  && addgroup -S -g 1000 scm \
  && adduser -S -s /bin/false -G scm -h ${SCM_HOME} -D -H -u 1000 scm \
  && mkdir -p ${SCM_HOME} ${CACHE_DIR} \
+ && chmod +x /opt/scm-server/bin/scm-server \
  && chown scm:scm ${SCM_HOME} ${CACHE_DIR}
 
 # copy mercurial installation
@@ -58,4 +59,4 @@ VOLUME ["${SCM_HOME}", "${CACHE_DIR}"]
 EXPOSE 8080
 USER scm
 
-CMD [ "java", "-cp", "/etc/scm:/opt/scm-server/lib/*", "-Djava.awt.headless=true", "-Dlogback.configurationFile=logging.xml", "sonia.scm.server.ScmServerDaemon" ]
+ENTRYPOINT [ "/opt/scm-server/bin/scm-server" ]

--- a/scm-packaging/docker/src/main/fs/opt/scm-server/bin/scm-server
+++ b/scm-packaging/docker/src/main/fs/opt/scm-server/bin/scm-server
@@ -1,0 +1,6 @@
+#!/bin/sh
+exec java -cp "/etc/scm:/opt/scm-server/lib/*" \
+  -Djava.awt.headless=true \
+  -Dlogback.configurationFile=logging.xml \
+  $JAVA_OPTS $* \
+  sonia.scm.server.ScmServerDaemon


### PR DESCRIPTION
## Proposed changes

Added option to configure jvm parameters of docker image.

The options can be configured by arguments e.g:

```bash
docker run cloudogu/scm-manager -Dsome.property=value
```

or via `JAVA_OPTS` environment variable e.g.:

```bash
docker run -e JAVA_OPTS="-Dsome.property=value" cloudogu/scm-manager
```

### Your checklist for this pull request

- [X] PR is well described
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [x] CHANGELOG.md updated
- [x] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
