### PR TITLE
update project metadata in order to fix deb and rpm package information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed installation of debian packages on distros without preinstalled `at` ([#1216](https://github.com/scm-manager/scm-manager/issues/1216) and [#1217](https://github.com/scm-manager/scm-manager/pull/1217))
 - Fixed broken migration with empty security.xml ([#1219](https://github.com/scm-manager/scm-manager/issues/1219) and [#1221](https://github.com/scm-manager/scm-manager/pull/1221))
 - Added missing architecture to debian installation documentation ([#1230](https://github.com/scm-manager/scm-manager/pull/1230))
+- Fixed wrong package information for deb and rpm packages ([#1229](https://github.com/scm-manager/scm-manager/pull/1229))
 
 ## [2.1.1] - 2020-06-23
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 The easiest way to share and manage your Git, Mercurial and Subversion
-repositories over http.
+repositories.
 
 - Very easy installation
 - No need to hack configuration files, SCM-Manager is completely

--- a/pom.xml
+++ b/pom.xml
@@ -35,11 +35,16 @@
   <version>2.2.0-SNAPSHOT</version>
   <description>
     The easiest way to share your Git, Mercurial
-    and Subversion repositories over http.
+    and Subversion repositories.
   </description>
   <name>scm</name>
 
   <url>https://github.com/scm-manager/scm-manager</url>
+
+  <organization>
+    <name>Cloudogu GmbH</name>
+    <url>https://cloudogu.com</url>
+  </organization>
 
   <licenses>
     <license>
@@ -50,9 +55,33 @@
 
   <developers>
     <developer>
-      <id>sdorra</id>
+      <id>sebastian.sdorra</id>
       <name>Sebastian Sdorra</name>
-      <email>s.sdorra@gmail.com</email>
+      <email>sebastian.sdorra@cloudogu.com</email>
+      <timezone>Europe/Berlin</timezone>
+    </developer>
+    <developer>
+      <id>rene.pfeuffer</id>
+      <name>Rene Pfeufer</name>
+      <email>rene.pfeuffer@cloudogu.com</email>
+      <timezone>Europe/Berlin</timezone>
+    </developer>
+    <developer>
+      <id>eduard.heimbuch</id>
+      <name>Eduard Heimbuch</name>
+      <email>eduard.heimbuch@cloudogu.com</email>
+      <timezone>Europe/Berlin</timezone>
+    </developer>
+    <developer>
+      <id>florian.scholdei</id>
+      <name>Florian Scholdei</name>
+      <email>florian.scholdei@cloudogu.com</email>
+      <timezone>Europe/Berlin</timezone>
+    </developer>
+    <developer>
+      <id>Konstantin Schaper</id>
+      <name>Konstantin Schaper</name>
+      <email>konstantin.schaper@cloudogu.com</email>
       <timezone>Europe/Berlin</timezone>
     </developer>
   </developers>

--- a/scm-packaging/deb/pom.xml
+++ b/scm-packaging/deb/pom.xml
@@ -157,7 +157,6 @@
               </mapper>
             </data>
 
-
             <data>
               <type>file</type>
               <src>src/main/fs/etc/scm/logging.xml</src>

--- a/scm-packaging/deb/src/main/deb/control/control
+++ b/scm-packaging/deb/src/main/deb/control/control
@@ -3,7 +3,8 @@ Version: [[version]]
 Section: devel
 Priority: extra
 Architecture: all
-Description: The easiest way to share and manage your Git, Mercurial and Subversion repositories over http
-Maintainer: Sebastian Sdorra <sebastian.sdorra@cloudogu.com>
+Description: The easiest way to share and manage your Git, Mercurial and Subversion repositories
+Maintainer: SCM-Team <scm-team@cloudogu.com>
+Homepage: https://scm-manager.org
 Depends: adduser, procps, psmisc, net-tools
 Recommends: openjdk-11-jre-headless, mercurial

--- a/scm-packaging/rpm/pom.xml
+++ b/scm-packaging/rpm/pom.xml
@@ -41,6 +41,12 @@
   <description>Packaging for RedHat/Centos/Fedora</description>
   <name>rpm</name>
 
+  <!--
+  de.dentrassi.maven:rpm
+  has no other way to set the url of the package
+  -->
+  <url>https://scm-manager.org</url>
+
   <dependencies>
 
     <dependency>
@@ -127,6 +133,8 @@
         <configuration>
           <attach>true</attach>
           <packageName>scm-server</packageName>
+          <summary>SCM-Manager Server</summary>
+          <description>The easiest way to share and manage your Git, Mercurial and Subversion repositories</description>
           <group>Development/Tools</group>
           <license>MIT</license>
           <skipSigning>true</skipSigning>
@@ -318,7 +326,6 @@
 
         </configuration>
       </plugin>
-
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Proposed changes

This change will fix some wrong package information fields of deb and rpm packages.
The package information can be displayed with the following commands:

**deb**:
```bash
docker run -ti --rm -v $(pwd):$(pwd):ro -w $(pwd) ubuntu:20.04 apt show ./scm-server_2.2.0-SNAPSHOT_all.deb
```

**rpm**:
```bash
docker run -ti --rm -v $(pwd):$(pwd):ro -w $(pwd) centos:8 rpm -qip target/scm-server-2.2.0-0.202007010443.noarch.rpm
```

The pr will also add some missing informations to the pom.

### Your checklist for this pull request

- [X] PR is well described
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [x] CHANGELOG.md updated

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
