### PR TITLE
Set new plugin center URL in update step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Avoid caching of detected browser language ([#1176](https://github.com/scm-manager/scm-manager/pull/1176))
 - Fixes configuration of jetty listener address with system property `jetty.host` ([#1173](https://github.com/scm-manager/scm-manager/pull/1173), [#1174](https://github.com/scm-manager/scm-manager/pull/1174))
 - Fixes loading plugin bundles with context path `/` ([#1182](https://github.com/scm-manager/scm-manager/pull/1182/files), [#1181](https://github.com/scm-manager/scm-manager/issues/1181))
+- Sets the new plugin center URL once ([#1184](https://github.com/scm-manager/scm-manager/pull/1184))
 
 ## [2.0.0] - 2020-06-04
 ### Added

--- a/scm-webapp/src/main/java/sonia/scm/update/plugin/PluginCenterUpdateStep.java
+++ b/scm-webapp/src/main/java/sonia/scm/update/plugin/PluginCenterUpdateStep.java
@@ -1,0 +1,70 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.update.plugin;
+
+import sonia.scm.config.ScmConfiguration;
+import sonia.scm.migration.UpdateStep;
+import sonia.scm.plugin.Extension;
+import sonia.scm.store.ConfigurationStore;
+import sonia.scm.store.ConfigurationStoreFactory;
+import sonia.scm.version.Version;
+
+import javax.inject.Inject;
+
+import static sonia.scm.version.Version.parse;
+
+@Extension
+public class PluginCenterUpdateStep implements UpdateStep {
+
+  private final ConfigurationStoreFactory configurationStoreFactory;
+
+  @Inject
+  public PluginCenterUpdateStep(ConfigurationStoreFactory configurationStoreFactory) {
+    this.configurationStoreFactory = configurationStoreFactory;
+  }
+
+  @Override
+  public void doUpdate() {
+    ConfigurationStore<ScmConfiguration> configurationStore = configurationStoreFactory
+      .withType(ScmConfiguration.class)
+      .withName("config")
+      .build();
+    configurationStore.getOptional()
+      .ifPresent(config -> {
+        config.setPluginUrl(ScmConfiguration.DEFAULT_PLUGINURL);
+        configurationStore.set(config);
+      });
+  }
+
+  @Override
+  public Version getTargetVersion() {
+    return parse("2.0.0");
+  }
+
+  @Override
+  public String getAffectedDataType() {
+    return "sonia.scm.plugin-center";
+  }
+}

--- a/scm-webapp/src/test/java/sonia/scm/update/plugin/PluginCenterUpdateStepTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/update/plugin/PluginCenterUpdateStepTest.java
@@ -1,0 +1,58 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.update.plugin;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import sonia.scm.config.ScmConfiguration;
+import sonia.scm.store.ConfigurationStore;
+import sonia.scm.store.InMemoryConfigurationStoreFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PluginCenterUpdateStepTest {
+
+  @Test
+  void shouldNotCreateConfigIfNoConfigIsPresent() {
+    InMemoryConfigurationStoreFactory configurationStoreFactory = new InMemoryConfigurationStoreFactory();
+    new PluginCenterUpdateStep(configurationStoreFactory)
+      .doUpdate();
+    ScmConfiguration config = configurationStoreFactory.withType(ScmConfiguration.class).withName("config").build().get();
+    assertThat(config).isNull();
+  }
+
+  @Test
+  void shouldOverwriteOldPluginCenterUrl() {
+    InMemoryConfigurationStoreFactory configurationStoreFactory = new InMemoryConfigurationStoreFactory();
+    ConfigurationStore<ScmConfiguration> configurationStore = configurationStoreFactory.withType(ScmConfiguration.class).withName("config").build();
+    ScmConfiguration scmConfiguration = new ScmConfiguration();
+    scmConfiguration.setPluginUrl("http://some.old/url");
+    configurationStore.set(scmConfiguration);
+    new PluginCenterUpdateStep(configurationStoreFactory)
+      .doUpdate();
+    ScmConfiguration config = configurationStore.get();
+    assertThat(config.getPluginUrl()).isEqualTo(ScmConfiguration.DEFAULT_PLUGINURL);
+  }
+}


### PR DESCRIPTION
## Proposed changes

Fixes the issue, that migrated instances of SCM-Manager still use the
old plugin center url and therefore cannot read the new plugins.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
