### PR TITLE
wait until recommended java installation is available for deb packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Fixed
-- Wait until recommended java installation is available for deb packages
+- Wait until recommended java installation is available for deb packages ([#1209](https://github.com/scm-manager/scm-manager/pull/1209))
 
 ## [2.1.0] - 2020-06-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Wait until recommended java installation is available for deb packages
+
 ## [2.1.0] - 2020-06-18
 ### Added
 - Option to configure jvm parameter of docker container with env JAVA_OPTS or with arguments ([#1175](https://github.com/scm-manager/scm-manager/pull/1175))

--- a/scm-packaging/deb/src/main/deb/control/postinst
+++ b/scm-packaging/deb/src/main/deb/control/postinst
@@ -39,5 +39,5 @@ sudo systemctl enable scm-server
 
 # we start scm-manager after 5 seconds
 # this is required, because if we install scm-manager with recommend java
-# java is not fully setup if we ran our posint script
+# java is not fully setup if we ran our postint script
 echo "sleep 5; sudo systemctl start scm-server" | at now

--- a/scm-packaging/deb/src/main/deb/control/postinst
+++ b/scm-packaging/deb/src/main/deb/control/postinst
@@ -36,4 +36,8 @@ systemctl daemon-reload
 
 # enable and start the service
 sudo systemctl enable scm-server
-sudo systemctl start scm-server
+
+# we start scm-manager after 5 seconds
+# this is required, because if we install scm-manager with recommend java
+# java is not fully setup if we ran our posint script
+echo "sleep 5; sudo systemctl start scm-server" | at now


### PR DESCRIPTION
We delay the start of scm-server for 5 seconds, after the installation of the debian package.

This is necessary because if we install scm-manager together with the recommended Java, Java is not fully installed when the postinst script is running.
