### PR TITLE
Fix loading plugin resources without context path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Avoid caching of detected browser language ([#1176](https://github.com/scm-manager/scm-manager/pull/1176))
 - Fixes configuration of jetty listener address with system property `jetty.host` ([#1173](https://github.com/scm-manager/scm-manager/pull/1173), [#1174](https://github.com/scm-manager/scm-manager/pull/1174))
+- Fixes loading plugin bundles with context path `/` ([#1182](https://github.com/scm-manager/scm-manager/pull/1182/files), [#1181](https://github.com/scm-manager/scm-manager/issues/1181))
 
 ## [2.0.0] - 2020-06-04
 ### Added

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/UIPluginDtoMapper.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/UIPluginDtoMapper.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.api.v2.resources;
 
 import com.google.common.base.Strings;
@@ -77,7 +77,7 @@ public class UIPluginDtoMapper {
   private String addContextPath(String resource) {
     String ctxPath = request.getContextPath();
     if (Strings.isNullOrEmpty(ctxPath)) {
-      return resource;
+      return "/" + resource;
     }
     return HttpUtil.append(ctxPath, resource);
   }


### PR DESCRIPTION
## Proposed changes

When the context path is set to '/', we get an empty context path. Nonetheless the URL has to start with a '/'. So we have to add it explicitly, here.

Fixes #1181 

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
