### PR TITLE
remove wait for sonarqube qualitygate

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,10 +83,6 @@ node('docker') {
       stage('SonarQube') {
         def sonarQube = new SonarCloud(this, [sonarQubeEnv: 'sonarcloud.io-scm', sonarOrganization: 'scm-manager', integrationBranch: 'develop'])
         sonarQube.analyzeWith(mvn)
-
-        if (!waitForQualityGateWebhookToBeCalled()) {
-          currentBuild.result = 'UNSTABLE'
-        }
       }
 
       if (isBuildSuccessful() && (isMainBranch() || isReleaseBranch())) {
@@ -222,18 +218,6 @@ String getReleaseVersion() {
 
 boolean isMainBranch() {
   return mainBranch.equals(env.BRANCH_NAME)
-}
-
-boolean waitForQualityGateWebhookToBeCalled() {
-  boolean isQualityGateSucceeded = true
-  timeout(time: 10, unit: 'MINUTES') { // Needed when there is no webhook for example
-    def qGate = waitForQualityGate()
-    echo "SonarQube Quality Gate status: ${qGate.status}"
-    if (qGate.status != 'OK') {
-      isQualityGateSucceeded = false
-    }
-  }
-  return isQualityGateSucceeded
 }
 
 void withGPGEnvironment(def closure) {


### PR DESCRIPTION
## Proposed changes

We do not longer wait for the sonarqube webhook, because nearly every build fails with a timeout.
Increasing the timeout is also no option, because it is already relative high.

### Your checklist for this pull request

- [X] PR is well described
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
