### PR TITLE
avoid caching of detected browser language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+- Avoid caching of detected browser language
 - Fixes configuration of jetty listener address with system property `jetty.host` ([#1173](https://github.com/scm-manager/scm-manager/pull/1173), [#1174](https://github.com/scm-manager/scm-manager/pull/1174))
 
 ## [2.0.0] - 2020-06-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- Avoid caching of detected browser language
+- Avoid caching of detected browser language ([#1176](https://github.com/scm-manager/scm-manager/pull/1176))
 - Fixes configuration of jetty listener address with system property `jetty.host` ([#1173](https://github.com/scm-manager/scm-manager/pull/1173), [#1174](https://github.com/scm-manager/scm-manager/pull/1174))
 
 ## [2.0.0] - 2020-06-04

--- a/scm-ui/ui-webapp/src/i18n.ts
+++ b/scm-ui/ui-webapp/src/i18n.ts
@@ -61,6 +61,15 @@ i18n
       init: {
         credentials: "same-origin"
       }
+    },
+
+    // configure LanguageDetector
+    // see https://github.com/i18next/i18next-browser-languageDetector#detector-options
+    detection: {
+      // we only use browser configuration
+      order: ["navigator"],
+      // we do not cache the detected language
+      caches: []
     }
   });
 


### PR DESCRIPTION
## Proposed changes

The detected browser language is currently cached in the localStorage of the client browser. If the user changes the language in his browser, scm-manager will show the old language, because of the cached language.

This pr will disable the caching and ignores the already cached values.

### Your checklist for this pull request

- [X] PR is well described
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [x] CHANGELOG.md updated

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
