### PR TITLE
Fix tooltip overflow of help icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Help tooltips are now mutliline by default ([#1271](https://github.com/scm-manager/scm-manager/pull/1271))
+
 ### Fixed
-- Fix tooltip overflow in checkbox and radio context ([#1271](https://github.com/scm-manager/scm-manager/pull/1271))
+- Fixed unecessary horizontal scrollbar in modal dialogs ([#1271](https://github.com/scm-manager/scm-manager/pull/1271))
 
 ## [2.3.0] - 2020-07-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.3.0] - 2020-07-23
+## Unreleased
+### Fixed
+- Fix tooltip overflow in checkbox and radio context ([#1271](https://github.com/scm-manager/scm-manager/pull/1271))
 
+## [2.3.0] - 2020-07-23
 ### Added
 - Add branch link provider to access branch links in plugins ([#1243](https://github.com/scm-manager/scm-manager/pull/1243))
 - Add key value input field component ([#1246](https://github.com/scm-manager/scm-manager/pull/1246))

--- a/scm-ui/ui-components/src/Help.stories.tsx
+++ b/scm-ui/ui-components/src/Help.stories.tsx
@@ -21,34 +21,38 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import React, { FC } from "react";
-import classNames from "classnames";
+
 import styled from "styled-components";
-import Tooltip from "./Tooltip";
-import HelpIcon from "./HelpIcon";
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import Help from "./Help";
 
-type Props = {
-  message: string;
-  multiline?: boolean;
-  className?: string;
-};
-
-const HelpTooltip = styled(Tooltip)`
-  position: absolute;
-  padding-left: 3px;
+const Wrapper = styled.div`
+  margin: 5rem;
 `;
 
-const Help: FC<Props> = ({ message, multiline, className }) => (
-  <HelpTooltip
-    className={classNames("is-inline-block", multiline ? "has-tooltip-multiline" : undefined, className)}
-    message={message}
-  >
-    <HelpIcon />
-  </HelpTooltip>
-);
+const Spacing = styled.div`
+  margin-top: 1rem;
+`;
 
-Help.defaultProps = {
-  multiline: true
-};
+const longContent =
+  "Cleverness nuclear genuine static irresponsibility invited President Zaphod\n" +
+  "Beeblebrox hyperspace ship. Another custard through computer-generated universe\n" +
+  "shapes field strong disaster parties Russell’s ancestors infinite colour\n" +
+  "imaginative generator sweep.";
 
-export default Help;
+storiesOf("Help", module)
+  .addDecorator(storyFn => <Wrapper>{storyFn()}</Wrapper>)
+  .add("Default", () => <Help message="This is a help message" />)
+  .add("Multiline", () => (
+    <>
+      <Spacing>
+        <label>With multiline (default):</label>
+        <Help message={longContent} />
+      </Spacing>
+      <Spacing>
+        <label>Without multiline:</label>
+        <Help message={longContent} multiline={false} />
+      </Spacing>
+    </>
+  ));

--- a/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
+++ b/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
@@ -41565,6 +41565,97 @@ exports[`Storyshots Modal|Modal Default 1`] = `
 </div>
 `;
 
+exports[`Storyshots Modal|Modal With Checkbox with HelpText inside 1`] = `
+<div
+  className="modal is-active"
+>
+  <div
+    className="modal-background"
+  />
+  <div
+    className="modal-card"
+  >
+    <header
+      className="modal-card-head has-background-light"
+    >
+      <p
+        className="modal-card-title is-marginless"
+      >
+        Hitchhiker Modal
+      </p>
+      <button
+        aria-label="close"
+        className="delete"
+        onClick={[Function]}
+      />
+    </header>
+    <section
+      className="modal-card-body"
+    >
+      <p>
+        This content should not cause a vertical scrollbar.
+      </p>
+      <div
+        className="Modalstories__TopAndBottomMargin-sc-2lb0wg-0 bfocSI"
+      >
+        <div
+          className="field"
+        >
+          <div
+            className="control"
+            onClick={[Function]}
+          >
+            <label
+              className="checkbox"
+            >
+              <i
+                className="is-outlined fa-square has-text-black far"
+              />
+               
+              Classic helpText
+              <span
+                className="tooltip has-tooltip-right Help__HelpTooltip-ykmmew-0 cYhfno is-inline-block has-tooltip-multiline"
+                data-tooltip="This is a classic help text."
+              >
+                <i
+                  className="fas fa-question-circle has-text-blue-light"
+                />
+              </span>
+            </label>
+          </div>
+        </div>
+        <div
+          className="field"
+        >
+          <div
+            className="control"
+            onClick={[Function]}
+          >
+            <label
+              className="checkbox"
+            >
+              <i
+                className="is-outlined fa-check-square has-text-link fa"
+              />
+               
+              Long helpText
+              <span
+                className="tooltip has-tooltip-right Help__HelpTooltip-ykmmew-0 cYhfno is-inline-block has-tooltip-multiline"
+                data-tooltip="Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
+              >
+                <i
+                  className="fas fa-question-circle has-text-blue-light"
+                />
+              </span>
+            </label>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Navigation|Secondary Active when match 1`] = `
 <div
   className="SecondaryNavigationstories__Columns-fdxo4w-0 iEPunq columns"

--- a/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
+++ b/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
@@ -38549,6 +38549,65 @@ exports[`Storyshots Forms|Checkbox Disabled 1`] = `
 </div>
 `;
 
+exports[`Storyshots Forms|Checkbox With HelpText 1`] = `
+<div
+  className="Checkboxstories__Spacing-sc-1bg8q8e-0 kJtXav"
+>
+  <div
+    className="field"
+  >
+    <div
+      className="control"
+      onClick={[Function]}
+    >
+      <label
+        className="checkbox"
+      >
+        <i
+          className="is-outlined fa-square has-text-black far"
+        />
+         
+        Classic helpText
+        <span
+          className="tooltip has-tooltip-right Help__HelpTooltip-ykmmew-0 cYhfno is-inline-block has-tooltip-multiline"
+          data-tooltip="This is a classic help text."
+        >
+          <i
+            className="fas fa-question-circle has-text-blue-light"
+          />
+        </span>
+      </label>
+    </div>
+  </div>
+  <div
+    className="field"
+  >
+    <div
+      className="control"
+      onClick={[Function]}
+    >
+      <label
+        className="checkbox"
+      >
+        <i
+          className="is-outlined fa-check-square has-text-link fa"
+        />
+         
+        Long helpText
+        <span
+          className="tooltip has-tooltip-right Help__HelpTooltip-ykmmew-0 cYhfno is-inline-block has-tooltip-multiline"
+          data-tooltip="Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
+        >
+          <i
+            className="fas fa-question-circle has-text-blue-light"
+          />
+        </span>
+      </label>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Forms|DropDown Default 1`] = `
 <div
   className="select"
@@ -38654,6 +38713,51 @@ exports[`Storyshots Forms|Radio Disabled 1`] = `
     />
      
     Checked but disabled
+  </label>
+</div>
+`;
+
+exports[`Storyshots Forms|Radio With HelpText 1`] = `
+<div
+  className="Radiostories__RadioList-sc-18hvwhd-1 fSTSuW"
+>
+  <label
+    className="Radio__StyledRadio-ays4vp-0 hrHCWE radio"
+  >
+    <input
+      checked={false}
+      onChange={[Function]}
+      type="radio"
+    />
+     
+    Classic helpText
+    <span
+      className="tooltip has-tooltip-right Help__HelpTooltip-ykmmew-0 cYhfno is-inline-block has-tooltip-multiline"
+      data-tooltip="This is a classic help text."
+    >
+      <i
+        className="fas fa-question-circle has-text-blue-light"
+      />
+    </span>
+  </label>
+  <label
+    className="Radio__StyledRadio-ays4vp-0 hrHCWE radio"
+  >
+    <input
+      checked={true}
+      onChange={[Function]}
+      type="radio"
+    />
+     
+    Long helpText
+    <span
+      className="tooltip has-tooltip-right Help__HelpTooltip-ykmmew-0 cYhfno is-inline-block has-tooltip-multiline"
+      data-tooltip="Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
+    >
+      <i
+        className="fas fa-question-circle has-text-blue-light"
+      />
+    </span>
   </label>
 </div>
 `;

--- a/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
+++ b/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
@@ -38839,6 +38839,64 @@ exports[`Storyshots Forms|Textarea OnSubmit 1`] = `
 </div>
 `;
 
+exports[`Storyshots Help Default 1`] = `
+<div
+  className="Helpstories__Wrapper-yq79zu-0 fkZuPN"
+>
+  <span
+    className="tooltip has-tooltip-right Help__HelpTooltip-ykmmew-0 cYhfno is-inline-block has-tooltip-multiline"
+    data-tooltip="This is a help message"
+  >
+    <i
+      className="fas fa-question-circle has-text-blue-light"
+    />
+  </span>
+</div>
+`;
+
+exports[`Storyshots Help Multiline 1`] = `
+<div
+  className="Helpstories__Wrapper-yq79zu-0 fkZuPN"
+>
+  <div
+    className="Helpstories__Spacing-yq79zu-1 jVjwc"
+  >
+    <label>
+      With multiline (default):
+    </label>
+    <span
+      className="tooltip has-tooltip-right Help__HelpTooltip-ykmmew-0 cYhfno is-inline-block has-tooltip-multiline"
+      data-tooltip="Cleverness nuclear genuine static irresponsibility invited President Zaphod
+Beeblebrox hyperspace ship. Another custard through computer-generated universe
+shapes field strong disaster parties Russell’s ancestors infinite colour
+imaginative generator sweep."
+    >
+      <i
+        className="fas fa-question-circle has-text-blue-light"
+      />
+    </span>
+  </div>
+  <div
+    className="Helpstories__Spacing-yq79zu-1 jVjwc"
+  >
+    <label>
+      Without multiline:
+    </label>
+    <span
+      className="tooltip has-tooltip-right Help__HelpTooltip-ykmmew-0 cYhfno is-inline-block"
+      data-tooltip="Cleverness nuclear genuine static irresponsibility invited President Zaphod
+Beeblebrox hyperspace ship. Another custard through computer-generated universe
+shapes field strong disaster parties Russell’s ancestors infinite colour
+imaginative generator sweep."
+    >
+      <i
+        className="fas fa-question-circle has-text-blue-light"
+      />
+    </span>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Icon Colors 1`] = `
 <div
   className="Iconstories__Wrapper-sc-1g657fe-0 culAJk"
@@ -41530,6 +41588,44 @@ exports[`Storyshots Modal|ConfirmAlert Default 1`] = `
 </div>
 `;
 
+exports[`Storyshots Modal|Modal Closeable 1`] = `
+<div
+  className="modal is-active"
+>
+  <div
+    className="modal-background"
+  />
+  <div
+    className="modal-card"
+  >
+    <header
+      className="modal-card-head has-background-light"
+    >
+      <p
+        className="modal-card-title is-marginless"
+      >
+        Hitchhiker Modal
+      </p>
+      <button
+        aria-label="close"
+        className="delete"
+        onClick={[Function]}
+      />
+    </header>
+    <section
+      className="modal-card-body"
+    >
+      <p>
+        Mind-paralyzing change needed improbability vortex machine sorts sought same theory upending job just allows
+    hostess’s really oblong Infinite Improbability thing into the starship against which behavior accordance.with
+    Kakrafoon humanoid undergarment ship powered by GPP-guided bowl of petunias nothing was frequently away incredibly
+    ordinary mob.
+      </p>
+    </section>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Modal|Modal Default 1`] = `
 <div
   className="modal is-active"
@@ -41558,14 +41654,17 @@ exports[`Storyshots Modal|Modal Default 1`] = `
       className="modal-card-body"
     >
       <p>
-        Mind-paralyzing change needed improbability vortex machine sorts sought same theory upending job just allows hostess’s really oblong Infinite Improbability thing into the starship against which behavior accordance.with Kakrafoon humanoid undergarment ship powered by GPP-guided bowl of petunias nothing was frequently away incredibly ordinary mob.
+        Mind-paralyzing change needed improbability vortex machine sorts sought same theory upending job just allows
+    hostess’s really oblong Infinite Improbability thing into the starship against which behavior accordance.with
+    Kakrafoon humanoid undergarment ship powered by GPP-guided bowl of petunias nothing was frequently away incredibly
+    ordinary mob.
       </p>
     </section>
   </div>
 </div>
 `;
 
-exports[`Storyshots Modal|Modal With Checkbox with HelpText inside 1`] = `
+exports[`Storyshots Modal|Modal Long content 1`] = `
 <div
   className="modal is-active"
 >
@@ -41592,9 +41691,260 @@ exports[`Storyshots Modal|Modal With Checkbox with HelpText inside 1`] = `
     <section
       className="modal-card-body"
     >
-      <p>
-        This content should not cause a vertical scrollbar.
+      <h1
+        className="title"
+      >
+        Marvin
+      </h1>
+      <h2
+        className="subtitle"
+      >
+        The Paranoid Android
+      </h2>
+      <hr />
+      <div
+        className="notification is-info"
+      >
+        
+        The following content comes from the awesome
+         
+        <a
+          href="https://hitchhikers.fandom.com/wiki/Main_Page"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Hitchhikers Wiki
+        </a>
+      </div>
+      <hr />
+      <div
+        className="has-text-centered"
+      >
+        <img
+          alt="Marvin"
+          src="https://vignette.wikia.nocookie.net/hitchhikers/images/a/a4/Marvin.jpg/revision/latest/scale-to-width-down/150?cb=20100530114055"
+        />
+      </div>
+      <hr />
+      <p
+        className="content"
+      >
+        Marvin, more fully known as Marvin the Paranoid Android, is an incredibly brilliant but overwhelmingly depressed robot manufactured by the Sirius Cybernetics Corporation and unwilling servant to the crew of the Heart of Gold.
       </p>
+      <hr />
+      <div
+        className="content"
+      >
+        <h4>
+          Physical Appearance
+        </h4>
+        <p>
+          In the novels, Marvin is described thusly: "...though it was beautifully constructed and polished it looked somehow as if the various parts of its more or less humanoid body didn't quite fit properly. In fact, they fit perfectly well, but something in its bearing suggested that they might have fitted better."
+        </p>
+        <p>
+          On the radio show, there's no physical description of Marvin, though his voice is digitally altered to sound more robotic, and any scene that focuses on him is accompanied by sounds of mechanical clanking and hissing.
+        </p>
+        <p>
+          In the TV series, Marvin is built in the style of a 1950's robot similar to Robbie the Robot from Forbidden Planet or Twiki from Buck Rogers. His body is blocky and angular, with a pair of clamp-claw hands, shuffling feet and a squarish head with a dour face.
+        </p>
+        <p>
+          In the movie, Marvin is a short, stout robot built of smooth, white plastic. His arms are much longer than his legs, and his head is a massive sphere with only a pair of triangle eyes for a face. His large head and simian-like proportions give Marvin a perpetual slouch, adding to his melancholy personality. At the start of the film his eyes glow, but at the end he is shot but unharmed, leaving a hole in his head and dimming his eyes. This is probably the most depressing and unacceptable manifestation of Marvin ever conceived, and thus paradoxically the most accurate.
+        </p>
+      </div>
+      <hr />
+      <div
+        className="content"
+      >
+        <h4>
+          Personality
+        </h4>
+        <p>
+          Marvin the robot has a prototype version of the Genuine People Personality (GPP) software from SCC, allowing him sentience and the ability to feel emotions and develop a personality. He's also incredibly smart, having a "brain the size of a planet" capable of computing extremely complex mathematics, as well as solving difficult problems and operating high-tech devices.
+        </p>
+        <p>
+          However, despite being so smart, Marvin is typically made to perform menial tasks and labour such as escorting people, opening doors, picking up pieces of paper, and other tasks well beneath his skills. Even extremely hard tasks, such as computing for the vast Krikkit robot army, are trivial for Marvin. All this leaves him extremely bored, frustrated, and overwhelmingly depressed. Because of this, all modern GPP-capable machines, such as Eddie the computer and the Heart of Gold's automatic doors, are programmed to be extremely cheerful and happy, much to Marvin's disgust.
+        </p>
+        <p>
+          Marvin hates everyone and everything he comes into contact with, having no respect for anybody and will criticise and insult others at any opportunity, or otherwise rant and complain for hours on end about his own problems, such as the terrible pain he suffers in all the diodes down his left side. His contempt for everyone is often justified, as almost every person he comes across, even those who consider him a friend, (such as Arthur and Trillian, who treat him more kindly than Ford and Zaphod) treat Marvin as an expendable servant, even sending him to his death more than once (such as when Zaphod ordered Marvin to fight the gigantic, heavy-duty Frogstar Scout Robot Class D so he could escape). Being a robot, he still does what he's told (he won't enjoy it, nor will he let you forget it, but he'll do it anyway), though he'd much rather sulk in a corner by himself.
+        </p>
+        <p>
+          Several times in the series Marvin ends up alone and isolated for extremely long periods of time, sometimes spanning millions of years, either by sheer bad luck (such as the explosion that propelled everyone but Marvin to Milliways in the far-off future) or because his unpleasantly depressing personality drives them away or, in more than one case, makes them commit suicide. In his spare time (which he has a lot of), Marvin will attempt to occupy himself by composing songs and writing poetry. Of course, none of them are particularly cheerful, or even that good.
+        </p>
+      </div>
+    </section>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Modal|Modal With form elements 1`] = `
+<div
+  className="modal is-active"
+>
+  <div
+    className="modal-background"
+  />
+  <div
+    className="modal-card"
+  >
+    <header
+      className="modal-card-head has-background-light"
+    >
+      <p
+        className="modal-card-title is-marginless"
+      >
+        Hitchhiker Modal
+      </p>
+      <button
+        aria-label="close"
+        className="delete"
+        onClick={[Function]}
+      />
+    </header>
+    <section
+      className="modal-card-body"
+    >
+      <div
+        className="Modalstories__RadioList-sc-2lb0wg-1 hFfBOw"
+      >
+        <label
+          className="Radio__StyledRadio-ays4vp-0 hrHCWE radio"
+        >
+          <input
+            checked={true}
+            onChange={[Function]}
+            type="radio"
+          />
+           
+          One
+          <span
+            className="tooltip has-tooltip-right Help__HelpTooltip-ykmmew-0 cYhfno is-inline-block has-tooltip-multiline"
+            data-tooltip="The first one"
+          >
+            <i
+              className="fas fa-question-circle has-text-blue-light"
+            />
+          </span>
+        </label>
+        <label
+          className="Radio__StyledRadio-ays4vp-0 hrHCWE radio"
+        >
+          <input
+            checked={false}
+            onChange={[Function]}
+            type="radio"
+          />
+           
+          Two
+          <span
+            className="tooltip has-tooltip-right Help__HelpTooltip-ykmmew-0 cYhfno is-inline-block has-tooltip-multiline"
+            data-tooltip="The second one"
+          >
+            <i
+              className="fas fa-question-circle has-text-blue-light"
+            />
+          </span>
+        </label>
+      </div>
+      <hr />
+      <p>
+        Mind-paralyzing change needed improbability vortex machine sorts sought same theory upending job just allows
+    hostess’s really oblong Infinite Improbability thing into the starship against which behavior accordance.with
+    Kakrafoon humanoid undergarment ship powered by GPP-guided bowl of petunias nothing was frequently away incredibly
+    ordinary mob.
+      </p>
+      <hr />
+      <div
+        className="field"
+      >
+        <label
+          className="label"
+        >
+          Text
+           
+        </label>
+        <div
+          className="control"
+        >
+          <textarea
+            className="textarea"
+            disabled={false}
+            onChange={[Function]}
+            onKeyDown={[Function]}
+          />
+        </div>
+      </div>
+      <hr />
+      <div
+        className="field is-grouped"
+      >
+        <div
+          className="control"
+        >
+          <button
+            className="button is-default"
+            onClick={[Function]}
+            type="button"
+          >
+            One
+             
+          </button>
+        </div>
+        <div
+          className="control"
+        >
+          <button
+            className="button is-default"
+            onClick={[Function]}
+            type="button"
+          >
+            Two
+             
+          </button>
+        </div>
+      </div>
+    </section>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Modal|Modal With long tooltips 1`] = `
+<div
+  className="modal is-active"
+>
+  <div
+    className="modal-background"
+  />
+  <div
+    className="modal-card"
+  >
+    <header
+      className="modal-card-head has-background-light"
+    >
+      <p
+        className="modal-card-title is-marginless"
+      >
+        Hitchhiker Modal
+      </p>
+      <button
+        aria-label="close"
+        className="delete"
+        onClick={[Function]}
+      />
+    </header>
+    <section
+      className="modal-card-body"
+    >
+      <div
+        className="notification is-info"
+      >
+        
+        This story exists because we had a problem, that long tooltips causes a horizontal scrollbar on the modal.
+      </div>
+      <hr />
+      <p>
+        The following elements will have a verly long help text, which has triggered the scrollbar in the past.
+      </p>
+      <hr />
       <div
         className="Modalstories__TopAndBottomMargin-sc-2lb0wg-0 bfocSI"
       >
@@ -41609,39 +41959,16 @@ exports[`Storyshots Modal|Modal With Checkbox with HelpText inside 1`] = `
               className="checkbox"
             >
               <i
-                className="is-outlined fa-square has-text-black far"
-              />
-               
-              Classic helpText
-              <span
-                className="tooltip has-tooltip-right Help__HelpTooltip-ykmmew-0 cYhfno is-inline-block has-tooltip-multiline"
-                data-tooltip="This is a classic help text."
-              >
-                <i
-                  className="fas fa-question-circle has-text-blue-light"
-                />
-              </span>
-            </label>
-          </div>
-        </div>
-        <div
-          className="field"
-        >
-          <div
-            className="control"
-            onClick={[Function]}
-          >
-            <label
-              className="checkbox"
-            >
-              <i
                 className="is-outlined fa-check-square has-text-link fa"
               />
                
-              Long helpText
+              Checkbox
               <span
                 className="tooltip has-tooltip-right Help__HelpTooltip-ykmmew-0 cYhfno is-inline-block has-tooltip-multiline"
-                data-tooltip="Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
+                data-tooltip="Mind-paralyzing change needed improbability vortex machine sorts sought same theory upending job just allows
+    hostess’s really oblong Infinite Improbability thing into the starship against which behavior accordance.with
+    Kakrafoon humanoid undergarment ship powered by GPP-guided bowl of petunias nothing was frequently away incredibly
+    ordinary mob."
               >
                 <i
                   className="fas fa-question-circle has-text-blue-light"
@@ -41651,6 +41978,111 @@ exports[`Storyshots Modal|Modal With Checkbox with HelpText inside 1`] = `
           </div>
         </div>
       </div>
+      <hr />
+      <div
+        className="Modalstories__TopAndBottomMargin-sc-2lb0wg-0 bfocSI"
+      >
+        <label
+          className="Radio__StyledRadio-ays4vp-0 hrHCWE radio"
+        >
+          <input
+            checked={false}
+            onChange={[Function]}
+            type="radio"
+          />
+           
+          Radio button
+          <span
+            className="tooltip has-tooltip-right Help__HelpTooltip-ykmmew-0 cYhfno is-inline-block has-tooltip-multiline"
+            data-tooltip="Mind-paralyzing change needed improbability vortex machine sorts sought same theory upending job just allows
+    hostess’s really oblong Infinite Improbability thing into the starship against which behavior accordance.with
+    Kakrafoon humanoid undergarment ship powered by GPP-guided bowl of petunias nothing was frequently away incredibly
+    ordinary mob."
+          >
+            <i
+              className="fas fa-question-circle has-text-blue-light"
+            />
+          </span>
+        </label>
+      </div>
+      <hr />
+      <div
+        className="Modalstories__TopAndBottomMargin-sc-2lb0wg-0 bfocSI"
+      >
+        <div
+          className="field"
+        >
+          <label
+            className="label"
+          >
+            Input
+             
+            <span
+              className="tooltip has-tooltip-right Help__HelpTooltip-ykmmew-0 cYhfno is-inline-block has-tooltip-multiline"
+              data-tooltip="Mind-paralyzing change needed improbability vortex machine sorts sought same theory upending job just allows
+    hostess’s really oblong Infinite Improbability thing into the starship against which behavior accordance.with
+    Kakrafoon humanoid undergarment ship powered by GPP-guided bowl of petunias nothing was frequently away incredibly
+    ordinary mob."
+            >
+              <i
+                className="fas fa-question-circle has-text-blue-light"
+              />
+            </span>
+          </label>
+          <div
+            className="control"
+          >
+            <input
+              className="input"
+              onChange={[Function]}
+              onKeyPress={[Function]}
+              placeholder=""
+              type="text"
+            />
+          </div>
+          
+        </div>
+      </div>
+      <hr />
+      <div
+        className="Modalstories__TopAndBottomMargin-sc-2lb0wg-0 bfocSI"
+      >
+        <div
+          className="field"
+        >
+          <label
+            className="label"
+          >
+            Textarea
+             
+            <span
+              className="tooltip has-tooltip-right Help__HelpTooltip-ykmmew-0 cYhfno is-inline-block has-tooltip-multiline"
+              data-tooltip="Mind-paralyzing change needed improbability vortex machine sorts sought same theory upending job just allows
+    hostess’s really oblong Infinite Improbability thing into the starship against which behavior accordance.with
+    Kakrafoon humanoid undergarment ship powered by GPP-guided bowl of petunias nothing was frequently away incredibly
+    ordinary mob."
+            >
+              <i
+                className="fas fa-question-circle has-text-blue-light"
+              />
+            </span>
+          </label>
+          <div
+            className="control"
+          >
+            <textarea
+              className="textarea"
+              disabled={false}
+              onChange={[Function]}
+              onKeyDown={[Function]}
+            />
+          </div>
+        </div>
+      </div>
+      <hr />
+      <p>
+        If this modal has no horizontal scrollbar the issue is fixed
+      </p>
     </section>
   </div>
 </div>

--- a/scm-ui/ui-components/src/forms/Checkbox.stories.tsx
+++ b/scm-ui/ui-components/src/forms/Checkbox.stories.tsx
@@ -25,7 +25,6 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import Checkbox from "./Checkbox";
 import styled from "styled-components";
-import Radio from "./Radio";
 
 const Spacing = styled.div`
   padding: 2em;

--- a/scm-ui/ui-components/src/forms/Checkbox.stories.tsx
+++ b/scm-ui/ui-components/src/forms/Checkbox.stories.tsx
@@ -25,6 +25,7 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import Checkbox from "./Checkbox";
 import styled from "styled-components";
+import Radio from "./Radio";
 
 const Spacing = styled.div`
   padding: 2em;
@@ -41,5 +42,15 @@ storiesOf("Forms|Checkbox", module)
   .add("Disabled", () => (
     <Spacing>
       <Checkbox label="Checked but disabled" checked={true} disabled={true} />
+    </Spacing>
+  ))
+  .add("With HelpText", () => (
+    <Spacing>
+      <Checkbox label="Classic helpText" checked={false} helpText="This is a classic help text." />
+      <Checkbox
+        label="Long helpText"
+        checked={true}
+        helpText="Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
+      />
     </Spacing>
   ));

--- a/scm-ui/ui-components/src/forms/Checkbox.tsx
+++ b/scm-ui/ui-components/src/forms/Checkbox.tsx
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import React, { ChangeEvent } from "react";
+import React from "react";
 import { Help } from "../index";
 import LabelWithHelpIcon from "./LabelWithHelpIcon";
 import TriStateCheckbox from "./TriStateCheckbox";
@@ -47,7 +47,7 @@ export default class Checkbox extends React.Component<Props> {
   renderHelp = () => {
     const { title, helpText } = this.props;
     if (helpText && !title) {
-      return <Help message={helpText} className="has-tooltip-multiline" />;
+      return <Help message={helpText} />;
     }
   };
 

--- a/scm-ui/ui-components/src/forms/Checkbox.tsx
+++ b/scm-ui/ui-components/src/forms/Checkbox.tsx
@@ -47,7 +47,7 @@ export default class Checkbox extends React.Component<Props> {
   renderHelp = () => {
     const { title, helpText } = this.props;
     if (helpText && !title) {
-      return <Help message={helpText} />;
+      return <Help message={helpText} className="has-tooltip-multiline" />;
     }
   };
 

--- a/scm-ui/ui-components/src/forms/Radio.stories.tsx
+++ b/scm-ui/ui-components/src/forms/Radio.stories.tsx
@@ -30,6 +30,15 @@ const Spacing = styled.div`
   padding: 2em;
 `;
 
+const RadioList = styled.div`
+  display: flex;
+  flex-direction: column;
+  > label:not(:last-child) {
+    margin-bottom: 0.75rem;
+  }
+  padding: 2em;
+`;
+
 storiesOf("Forms|Radio", module)
   .add("Default", () => (
     <Spacing>
@@ -41,4 +50,14 @@ storiesOf("Forms|Radio", module)
     <Spacing>
       <Radio label="Checked but disabled" checked={true} disabled={true} />
     </Spacing>
+  ))
+  .add("With HelpText", () => (
+    <RadioList>
+      <Radio label="Classic helpText" checked={false} helpText="This is a classic help text." />
+      <Radio
+        label="Long helpText"
+        checked={true}
+        helpText="Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
+      />
+    </RadioList>
   ));

--- a/scm-ui/ui-components/src/forms/Radio.tsx
+++ b/scm-ui/ui-components/src/forms/Radio.tsx
@@ -43,7 +43,7 @@ class Radio extends React.Component<Props> {
   renderHelp = () => {
     const helpText = this.props.helpText;
     if (helpText) {
-      return <Help message={helpText} className="has-tooltip-multiline" />;
+      return <Help message={helpText} />;
     }
   };
 

--- a/scm-ui/ui-components/src/forms/Radio.tsx
+++ b/scm-ui/ui-components/src/forms/Radio.tsx
@@ -43,7 +43,7 @@ class Radio extends React.Component<Props> {
   renderHelp = () => {
     const helpText = this.props.helpText;
     if (helpText) {
-      return <Help message={helpText} />;
+      return <Help message={helpText} className="has-tooltip-multiline" />;
     }
   };
 

--- a/scm-ui/ui-components/src/modals/Modal.stories.tsx
+++ b/scm-ui/ui-components/src/modals/Modal.stories.tsx
@@ -24,52 +24,194 @@
 
 import { storiesOf } from "@storybook/react";
 import { MemoryRouter } from "react-router-dom";
-import * as React from "react";
-import { useState } from "react";
+import React, { useState, FC } from "react";
 import Modal from "./Modal";
 import Checkbox from "../forms/Checkbox";
 import styled from "styled-components";
+import ExternalLink from "../navigation/ExternalLink";
+import { Radio, Textarea, InputField } from "../forms";
+import { ButtonGroup, Button } from "../buttons";
+import Notification from "../Notification";
 
 const TopAndBottomMargin = styled.div`
   margin: 0.75rem 0; // only for aesthetic reasons
 `;
 
-const body = (
-  <p>
-    Mind-paralyzing change needed improbability vortex machine sorts sought same theory upending job just allows
+const RadioList = styled.div`
+  display: flex;
+  flex-direction: column;
+  > label:not(:last-child) {
+    margin-bottom: 0.6em;
+  }
+`;
+
+const text = `Mind-paralyzing change needed improbability vortex machine sorts sought same theory upending job just allows
     hostess’s really oblong Infinite Improbability thing into the starship against which behavior accordance.with
     Kakrafoon humanoid undergarment ship powered by GPP-guided bowl of petunias nothing was frequently away incredibly
-    ordinary mob.
-  </p>
-);
+    ordinary mob.`;
 
-const checkboxBody = (
-  <>
-    <p>This content should not cause a vertical scrollbar.</p>
-    <TopAndBottomMargin>
-      <Checkbox label="Classic helpText" checked={false} helpText="This is a classic help text." />
-      <Checkbox
-        label="Long helpText"
-        checked={true}
-        helpText="Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
-      />
-    </TopAndBottomMargin>
-  </>
-);
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const doNothing = () => {};
 
 storiesOf("Modal|Modal", module)
   .addDecorator(story => <MemoryRouter initialEntries={["/"]}>{story()}</MemoryRouter>)
-  .add("Default", () => <CloseableModal />)
-  .add("With Checkbox with HelpText inside", () => (
-    <Modal body={checkboxBody} closeFunction={() => true} active={true} title={"Hitchhiker Modal"} />
+  .add("Default", () => (
+    <NonCloseableModal>
+      <p>{text}</p>
+    </NonCloseableModal>
+  ))
+  .add("Closeable", () => (
+    <CloseableModal>
+      <p>{text}</p>
+    </CloseableModal>
+  ))
+  .add("With form elements", () => (
+    <NonCloseableModal>
+      <RadioList>
+        <Radio label="One" checked={true} helpText="The first one" />
+        <Radio label="Two" checked={false} helpText="The second one" />
+      </RadioList>
+      <hr />
+      <p>{text}</p>
+      <hr />
+      <Textarea label="Text" onChange={doNothing} />
+      <hr />
+      <ButtonGroup>
+        <Button label="One" />
+        <Button label="Two" />
+      </ButtonGroup>
+    </NonCloseableModal>
+  ))
+  .add("With long tooltips", () => {
+    return (
+      <NonCloseableModal>
+        <Notification type="info">
+          This story exists because we had a problem, that long tooltips causes a horizontal scrollbar on the modal.
+        </Notification>
+        <hr />
+        <p>The following elements will have a verly long help text, which has triggered the scrollbar in the past.</p>
+        <hr />
+        <TopAndBottomMargin>
+          <Checkbox label="Classic helpText" checked={false} helpText="This is a classic help text." />
+          <Checkbox label="Long helpText" checked={true} helpText={text} />
+        </TopAndBottomMargin>
+        <hr />
+        <RadioList>
+          <Radio label="Classic helpText" checked={true} helpText="This is a classic help text." />
+          <Radio label="Long helpText" checked={false} helpText={text} />
+        </RadioList>
+        <hr />
+        <TopAndBottomMargin>
+          <InputField onChange={doNothing} label="Classic helpText" helpText="This is a classic help text." />
+          <InputField onChange={doNothing} label="Long helpText" helpText={text} />
+        </TopAndBottomMargin>
+        <hr />
+        <TopAndBottomMargin>
+          <Textarea onChange={doNothing} label="Classic helpText" helpText="This is a classic help text." />
+          <Textarea onChange={doNothing} label="Long helpText" helpText={text} />
+        </TopAndBottomMargin>
+        <hr />
+        <p>If this modal has not horizontal scrollbar the issue is fixed</p>
+      </NonCloseableModal>
+    );
+  })
+  .add("Long content", () => (
+    <NonCloseableModal>
+      <h1 className="title">Marvin</h1>
+      <h2 className="subtitle">The Paranoid Android</h2>
+      <hr />
+      <Notification type="info">
+        The following content comes from the awesome{" "}
+        <ExternalLink to="https://hitchhikers.fandom.com/wiki/Main_Page">Hitchhikers Wiki</ExternalLink>
+      </Notification>
+      <hr />
+      <div className="has-text-centered">
+        <img
+          alt="Marvin"
+          src="https://vignette.wikia.nocookie.net/hitchhikers/images/a/a4/Marvin.jpg/revision/latest/scale-to-width-down/150?cb=20100530114055"
+        />
+      </div>
+      <hr />
+      <p className="content">
+        Marvin, more fully known as Marvin the Paranoid Android, is an incredibly brilliant but overwhelmingly depressed
+        robot manufactured by the Sirius Cybernetics Corporation and unwilling servant to the crew of the Heart of Gold.
+      </p>
+      <hr />
+      <div className="content">
+        <h4>Physical Appearance</h4>
+        <p>
+          In the novels, Marvin is described thusly: "...though it was beautifully constructed and polished it looked
+          somehow as if the various parts of its more or less humanoid body didn't quite fit properly. In fact, they fit
+          perfectly well, but something in its bearing suggested that they might have fitted better."
+        </p>
+        <p>
+          On the radio show, there's no physical description of Marvin, though his voice is digitally altered to sound
+          more robotic, and any scene that focuses on him is accompanied by sounds of mechanical clanking and hissing.
+        </p>
+        <p>
+          In the TV series, Marvin is built in the style of a 1950's robot similar to Robbie the Robot from Forbidden
+          Planet or Twiki from Buck Rogers. His body is blocky and angular, with a pair of clamp-claw hands, shuffling
+          feet and a squarish head with a dour face.
+        </p>
+        <p>
+          In the movie, Marvin is a short, stout robot built of smooth, white plastic. His arms are much longer than his
+          legs, and his head is a massive sphere with only a pair of triangle eyes for a face. His large head and
+          simian-like proportions give Marvin a perpetual slouch, adding to his melancholy personality. At the start of
+          the film his eyes glow, but at the end he is shot but unharmed, leaving a hole in his head and dimming his
+          eyes. This is probably the most depressing and unacceptable manifestation of Marvin ever conceived, and thus
+          paradoxically the most accurate.
+        </p>
+      </div>
+      <hr />
+      <div className="content">
+        <h4>Personality</h4>
+        <p>
+          Marvin the robot has a prototype version of the Genuine People Personality (GPP) software from SCC, allowing
+          him sentience and the ability to feel emotions and develop a personality. He's also incredibly smart, having a
+          "brain the size of a planet" capable of computing extremely complex mathematics, as well as solving difficult
+          problems and operating high-tech devices.
+        </p>
+        <p>
+          However, despite being so smart, Marvin is typically made to perform menial tasks and labour such as escorting
+          people, opening doors, picking up pieces of paper, and other tasks well beneath his skills. Even extremely
+          hard tasks, such as computing for the vast Krikkit robot army, are trivial for Marvin. All this leaves him
+          extremely bored, frustrated, and overwhelmingly depressed. Because of this, all modern GPP-capable machines,
+          such as Eddie the computer and the Heart of Gold's automatic doors, are programmed to be extremely cheerful
+          and happy, much to Marvin's disgust.
+        </p>
+        <p>
+          Marvin hates everyone and everything he comes into contact with, having no respect for anybody and will
+          criticise and insult others at any opportunity, or otherwise rant and complain for hours on end about his own
+          problems, such as the terrible pain he suffers in all the diodes down his left side. His contempt for everyone
+          is often justified, as almost every person he comes across, even those who consider him a friend, (such as
+          Arthur and Trillian, who treat him more kindly than Ford and Zaphod) treat Marvin as an expendable servant,
+          even sending him to his death more than once (such as when Zaphod ordered Marvin to fight the gigantic,
+          heavy-duty Frogstar Scout Robot Class D so he could escape). Being a robot, he still does what he's told (he
+          won't enjoy it, nor will he let you forget it, but he'll do it anyway), though he'd much rather sulk in a
+          corner by himself.
+        </p>
+        <p>
+          Several times in the series Marvin ends up alone and isolated for extremely long periods of time, sometimes
+          spanning millions of years, either by sheer bad luck (such as the explosion that propelled everyone but Marvin
+          to Milliways in the far-off future) or because his unpleasantly depressing personality drives them away or, in
+          more than one case, makes them commit suicide. In his spare time (which he has a lot of), Marvin will attempt
+          to occupy himself by composing songs and writing poetry. Of course, none of them are particularly cheerful, or
+          even that good.
+        </p>
+      </div>
+    </NonCloseableModal>
   ));
 
-const CloseableModal = () => {
+const NonCloseableModal: FC = ({ children }) => {
+  return <Modal body={children} closeFunction={doNothing} active={true} title={"Hitchhiker Modal"} />;
+};
+
+const CloseableModal: FC = ({ children }) => {
   const [show, setShow] = useState(true);
 
   const toggleModal = () => {
     setShow(!show);
   };
 
-  return <Modal body={body} closeFunction={toggleModal} active={show} title={"Hitchhiker Modal"} />;
+  return <Modal body={children} closeFunction={toggleModal} active={show} title={"Hitchhiker Modal"} />;
 };

--- a/scm-ui/ui-components/src/modals/Modal.stories.tsx
+++ b/scm-ui/ui-components/src/modals/Modal.stories.tsx
@@ -27,6 +27,12 @@ import { MemoryRouter } from "react-router-dom";
 import * as React from "react";
 import { useState } from "react";
 import Modal from "./Modal";
+import Checkbox from "../forms/Checkbox";
+import styled from "styled-components";
+
+const TopAndBottomMargin = styled.div`
+  margin: 0.75rem 0; // only for aesthetic reasons
+`;
 
 const body = (
   <p>
@@ -37,9 +43,26 @@ const body = (
   </p>
 );
 
+const checkboxBody = (
+  <>
+    <p>This content should not cause a vertical scrollbar.</p>
+    <TopAndBottomMargin>
+      <Checkbox label="Classic helpText" checked={false} helpText="This is a classic help text." />
+      <Checkbox
+        label="Long helpText"
+        checked={true}
+        helpText="Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
+      />
+    </TopAndBottomMargin>
+  </>
+);
+
 storiesOf("Modal|Modal", module)
   .addDecorator(story => <MemoryRouter initialEntries={["/"]}>{story()}</MemoryRouter>)
-  .add("Default", () => <CloseableModal />);
+  .add("Default", () => <CloseableModal />)
+  .add("With Checkbox with HelpText inside", () => (
+    <Modal body={checkboxBody} closeFunction={() => true} active={true} title={"Hitchhiker Modal"} />
+  ));
 
 const CloseableModal = () => {
   const [show, setShow] = useState(true);

--- a/scm-ui/ui-components/src/modals/Modal.stories.tsx
+++ b/scm-ui/ui-components/src/modals/Modal.stories.tsx
@@ -92,26 +92,22 @@ storiesOf("Modal|Modal", module)
         <p>The following elements will have a verly long help text, which has triggered the scrollbar in the past.</p>
         <hr />
         <TopAndBottomMargin>
-          <Checkbox label="Classic helpText" checked={false} helpText="This is a classic help text." />
-          <Checkbox label="Long helpText" checked={true} helpText={text} />
-        </TopAndBottomMargin>
-        <hr />
-        <RadioList>
-          <Radio label="Classic helpText" checked={true} helpText="This is a classic help text." />
-          <Radio label="Long helpText" checked={false} helpText={text} />
-        </RadioList>
-        <hr />
-        <TopAndBottomMargin>
-          <InputField onChange={doNothing} label="Classic helpText" helpText="This is a classic help text." />
-          <InputField onChange={doNothing} label="Long helpText" helpText={text} />
+          <Checkbox label="Checkbox" checked={true} helpText={text} />
         </TopAndBottomMargin>
         <hr />
         <TopAndBottomMargin>
-          <Textarea onChange={doNothing} label="Classic helpText" helpText="This is a classic help text." />
-          <Textarea onChange={doNothing} label="Long helpText" helpText={text} />
+          <Radio label="Radio button" checked={false} helpText={text} />
         </TopAndBottomMargin>
         <hr />
-        <p>If this modal has not horizontal scrollbar the issue is fixed</p>
+        <TopAndBottomMargin>
+          <InputField onChange={doNothing} label="Input" helpText={text} />
+        </TopAndBottomMargin>
+        <hr />
+        <TopAndBottomMargin>
+          <Textarea onChange={doNothing} label="Textarea" helpText={text} />
+        </TopAndBottomMargin>
+        <hr />
+        <p>If this modal has no horizontal scrollbar the issue is fixed</p>
       </NonCloseableModal>
     );
   })


### PR DESCRIPTION
## Proposed changes

Fix unecessary horizontal scrollbar in modal dialogs caused by Help Icons

### Your checklist for this pull request

- [x] PR is well described
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [x] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [x] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [x] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
