### PR TITLE
Fix migration of non-bare git repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Migration of non-bare repositories ([#1213](https://github.com/scm-manager/scm-manager/pull/1213))
+
 ## [2.1.0] - 2020-06-18
 ### Added
 - Option to configure jvm parameter of docker container with env JAVA_OPTS or with arguments ([#1175](https://github.com/scm-manager/scm-manager/pull/1175))

--- a/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/update/GitV2UpdateStepTest.java
+++ b/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/update/GitV2UpdateStepTest.java
@@ -1,0 +1,92 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.repository.update;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sonia.scm.repository.Repository;
+import sonia.scm.repository.RepositoryLocationResolver;
+import sonia.scm.update.UpdateStepRepositoryMetadataAccess;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.BiConsumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GitV2UpdateStepTest {
+
+  @Mock
+  RepositoryLocationResolver locationResolver;
+  @Mock
+  RepositoryLocationResolver.RepositoryLocationResolverInstance<Path> locationResolverInstance;
+  @Mock
+  UpdateStepRepositoryMetadataAccess<Path> repositoryMetadataAccess;
+
+  @InjectMocks
+  GitV2UpdateStep updateStep;
+
+  @BeforeEach
+  void createDataDirectory(@TempDir Path temp) throws IOException {
+    Files.createDirectories(temp.resolve("data"));
+  }
+
+  @BeforeEach
+  void initRepositoryFolder(@TempDir Path temp) {
+    when(locationResolver.forClass(Path.class)).thenReturn(locationResolverInstance);
+    when(repositoryMetadataAccess.read(temp)).thenReturn(new Repository("123", "git", "space", "X"));
+    doAnswer(invocation -> {
+      invocation.getArgument(0, BiConsumer.class).accept("123", temp);
+      return null;
+    }).when(locationResolverInstance).forAllLocations(any());
+  }
+
+  @Test
+  void shouldWriteConfigFileForBareRepositories(@TempDir Path temp) {
+    updateStep.doUpdate();
+
+    assertThat(temp.resolve("data").resolve("config")).exists();
+  }
+
+  @Test
+  void shouldWriteConfigFileForNonBareRepositories(@TempDir Path temp) throws IOException {
+    Files.createDirectories(temp.resolve("data").resolve(".git"));
+
+    updateStep.doUpdate();
+
+    assertThat(temp.resolve("data").resolve("config")).doesNotExist();
+    assertThat(temp.resolve("data").resolve(".git").resolve("config")).exists();
+  }
+}


### PR DESCRIPTION
## Proposed changes

During the migration of git repositories from v1 to v2, we have to
create an "scmm" config section with the repository id of the current
repository. If this does not happen, further write requests to this
repository will fail, because the hooks cannot determine the id.

However, the migration failed to write this configuration for non-bare
repositories. Therefore this fix checks beforehand, whether a '.git'
folder exists in the date directory. If this is the case, we assume that
this is a non-bare repository and write the config file inside this
folder.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
