### PR TITLE
Validate new namespace on rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Redirection to requested page after login in anonymous mode
+- Validate new namespace on repository rename ([#1322](https://github.com/scm-manager/scm-manager/pull/1322))
 
 ## [2.4.1] - 2020-09-01
 ### Added

--- a/scm-webapp/src/main/java/sonia/scm/repository/DefaultRepositoryManager.java
+++ b/scm-webapp/src/main/java/sonia/scm/repository/DefaultRepositoryManager.java
@@ -261,6 +261,7 @@ public class DefaultRepositoryManager extends AbstractRepositoryManager {
         throw new ChangeNamespaceNotAllowedException(repository);
       }
       changedRepository.setNamespace(newNamespace);
+      strategy.createNamespace(changedRepository);
     }
 
     managerDaoAdapter.modify(

--- a/scm-webapp/src/main/java/sonia/scm/repository/DefaultRepositoryManager.java
+++ b/scm-webapp/src/main/java/sonia/scm/repository/DefaultRepositoryManager.java
@@ -261,7 +261,7 @@ public class DefaultRepositoryManager extends AbstractRepositoryManager {
         throw new ChangeNamespaceNotAllowedException(repository);
       }
       changedRepository.setNamespace(newNamespace);
-      strategy.createNamespace(changedRepository);
+      changedRepository.setNamespace(strategy.createNamespace(changedRepository));
     }
 
     managerDaoAdapter.modify(


### PR DESCRIPTION
## Proposed changes

During the rename of a repository, the server did not validate the new namespace. In this change this is done by calling `createNamespace` once in the current namespace strategy.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [ ] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
