### PR TITLE
adds missing architecture to debian installation documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed installation of debian packages on distros without preinstalled `at` ([#1216](https://github.com/scm-manager/scm-manager/issues/1216) and [#1217](https://github.com/scm-manager/scm-manager/pull/1217))
 - Fixed broken migration with empty security.xml ([#1219](https://github.com/scm-manager/scm-manager/issues/1219) and [#1221](https://github.com/scm-manager/scm-manager/pull/1221))
+- Added missing architecture to debian installation documentation ([#1230](https://github.com/scm-manager/scm-manager/pull/1230))
 
 ## [2.1.1] - 2020-06-23
 ### Fixed

--- a/docs/en/installation/debian.md
+++ b/docs/en/installation/debian.md
@@ -9,7 +9,7 @@ displayToc: true
 The following code block will configure an apt repository for scm-manager and install it.
 
 ```bash
-echo 'deb https://packages.scm-manager.org/repository/apt-v2-releases/ stable main' | sudo tee /etc/apt/sources.list.d/scm-manager.list
+echo 'deb [arch=all] https://packages.scm-manager.org/repository/apt-v2-releases/ stable main' | sudo tee /etc/apt/sources.list.d/scm-manager.list
 sudo apt-key adv --recv-keys --keyserver hkps://keys.openpgp.org 0x975922F193B07D6E
 sudo apt-get update
 sudo apt-get install scm-server
@@ -24,7 +24,7 @@ To install SCM-Manager as a debian package (.deb), we have to configure an apt r
 Create a file at `/etc/apt/sources.list.d/scm-manager.list` with the following content:
 
 ```text
-deb https://packages.scm-manager.org/repository/apt-v2-releases/ stable main
+deb [arch=all] https://packages.scm-manager.org/repository/apt-v2-releases/ stable main
 ```
 
 This will add the apt repository of the scm-manager stable releases to the list of your apt repositories.


### PR DESCRIPTION
## Proposed changes

This change will add the architecture parameter to the debian installation tutorial. Without the parameter the repository could not be fetched on ubuntu 20.04.

Fixes #1228 

### Your checklist for this pull request

- [X] PR is well described
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] CHANGELOG.md updated
- [X] Documentation updated (only necessary for new features or changed behaviour)
