### PR TITLE
Only use LF for line breaks in diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes configuration of jetty listener address with system property `jetty.host` ([#1173](https://github.com/scm-manager/scm-manager/pull/1173), [#1174](https://github.com/scm-manager/scm-manager/pull/1174))
 - Fixes loading plugin bundles with context path `/` ([#1182](https://github.com/scm-manager/scm-manager/pull/1182/files), [#1181](https://github.com/scm-manager/scm-manager/issues/1181))
 - Sets the new plugin center URL once ([#1184](https://github.com/scm-manager/scm-manager/pull/1184))
+- Diffs with CR characters are parsed correctly ([#1185](https://github.com/scm-manager/scm-manager/pull/1185))
 
 ## [2.0.0] - 2020-06-04
 ### Added

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitHunkParser.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitHunkParser.java
@@ -49,7 +49,7 @@ final class GitHunkParser {
   public List<Hunk> parse(String content) {
     List<Hunk> hunks = new ArrayList<>();
 
-    try (Scanner scanner = new Scanner(content).useDelimiter("[\n\r\u2028\u2029\u0085]+")) {
+    try (Scanner scanner = new Scanner(content).useDelimiter("\n")) {
       while (scanner.hasNext()) {
         String line = scanner.next();
         if (line.startsWith("@@")) {


### PR DESCRIPTION
## Proposed changes

Git uses LF for line breaks in diffs, not CR or other delimiters. When
we are using other delimiters for diving diff output into lines, too,
we can get errors because diff lines can contain CRs. When we try to
split such lines, we get exceptions because these lines cannot be parsed

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
