### PR TITLE
Avoid stacktrace logging when protocol url is accessed outside of request scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- New api to resolve SCM-Manager root url ([#1276](https://github.com/scm-manager/scm-manager/pull/1276))
+
 ### Changed
 - Help tooltips are now mutliline by default ([#1271](https://github.com/scm-manager/scm-manager/pull/1271))
 
 ### Fixed
-- Fixed unecessary horizontal scrollbar in modal dialogs ([#1271](https://github.com/scm-manager/scm-manager/pull/1271))
+- Fixed unnecessary horizontal scrollbar in modal dialogs ([#1271](https://github.com/scm-manager/scm-manager/pull/1271))
+- Avoid stacktrace logging when protocol url is accessed outside of request scope ([#1276](https://github.com/scm-manager/scm-manager/pull/1276))
 
 ## [2.3.0] - 2020-07-23
 ### Added

--- a/scm-core/src/main/java/sonia/scm/RootURL.java
+++ b/scm-core/src/main/java/sonia/scm/RootURL.java
@@ -1,0 +1,53 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm;
+
+import java.net.URL;
+
+/**
+ * RootURL is able to return the root url of the SCM-Manager instance,
+ * regardless of the scope (web request, async hook, ssh command, etc).
+ *
+ * @since 2.3.1
+ */
+public interface RootURL {
+
+  /**
+   * Returns the root url of the SCM-Manager instance.
+   *
+   * @return root url
+   */
+  URL get();
+
+  /**
+   * Returns the root url of the SCM-Manager instance as string.
+   *
+   * @return root url as string
+   */
+  default String getAsString() {
+    return get().toExternalForm();
+  }
+
+}

--- a/scm-core/src/main/java/sonia/scm/util/HttpUtil.java
+++ b/scm-core/src/main/java/sonia/scm/util/HttpUtil.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.util;
 
 //~--- non-JDK imports --------------------------------------------------------
@@ -925,11 +925,16 @@ public final class HttpUtil
   @VisibleForTesting
   static String createForwardedBaseUrl(HttpServletRequest request)
   {
-    String proto = getHeader(request, HEADER_X_FORWARDED_PROTO,
-                     request.getScheme());
+    String fhost = getHeader(request, HEADER_X_FORWARDED_HOST, null);
+    if (fhost == null) {
+      throw new IllegalStateException(
+        String.format("request has no %s header and does not look like it is forwarded", HEADER_X_FORWARDED_HOST)
+      );
+    }
+
+    String proto = getHeader(request, HEADER_X_FORWARDED_PROTO, request.getScheme());
     String host;
-    String fhost = getHeader(request, HEADER_X_FORWARDED_HOST,
-                     request.getScheme());
+
     String port = request.getHeader(HEADER_X_FORWARDED_PORT);
     int s = fhost.indexOf(SEPARATOR_PORT);
 

--- a/scm-core/src/test/java/sonia/scm/repository/spi/InitializingHttpScmProtocolWrapperTest.java
+++ b/scm-core/src/test/java/sonia/scm/repository/spi/InitializingHttpScmProtocolWrapperTest.java
@@ -134,9 +134,10 @@ class InitializingHttpScmProtocolWrapperTest {
 
   @Test
   void shouldFailForIllegalScmType() {
+    Repository repository = new Repository("", "other", "space", "name");
     assertThrows(
       IllegalArgumentException.class,
-      () -> wrapper.get(new Repository("", "other", "space", "name"))
+      () -> wrapper.get(repository)
     );
   }
 

--- a/scm-core/src/test/java/sonia/scm/util/HttpUtilTest.java
+++ b/scm-core/src/test/java/sonia/scm/util/HttpUtilTest.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.util;
 
 //~--- non-JDK imports --------------------------------------------------------
@@ -232,6 +232,12 @@ public class HttpUtilTest
     when(request.getContextPath()).thenReturn("/scm");
     assertEquals("https://www.scm-manager.org:443/scm",
       HttpUtil.createForwardedBaseUrl(request));
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void shouldTrowIllegalStateExceptionWithoutForwardedHostHeader() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpUtil.createForwardedBaseUrl(request);
   }
 
   /**

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/web/GitScmProtocolProviderWrapper.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/web/GitScmProtocolProviderWrapper.java
@@ -21,25 +21,23 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.web;
 
-import sonia.scm.api.v2.resources.ScmPathInfoStore;
-import sonia.scm.config.ScmConfiguration;
+import sonia.scm.RootURL;
 import sonia.scm.plugin.Extension;
 import sonia.scm.repository.GitRepositoryHandler;
 import sonia.scm.repository.spi.InitializingHttpScmProtocolWrapper;
 
 import javax.inject.Inject;
-import javax.inject.Provider;
 import javax.inject.Singleton;
 
 @Singleton
 @Extension
 public class GitScmProtocolProviderWrapper extends InitializingHttpScmProtocolWrapper {
   @Inject
-  public GitScmProtocolProviderWrapper(ScmGitServletProvider servletProvider, Provider<ScmPathInfoStore> uriInfoStore, ScmConfiguration scmConfiguration) {
-    super(servletProvider, uriInfoStore, scmConfiguration);
+  public GitScmProtocolProviderWrapper(ScmGitServletProvider servletProvider, RootURL rootURL) {
+    super(servletProvider, rootURL);
   }
 
   @Override

--- a/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/web/HgScmProtocolProviderWrapper.java
+++ b/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/web/HgScmProtocolProviderWrapper.java
@@ -21,25 +21,24 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.web;
 
-import sonia.scm.api.v2.resources.ScmPathInfoStore;
-import sonia.scm.config.ScmConfiguration;
+import sonia.scm.RootURL;
 import sonia.scm.plugin.Extension;
 import sonia.scm.repository.HgRepositoryHandler;
 import sonia.scm.repository.spi.InitializingHttpScmProtocolWrapper;
 
 import javax.inject.Inject;
-import javax.inject.Provider;
 import javax.inject.Singleton;
 
 @Singleton
 @Extension
 public class HgScmProtocolProviderWrapper extends InitializingHttpScmProtocolWrapper {
+
   @Inject
-  public HgScmProtocolProviderWrapper(HgCGIServletProvider servletProvider, Provider<ScmPathInfoStore> uriInfoStore, ScmConfiguration scmConfiguration) {
-    super(servletProvider, uriInfoStore, scmConfiguration);
+  public HgScmProtocolProviderWrapper(HgCGIServletProvider servletProvider, RootURL rootURL) {
+    super(servletProvider, rootURL);
   }
 
   @Override

--- a/scm-plugins/scm-svn-plugin/src/main/java/sonia/scm/web/SvnScmProtocolProviderWrapper.java
+++ b/scm-plugins/scm-svn-plugin/src/main/java/sonia/scm/web/SvnScmProtocolProviderWrapper.java
@@ -21,18 +21,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.web;
 
-import sonia.scm.api.v2.resources.ScmPathInfoStore;
-import sonia.scm.config.ScmConfiguration;
+import sonia.scm.RootURL;
 import sonia.scm.plugin.Extension;
 import sonia.scm.repository.SvnRepositoryHandler;
 import sonia.scm.repository.spi.InitializingHttpScmProtocolWrapper;
 import sonia.scm.repository.spi.ScmProviderHttpServlet;
 
 import javax.inject.Inject;
-import javax.inject.Provider;
 import javax.inject.Singleton;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
@@ -45,19 +43,18 @@ public class SvnScmProtocolProviderWrapper extends InitializingHttpScmProtocolWr
 
   public static final String PARAMETER_SVN_PARENTPATH = "SVNParentPath";
 
+  @Inject
+  public SvnScmProtocolProviderWrapper(SvnDAVServletProvider servletProvider, RootURL rootURL) {
+    super(servletProvider, rootURL);
+  }
+
   @Override
   public String getType() {
     return SvnRepositoryHandler.TYPE_NAME;
   }
 
-  @Inject
-  public SvnScmProtocolProviderWrapper(SvnDAVServletProvider servletProvider, Provider<ScmPathInfoStore> uriInfoStore, ScmConfiguration scmConfiguration) {
-    super(servletProvider, uriInfoStore, scmConfiguration);
-  }
-
   @Override
   protected void initializeServlet(ServletConfig config, ScmProviderHttpServlet httpServlet) throws ServletException {
-
     super.initializeServlet(new SvnConfigEnhancer(config), httpServlet);
   }
 

--- a/scm-webapp/src/main/java/sonia/scm/DefaultRootURL.java
+++ b/scm-webapp/src/main/java/sonia/scm/DefaultRootURL.java
@@ -1,0 +1,84 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm;
+
+import com.google.inject.OutOfScopeException;
+import com.google.inject.ProvisionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sonia.scm.config.ScmConfiguration;
+import sonia.scm.util.HttpUtil;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.servlet.http.HttpServletRequest;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Optional;
+
+/**
+ * Default implementation of {@link RootURL}.
+ *
+ * @since 2.3.1
+ */
+public class DefaultRootURL implements RootURL {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultRootURL.class);
+
+  private final Provider<HttpServletRequest> requestProvider;
+  private final ScmConfiguration configuration;
+
+  @Inject
+  public DefaultRootURL(Provider<HttpServletRequest> requestProvider, ScmConfiguration configuration) {
+    this.requestProvider = requestProvider;
+    this.configuration = configuration;
+  }
+
+  @Override
+  public URL get() {
+    String url = fromRequest().orElse(configuration.getBaseUrl());
+    if (url == null) {
+      throw new IllegalStateException("The configured base url is empty. This can only happened if SCM-Manager has not received any requests.");
+    }
+    try {
+      return new URL(url);
+    } catch (MalformedURLException e) {
+      throw new IllegalStateException(String.format("base url \"%s\" is malformed", url), e);
+    }
+  }
+
+  private Optional<String> fromRequest() {
+    try {
+      HttpServletRequest request = requestProvider.get();
+      return Optional.of(HttpUtil.getCompleteUrl(request));
+    } catch (ProvisionException ex) {
+      if (ex.getCause() instanceof OutOfScopeException) {
+        LOG.debug("could not find request, fall back to base url from configuration");
+        return Optional.empty();
+      }
+      throw ex;
+    }
+  }
+}

--- a/scm-webapp/src/main/java/sonia/scm/lifecycle/modules/ScmServletModule.java
+++ b/scm-webapp/src/main/java/sonia/scm/lifecycle/modules/ScmServletModule.java
@@ -33,8 +33,10 @@ import com.google.inject.throwingproviders.ThrowingProviderBinder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sonia.scm.Default;
+import sonia.scm.DefaultRootURL;
 import sonia.scm.PushStateDispatcher;
 import sonia.scm.PushStateDispatcherProvider;
+import sonia.scm.RootURL;
 import sonia.scm.Undecorated;
 import sonia.scm.api.rest.ObjectMapperProvider;
 import sonia.scm.api.v2.resources.BranchLinkProvider;
@@ -239,6 +241,9 @@ class ScmServletModule extends ServletModule {
 
     // bind api link provider
     bind(BranchLinkProvider.class).to(DefaultBranchLinkProvider.class);
+
+    // bind url helper
+    bind(RootURL.class).to(DefaultRootURL.class);
   }
 
   private <T> void bind(Class<T> clazz, Class<? extends T> defaultImplementation) {

--- a/scm-webapp/src/test/java/sonia/scm/DefaultRootURLTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/DefaultRootURLTest.java
@@ -1,0 +1,134 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm;
+
+import com.google.inject.OutOfScopeException;
+import com.google.inject.ProvisionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sonia.scm.config.ScmConfiguration;
+import sonia.scm.util.HttpUtil;
+
+import javax.inject.Provider;
+import javax.servlet.http.HttpServletRequest;
+import java.net.MalformedURLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultRootURLTest {
+
+  private static final String URL_CONFIG = "https://hitchhiker.com/from-configuration";
+  private static final String URL_REQUEST = "https://hitchhiker.com/from-request";
+
+  @Mock
+  private Provider<HttpServletRequest> requestProvider;
+
+  @Mock
+  private HttpServletRequest request;
+
+  private ScmConfiguration configuration;
+
+  private RootURL rootURL;
+
+  @BeforeEach
+  void init() {
+    configuration = new ScmConfiguration();
+    rootURL = new DefaultRootURL(requestProvider, configuration);
+  }
+
+  @Test
+  void shouldUseRootURLFromRequest() {
+    bindRequestUrl();
+    assertThat(rootURL.getAsString()).isEqualTo(URL_REQUEST);
+  }
+
+  private void bindRequestUrl() {
+    when(requestProvider.get()).thenReturn(request);
+    when(request.getRequestURL()).thenReturn(new StringBuffer(URL_REQUEST));
+    when(request.getRequestURI()).thenReturn("/from-request");
+    when(request.getContextPath()).thenReturn("/from-request");
+  }
+
+  @Test
+  void shouldUseRootURLFromConfiguration() {
+    bindNonHttpScope();
+    configuration.setBaseUrl(URL_CONFIG);
+    assertThat(rootURL.getAsString()).isEqualTo(URL_CONFIG);
+  }
+
+  private void bindNonHttpScope() {
+    when(requestProvider.get()).thenThrow(
+      new ProvisionException("no request available", new OutOfScopeException("out of scope"))
+    );
+  }
+
+  @Test
+  void shouldThrowNonOutOfScopeProvisioningExceptions() {
+    when(requestProvider.get()).thenThrow(
+      new ProvisionException("something ugly happened", new IllegalStateException("some wrong state"))
+    );
+
+    assertThrows(ProvisionException.class, () -> rootURL.get());
+  }
+
+  @Test
+  void shouldThrowIllegalStateExceptionForMalformedBaseUrl() {
+    bindNonHttpScope();
+    configuration.setBaseUrl("non_url");
+
+    IllegalStateException exception = assertThrows(IllegalStateException.class, () -> rootURL.get());
+    assertThat(exception.getMessage()).contains("malformed", "non_url");
+    assertThat(exception.getCause()).isInstanceOf(MalformedURLException.class);
+  }
+
+  @Test
+  void shouldThrowIllegalStateExceptionIfBaseURLIsNotConfigured() {
+    bindNonHttpScope();
+
+    IllegalStateException exception = assertThrows(IllegalStateException.class, () -> rootURL.get());
+    assertThat(exception.getMessage()).contains("empty");
+  }
+
+  @Test
+  void shouldUseRootURLFromForwardedRequest() {
+    bindForwardedRequestUrl();
+    assertThat(rootURL.get()).hasHost("hitchhiker.com");
+  }
+
+  private void bindForwardedRequestUrl() {
+    when(requestProvider.get()).thenReturn(request);
+    when(request.getHeader(HttpUtil.HEADER_X_FORWARDED_HOST)).thenReturn("hitchhiker.com");
+    when(request.getScheme()).thenReturn("https");
+    when(request.getServerPort()).thenReturn(443);
+    when(request.getContextPath()).thenReturn("/from-request");
+  }
+
+}


### PR DESCRIPTION
## Proposed changes

Creates a new simpler api to resolve the root url of an SCM-Manager instance.
Avoids logging of stacktraces when protocol url is accessed outside of a web request, such as during an async hook.

### Your checklist for this pull request
- [X] PR is well described
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests
- [X] CHANGELOG.md updated
- [X] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
