### PR TITLE
fix installation of debian packages on distros without preinstalled "at"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - enrich commit mentions in markdown viewer by internal links  ([#1210](https://github.com/scm-manager/scm-manager/pull/1210))
 
+### Fixed
+- Fixed installation of debian packages on distros without preinstalled `at` ([#1216](https://github.com/scm-manager/scm-manager/issues/1216) and [#1217](https://github.com/scm-manager/scm-manager/pull/1217))
+
 ## [2.1.1] - 2020-06-23
 ### Fixed
 - Wait until recommended java installation is available for deb packages ([#1209](https://github.com/scm-manager/scm-manager/pull/1209))

--- a/scm-packaging/deb/src/main/deb/control/postinst
+++ b/scm-packaging/deb/src/main/deb/control/postinst
@@ -40,4 +40,4 @@ sudo systemctl enable scm-server
 # we start scm-manager after 5 seconds
 # this is required, because if we install scm-manager with recommend java
 # java is not fully setup if we ran our postint script
-echo "sleep 5; sudo systemctl start scm-server" | at now
+nohup sh -c "sleep 5; systemctl start scm-server" >/dev/null 2>&1 &


### PR DESCRIPTION
This fix will replace the use of `at` with a `nohup` in background. `nohup` is part of **coreutils** and should be pre installed on all debian based distributions.

Fixes #1216 

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] PR is well described
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [x] CHANGELOG.md updated

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
