### PR TITLE
ignore ports on proxy exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed error in update step ([#1237](https://github.com/scm-manager/scm-manager/issues/1237) and [#1244](https://github.com/scm-manager/scm-manager/issues/1244))
 - Fix incorrect trimming of whitespaces in helm chart templates 
 - Fixed error on empty diff expand response ([#1247](https://github.com/scm-manager/scm-manager/pull/1247))
+- Ignore ports on proxy exclusions ([#1256](https://github.com/scm-manager/scm-manager/pull/1256))
 
 ## [2.2.0] - 2020-07-03
 ### Added

--- a/scm-core/src/main/java/sonia/scm/net/Proxies.java
+++ b/scm-core/src/main/java/sonia/scm/net/Proxies.java
@@ -91,6 +91,13 @@ public final class Proxies
         url = url.substring(0, index);
       }
 
+      index = url.indexOf(':');
+
+      if (index > 0)
+      {
+        url = url.substring(0, index);
+      }
+
       for (String exclude : configuration.getProxyExcludes())
       {
         if (GlobUtil.matches(exclude, url))

--- a/scm-core/src/test/java/sonia/scm/net/ProxiesTest.java
+++ b/scm-core/src/test/java/sonia/scm/net/ProxiesTest.java
@@ -21,99 +21,65 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.net;
 
-//~--- non-JDK imports --------------------------------------------------------
-
 import com.google.common.collect.Sets;
-
 import org.junit.Test;
-
 import sonia.scm.config.ScmConfiguration;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-/**
- *
- * @author Sebastian Sdorra
- */
-public class ProxiesTest
-{
+public class ProxiesTest {
 
-  /**
-   * Method description
-   *
-   */
   @Test
-  public void testDisabledWithoutExcludes()
-  {
+  public void testDisabledWithoutExcludes() {
     ScmConfiguration config = createConfiguration(false);
 
     assertFalse(Proxies.isEnabled(config, "localhost"));
+    assertFalse(Proxies.isEnabled(config, "localhost:8082"));
     assertFalse(Proxies.isEnabled(config, "download.scm-manager.org"));
     assertFalse(Proxies.isEnabled(config, "http://127.0.0.1"));
     assertFalse(Proxies.isEnabled(config, "http://127.0.0.1/test/ka"));
   }
 
-  /**
-   * Method description
-   *
-   */
   @Test
-  public void testEnabledWithoutExcludes()
-  {
+  public void testEnabledWithoutExcludes() {
     ScmConfiguration config = createConfiguration(true);
 
     assertTrue(Proxies.isEnabled(config, "localhost"));
+    assertTrue(Proxies.isEnabled(config, "localhost:8082"));
     assertTrue(Proxies.isEnabled(config, "download.scm-manager.org"));
     assertTrue(Proxies.isEnabled(config, "http://127.0.0.1"));
     assertTrue(Proxies.isEnabled(config, "http://127.0.0.1/test/ka"));
   }
 
-  /**
-   * Method description
-   *
-   */
   @Test
-  public void testWithExcludes()
-  {
+  public void testWithExcludes() {
     ScmConfiguration config = createConfiguration(true, "127.0.0.1",
-                                "localhost");
+      "localhost");
 
     assertFalse(Proxies.isEnabled(config, "localhost"));
+    assertFalse(Proxies.isEnabled(config, "localhost:8082"));
     assertTrue(Proxies.isEnabled(config, "download.scm-manager.org"));
     assertFalse(Proxies.isEnabled(config, "http://127.0.0.1"));
     assertFalse(Proxies.isEnabled(config, "http://127.0.0.1/test/ka"));
   }
 
-  /**
-   * Method description
-   *
-   */
   @Test
-  public void testWithGlobExcludes()
-  {
+  public void testWithGlobExcludes() {
     ScmConfiguration config = createConfiguration(true, "127.*", "*host");
 
     assertFalse(Proxies.isEnabled(config, "localhost"));
+    assertFalse(Proxies.isEnabled(config, "localhost:8082"));
     assertTrue(Proxies.isEnabled(config, "download.scm-manager.org"));
     assertFalse(Proxies.isEnabled(config, "http://127.0.0.1"));
     assertFalse(Proxies.isEnabled(config, "http://127.0.0.1/test/ka"));
   }
 
-  /**
-   * Method description
-   *
-   *
-   * @param enabled
-   * @param excludes
-   *
-   * @return
-   */
   private ScmConfiguration createConfiguration(boolean enabled,
-    String... excludes)
-  {
+                                               String... excludes) {
     ScmConfiguration configuration = new ScmConfiguration();
 
     configuration.setEnableProxy(enabled);


### PR DESCRIPTION
## Proposed changes
Ignore port on proxy exclusions.

Example: If the proxy settings were enabled and `localhost` was excluded but the jenkins instance url was configured to `localhost:8082`, the exclusion didn't match because of the port. 

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
