### PR TITLE
update filter value on props change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Redirection to requested page after login in anonymous mode
+- Update filter state on property change ([#1327](https://github.com/scm-manager/scm-manager/pull/1327))
 
 ## [2.4.1] - 2020-09-01
 ### Added

--- a/scm-ui/ui-components/src/forms/FilterInput.tsx
+++ b/scm-ui/ui-components/src/forms/FilterInput.tsx
@@ -21,10 +21,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import React, {ChangeEvent, FormEvent} from "react";
-import {WithTranslation, withTranslation} from "react-i18next";
+import React, { ChangeEvent, FormEvent } from "react";
+import { WithTranslation, withTranslation } from "react-i18next";
 import styled from "styled-components";
-import {createAttributesForTesting} from "../devBuild";
+import { createAttributesForTesting } from "../devBuild";
 
 type Props = WithTranslation & {
   filter: (p: string) => void;
@@ -59,12 +59,12 @@ class FilterInput extends React.Component<Props, State> {
     event.preventDefault();
   };
 
-  componentDidUpdate = (prevProps: Props) => {
-    const { value } = this.props;
+  componentDidUpdate = ({ value: oldValue }: Props) => {
+    const { value: newValue } = this.props;
     const { value: stateValue } = this.state;
-    if (prevProps.value !== value && value !== stateValue) {
+    if (oldValue !== newValue && newValue !== stateValue) {
       this.setState({
-        value: value || ""
+        value: newValue || ""
       });
     }
   };

--- a/scm-ui/ui-components/src/forms/FilterInput.tsx
+++ b/scm-ui/ui-components/src/forms/FilterInput.tsx
@@ -21,10 +21,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import React, { ChangeEvent, FormEvent } from "react";
-import { WithTranslation, withTranslation } from "react-i18next";
+import React, {ChangeEvent, FormEvent} from "react";
+import {WithTranslation, withTranslation} from "react-i18next";
 import styled from "styled-components";
-import { createAttributesForTesting } from "../devBuild";
+import {createAttributesForTesting} from "../devBuild";
 
 type Props = WithTranslation & {
   filter: (p: string) => void;
@@ -57,6 +57,16 @@ class FilterInput extends React.Component<Props, State> {
   handleSubmit = (event: FormEvent) => {
     this.props.filter(this.state.value);
     event.preventDefault();
+  };
+
+  componentDidUpdate = (prevProps: Props) => {
+    const { value } = this.props;
+    const { value: stateValue } = this.state;
+    if (prevProps.value !== value && value !== stateValue) {
+      this.setState({
+        value: value || ""
+      });
+    }
   };
 
   render() {


### PR DESCRIPTION
## Proposed changes

Filters are not reset when the repository page is reloaded through the navigation link. This PR adds a check to the filter component that causes an update to its state whenever the value property changes.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [ ] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [ ] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
