### PR TITLE
fixed active state of sub navigation items, which are using activeWhe…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Close file lists in migration ([#1191](https://github.com/scm-manager/scm-manager/pull/1191))
 - Use command in javahg.py from registrar (Upgrade to newer javahg version)  ([#1192](https://github.com/scm-manager/scm-manager/pull/1192))
 - Fixed wrong e-tag format ([sdorra/web-resource #1](https://github.com/sdorra/web-resources/pull/1))
-- Fixed active state of sub navigation items, which are using activeWhenMatch 
+- Fixed active state of sub navigation items, which are using activeWhenMatch ([#1199](https://github.com/scm-manager/scm-manager/pull/1199))
 - Handles repositories in custom directories correctly in migration from 1.x ([#1201](https://github.com/scm-manager/scm-manager/pull/1201))
 - Usage of short git commit ids in changeset urls ([#1200](https://github.com/scm-manager/scm-manager/pull/1200))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Close file lists in migration ([#1191](https://github.com/scm-manager/scm-manager/pull/1191))
 - Use command in javahg.py from registrar (Upgrade to newer javahg version)  ([#1192](https://github.com/scm-manager/scm-manager/pull/1192))
 - Fixed wrong e-tag format ([sdorra/web-resource #1](https://github.com/sdorra/web-resources/pull/1))
+- Fixed active state of sub navigation items, which are using activeWhenMatch 
 - Handles repositories in custom directories correctly in migration from 1.x ([#1201](https://github.com/scm-manager/scm-manager/pull/1201))
 - Usage of short git commit ids in changeset urls ([#1200](https://github.com/scm-manager/scm-manager/pull/1200))
 

--- a/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
+++ b/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
@@ -40777,6 +40777,68 @@ exports[`Storyshots Modal|Modal Default 1`] = `
 </div>
 `;
 
+exports[`Storyshots Navigation|Secondary Active when match 1`] = `
+<div
+  className="SecondaryNavigationstories__Columns-fdxo4w-0 iEPunq columns"
+>
+  <div
+    className="column is-3"
+  >
+    <aside
+      className="SecondaryNavigation__SectionContainer-sc-8p1rgi-0 cpLxdt menu"
+    >
+      <div>
+        <p
+          className="SecondaryNavigation__MenuLabel-sc-8p1rgi-2 bzrEDi menu-label"
+          onClick={[Function]}
+        >
+          <i
+            className="SecondaryNavigation__Icon-sc-8p1rgi-1 djTcfn is-medium"
+            color="info"
+          >
+            <i
+              className="fas fa-caret-right"
+            />
+          </i>
+          Hitchhiker
+        </p>
+        <ul
+          className="menu-list"
+          onClick={[Function]}
+        >
+          <li>
+            <a
+              className=""
+              href="/42"
+              onClick={[Function]}
+            >
+              <i
+                className="fas fa-puzzle-piece fa-fw"
+              />
+               
+              Puzzle 42
+            </a>
+          </li>
+          <li>
+            <a
+              className="is-active"
+              href="/heart-of-gold"
+              onClick={[Function]}
+            >
+              <i
+                className="fas fa-star fa-fw"
+              />
+               
+              Heart Of Gold
+            </a>
+          </li>
+        </ul>
+      </div>
+    </aside>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Navigation|Secondary Default 1`] = `
 <div
   className="SecondaryNavigationstories__Columns-fdxo4w-0 iEPunq columns"

--- a/scm-ui/ui-components/src/navigation/NavLink.tsx
+++ b/scm-ui/ui-components/src/navigation/NavLink.tsx
@@ -36,7 +36,7 @@ type Props = RoutingProps & {
 };
 
 const NavLink: FC<Props> = ({ to, activeWhenMatch, activeOnlyWhenExact, icon, label, title }) => {
-  const active = useActiveMatch({to, activeWhenMatch, activeOnlyWhenExact});
+  const active = useActiveMatch({ to, activeWhenMatch, activeOnlyWhenExact });
 
   const context = useMenuContext();
   const collapsed = context.isCollapsed();

--- a/scm-ui/ui-components/src/navigation/NavLink.tsx
+++ b/scm-ui/ui-components/src/navigation/NavLink.tsx
@@ -23,7 +23,7 @@
  */
 import * as React from "react";
 import classNames from "classnames";
-import { Link, useRouteMatch } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { RoutingProps } from "./RoutingProps";
 import { FC } from "react";
 import useMenuContext from "./MenuContext";

--- a/scm-ui/ui-components/src/navigation/SecondaryNavigation.stories.tsx
+++ b/scm-ui/ui-components/src/navigation/SecondaryNavigation.stories.tsx
@@ -86,4 +86,18 @@ storiesOf("Navigation|Secondary", module)
         </SecondaryNavigation>
       </BinderContext.Provider>
     );
-  });
+  })
+  .add("Active when match", () =>
+    withRoute("/hog")(
+      <SecondaryNavigation label="Hitchhiker">
+        <SecondaryNavigationItem to="/42" icon="fas fa-puzzle-piece" label="Puzzle 42" title="Puzzle 42" />
+        <SecondaryNavigationItem
+          activeWhenMatch={route => route.location.pathname === "/hog"}
+          to="/heart-of-gold"
+          icon="fas fa-star"
+          label="Heart Of Gold"
+          title="Heart Of Gold"
+        />
+      </SecondaryNavigation>
+    )
+  );

--- a/scm-ui/ui-components/src/navigation/SubNavigation.tsx
+++ b/scm-ui/ui-components/src/navigation/SubNavigation.tsx
@@ -21,10 +21,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import React, { FC, useContext } from "react";
-import { Link, useRouteMatch, useLocation } from "react-router-dom";
+import React, { FC } from "react";
+import { Link } from "react-router-dom";
 import classNames from "classnames";
-import useMenuContext, { MenuContext } from "./MenuContext";
+import useMenuContext from "./MenuContext";
 import { RoutingProps } from "./RoutingProps";
 import useActiveMatch from "./useActiveMatch";
 
@@ -46,7 +46,7 @@ const SubNavigation: FC<Props> = ({ to, activeOnlyWhenExact, activeWhenMatch, ic
     to: parent,
     activeOnlyWhenExact,
     activeWhenMatch
-  })
+  });
 
   let defaultIcon = "fas fa-cog";
   if (icon) {

--- a/scm-ui/ui-components/src/navigation/SubNavigation.tsx
+++ b/scm-ui/ui-components/src/navigation/SubNavigation.tsx
@@ -22,10 +22,11 @@
  * SOFTWARE.
  */
 import React, { FC, useContext } from "react";
-import { Link, useRouteMatch } from "react-router-dom";
+import { Link, useRouteMatch, useLocation } from "react-router-dom";
 import classNames from "classnames";
 import useMenuContext, { MenuContext } from "./MenuContext";
 import { RoutingProps } from "./RoutingProps";
+import useActiveMatch from "./useActiveMatch";
 
 type Props = RoutingProps & {
   label: string;
@@ -33,18 +34,19 @@ type Props = RoutingProps & {
   icon?: string;
 };
 
-const SubNavigation: FC<Props> = ({ to, activeOnlyWhenExact, icon, title, label, children }) => {
+const SubNavigation: FC<Props> = ({ to, activeOnlyWhenExact, activeWhenMatch, icon, title, label, children }) => {
+  const context = useMenuContext();
+  const collapsed = context.isCollapsed();
+
   const parents = to.split("/");
   parents.splice(-1, 1);
   const parent = parents.join("/");
 
-  const match = useRouteMatch({
-    path: parent,
-    exact: activeOnlyWhenExact
-  });
-
-  const context = useMenuContext();
-  const collapsed = context.isCollapsed();
+  const active = useActiveMatch({
+    to: parent,
+    activeOnlyWhenExact,
+    activeWhenMatch
+  })
 
   let defaultIcon = "fas fa-cog";
   if (icon) {
@@ -52,13 +54,13 @@ const SubNavigation: FC<Props> = ({ to, activeOnlyWhenExact, icon, title, label,
   }
 
   let childrenList = null;
-  if (match && !collapsed) {
+  if (active && !collapsed) {
     childrenList = <ul className="sub-menu">{children}</ul>;
   }
 
   return (
     <li title={collapsed ? title : undefined}>
-      <Link className={classNames(match != null ? "is-active" : "", collapsed ? "has-text-centered" : "")} to={to}>
+      <Link className={classNames(active ? "is-active" : "", collapsed ? "has-text-centered" : "")} to={to}>
         <i className={classNames(defaultIcon, "fa-fw")} /> {collapsed ? "" : label}
       </Link>
       {childrenList}

--- a/scm-ui/ui-components/src/navigation/useActiveMatch.ts
+++ b/scm-ui/ui-components/src/navigation/useActiveMatch.ts
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-import {useLocation, useRouteMatch} from "react-router-dom";
-import {RoutingProps} from "./RoutingProps";
+import { useLocation, useRouteMatch } from "react-router-dom";
+import { RoutingProps } from "./RoutingProps";
 
-const useActiveMatch = ({to, activeOnlyWhenExact, activeWhenMatch}: RoutingProps) => {
+const useActiveMatch = ({ to, activeOnlyWhenExact, activeWhenMatch }: RoutingProps) => {
   const match = useRouteMatch({
     path: to,
     exact: activeOnlyWhenExact

--- a/scm-ui/ui-components/src/navigation/useActiveMatch.ts
+++ b/scm-ui/ui-components/src/navigation/useActiveMatch.ts
@@ -21,47 +21,28 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from "react";
-import classNames from "classnames";
-import { Link, useRouteMatch } from "react-router-dom";
-import { RoutingProps } from "./RoutingProps";
-import { FC } from "react";
-import useMenuContext from "./MenuContext";
-import useActiveMatch from "./useActiveMatch";
 
-type Props = RoutingProps & {
-  label: string;
-  title?: string;
-  icon?: string;
+import {useLocation, useRouteMatch} from "react-router-dom";
+import {RoutingProps} from "./RoutingProps";
+
+const useActiveMatch = ({to, activeOnlyWhenExact, activeWhenMatch}: RoutingProps) => {
+  const match = useRouteMatch({
+    path: to,
+    exact: activeOnlyWhenExact
+  });
+
+  const location = useLocation();
+
+  const isActiveWhenMatch = () => {
+    if (activeWhenMatch) {
+      return activeWhenMatch({
+        location
+      });
+    }
+    return false;
+  };
+
+  return !!match || isActiveWhenMatch();
 };
 
-const NavLink: FC<Props> = ({ to, activeWhenMatch, activeOnlyWhenExact, icon, label, title }) => {
-  const active = useActiveMatch({to, activeWhenMatch, activeOnlyWhenExact});
-
-  const context = useMenuContext();
-  const collapsed = context.isCollapsed();
-
-  let showIcon = null;
-  if (icon) {
-    showIcon = (
-      <>
-        <i className={classNames(icon, "fa-fw")} />{" "}
-      </>
-    );
-  }
-
-  return (
-    <li title={collapsed ? title : undefined}>
-      <Link className={classNames(active ? "is-active" : "", collapsed ? "has-text-centered" : "")} to={to}>
-        {showIcon}
-        {collapsed ? null : label}
-      </Link>
-    </li>
-  );
-};
-
-NavLink.defaultProps = {
-  activeOnlyWhenExact: true
-};
-
-export default NavLink;
+export default useActiveMatch;


### PR DESCRIPTION
…nMatch

## Proposed changes

This pr fixes missing highlighting of sub navigation items, which are using the `activeWhenMatch` property (such as Script plugin).

### Your checklist for this pull request

- [X] PR is well described
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests (storyshot)
- [X] CHANGELOG.md updated

### Checklist for branch merge request (not required for forks)

- [x] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [x] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
