### PR TITLE
#1195 do not force java home of recommended java dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Wait until recommended java installation is available for deb packages ([#1209](https://github.com/scm-manager/scm-manager/pull/1209))
+- Do not force java home of recommended java dependency for rpm and deb packages ([#1195](https://github.com/scm-manager/scm-manager/issues/1195) and [#1208](https://github.com/scm-manager/scm-manager/pull/1208))
 
 ## [2.1.0] - 2020-06-18
 ### Added

--- a/scm-packaging/deb/src/main/fs/etc/default/scm-server
+++ b/scm-packaging/deb/src/main/fs/etc/default/scm-server
@@ -36,7 +36,7 @@ USER=scm
 export SCM_HOME=/var/lib/scm
 
 # force jvm path
-JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
+# JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
 
 # path to pid
 PIDFILE=/var/run/scm/scm.pid

--- a/scm-packaging/rpm/src/main/fs/etc/default/scm-server
+++ b/scm-packaging/rpm/src/main/fs/etc/default/scm-server
@@ -36,7 +36,7 @@ USER=scm
 export SCM_HOME=/var/lib/scm
 
 # force jvm path
-JAVA_HOME="/usr/lib/jvm/jre-11"
+# JAVA_HOME="/usr/lib/jvm/jre-11"
 
 # path to pid
 PIDFILE=/var/run/scm/scm.pid


### PR DESCRIPTION
## Proposed changes

This pr removes the JAVA_HOME environment variable from `/etc/default/scm-server` for deb and rpm packages. The environment variable points to the java home of a recommended java dependency. If a user refuses to install the recommended package, but has a working java installation the package will not work. 

The scm-server script is smart enough to find most of the java installations.

Fixes #1195 

### Your checklist for this pull request

- [X] PR is well described
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [x] CHANGELOG.md updated
