### PR TITLE
Fix branch not found direct after creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Missing synchronization during repository creation ([#1328](https://github.com/scm-manager/scm-manager/pull/1328))
+- Missing BranchCreatedEvent for mercurial ([#1334](https://github.com/scm-manager/scm-manager/pull/1334))
+- Branch not found right after creation ([#1334](https://github.com/scm-manager/scm-manager/pull/1334))
 
 ## [2.5.0] - 2020-09-10
 ### Added

--- a/scm-core/src/main/java/sonia/scm/repository/api/BranchCommandBuilder.java
+++ b/scm-core/src/main/java/sonia/scm/repository/api/BranchCommandBuilder.java
@@ -21,21 +21,51 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.repository.api;
 
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sonia.scm.event.ScmEventBus;
 import sonia.scm.repository.Branch;
+import sonia.scm.repository.BranchCreatedEvent;
+import sonia.scm.repository.Repository;
 import sonia.scm.repository.spi.BranchCommand;
-
-import java.io.IOException;
 
 /**
  * @since 2.0
  */
 public final class BranchCommandBuilder {
 
+  private static final Logger LOG = LoggerFactory.getLogger(BranchCommandBuilder.class);
+
+  private final Repository repository;
+  private final BranchCommand command;
+  private final ScmEventBus eventBus;
+  private final BranchRequest request = new BranchRequest();
+
+  public BranchCommandBuilder(Repository repository, BranchCommand command) {
+    this(repository, command, ScmEventBus.getInstance());
+  }
+
+  /**
+   * Creates a new {@link BranchCommandBuilder}.
+   *
+   * @param command type specific command implementation
+   *
+   * @deprecated use {@link #BranchCommandBuilder(Repository, BranchCommand)} instead.
+   */
+  @Deprecated
   public BranchCommandBuilder(BranchCommand command) {
+    this(null, command, ScmEventBus.getInstance());
+  }
+
+  @VisibleForTesting
+  BranchCommandBuilder(Repository repository, BranchCommand command, ScmEventBus eventBus) {
+    this.repository = repository;
     this.command = command;
+    this.eventBus = eventBus;
   }
 
   /**
@@ -53,17 +83,23 @@ public final class BranchCommandBuilder {
    * Execute the command and create a new branch with the given name.
    * @param name The name of the new branch.
    * @return The created branch.
-   * @throws IOException
    */
   public Branch branch(String name) {
     request.setNewBranch(name);
-    return command.branch(request);
+    Branch branch = command.branch(request);
+    fireCreatedEvent(branch);
+    return branch;
+  }
+
+  private void fireCreatedEvent(Branch branch) {
+    if (repository != null) {
+      eventBus.post(new BranchCreatedEvent(repository, branch.getName()));
+    } else {
+      LOG.warn("the branch command was created without a repository, so we are not able to fire a BranchCreatedEvent");
+    }
   }
 
   public void delete(String branchName) {
     command.deleteOrClose(branchName);
   }
-
-  private BranchCommand command;
-  private BranchRequest request = new BranchRequest();
 }

--- a/scm-core/src/main/java/sonia/scm/repository/api/RepositoryService.java
+++ b/scm-core/src/main/java/sonia/scm/repository/api/RepositoryService.java
@@ -177,7 +177,7 @@ public final class RepositoryService implements Closeable {
     LOG.debug("create branch command for repository {}",
       repository.getNamespaceAndName());
 
-    return new BranchCommandBuilder(provider.getBranchCommand());
+    return new BranchCommandBuilder(repository, provider.getBranchCommand());
   }
 
   /**

--- a/scm-core/src/main/java/sonia/scm/repository/api/RepositoryServiceFactory.java
+++ b/scm-core/src/main/java/sonia/scm/repository/api/RepositoryServiceFactory.java
@@ -298,10 +298,12 @@ public final class RepositoryServiceFactory {
 
     /**
      * Clear caches on repository push.
+     * We do this synchronously, because there are often workflows which are creating branches and fetch them straight
+     * after the creation.
      *
      * @param event hook event
      */
-    @Subscribe(referenceType = ReferenceType.STRONG)
+    @Subscribe(async = false, referenceType = ReferenceType.STRONG)
     public void onEvent(PostReceiveRepositoryHookEvent event) {
       Repository repository = event.getRepository();
 
@@ -322,13 +324,6 @@ public final class RepositoryServiceFactory {
       if (event.getEventType() == HandlerEventType.DELETE) {
         clearCaches(event.getItem().getId());
       }
-    }
-
-    @Subscribe(async = false)
-    @SuppressWarnings({"unchecked", "java:S3740", "rawtypes"})
-    public void onEvent(BranchCreatedEvent event) {
-      RepositoryCacheKeyPredicate predicate = new RepositoryCacheKeyPredicate(event.getRepository().getId());
-      cacheManager.getCache(BranchesCommandBuilder.CACHE_NAME).removeAll(predicate);
     }
 
     @Subscribe

--- a/scm-core/src/test/java/sonia/scm/repository/api/BranchCommandBuilderTest.java
+++ b/scm-core/src/test/java/sonia/scm/repository/api/BranchCommandBuilderTest.java
@@ -1,0 +1,105 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.repository.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sonia.scm.event.ScmEventBus;
+import sonia.scm.repository.Branch;
+import sonia.scm.repository.BranchCreatedEvent;
+import sonia.scm.repository.Repository;
+import sonia.scm.repository.spi.BranchCommand;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BranchCommandBuilderTest {
+
+  @Mock
+  private BranchCommand command;
+
+  @Mock
+  private ScmEventBus eventBus;
+
+  private final Repository repository = new Repository("42", "git", "spaceships", "heart-of-gold");
+
+  private final String branchName = "feature/infinite_improbability_drive";
+  private final Branch branch = Branch.normalBranch(branchName, "42");
+
+  @Nested
+  class Creation {
+
+    @BeforeEach
+    void configureMocks() {
+      when(command.branch(any())).thenReturn(branch);
+    }
+
+    @Test
+    void shouldDelegateCreationToCommand() {
+      BranchCommandBuilder builder = new BranchCommandBuilder(repository, command, eventBus);
+      Branch returnedBranch = builder.branch(branchName);
+      assertThat(branch).isSameAs(returnedBranch);
+    }
+
+    @Test
+    void shouldSendBranchCreatedEvent() {
+      BranchCommandBuilder builder = new BranchCommandBuilder(repository, command, eventBus);
+      builder.branch(branchName);
+
+      ArgumentCaptor<BranchCreatedEvent> captor = ArgumentCaptor.forClass(BranchCreatedEvent.class);
+      verify(eventBus).post(captor.capture());
+      BranchCreatedEvent event = captor.getValue();
+      assertThat(event.getBranchName()).isEqualTo("feature/infinite_improbability_drive");
+    }
+
+    @Test
+    void shouldNotSendEventWithoutRepository() {
+      BranchCommandBuilder builder = new BranchCommandBuilder(null, command, eventBus);
+      builder.branch(branchName);
+
+      verify(eventBus, never()).post(any());
+    }
+
+  }
+
+  @Nested
+  class Deletion {
+
+    @Test
+    void shouldDelegateDeletionToCommand() {
+      BranchCommandBuilder builder = new BranchCommandBuilder(repository, command, eventBus);
+      builder.delete(branchName);
+      verify(command).deleteOrClose(branchName);
+    }
+  }
+
+}

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitBranchCommand.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitBranchCommand.java
@@ -30,7 +30,6 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Ref;
 import sonia.scm.event.ScmEventBus;
 import sonia.scm.repository.Branch;
-import sonia.scm.repository.BranchCreatedEvent;
 import sonia.scm.repository.GitUtil;
 import sonia.scm.repository.InternalRepositoryException;
 import sonia.scm.repository.PostReceiveRepositoryHookEvent;
@@ -48,9 +47,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singleton;
-import static java.util.Collections.singletonList;
+import static java.util.Collections.*;
 import static sonia.scm.ContextEntry.ContextBuilder.entity;
 
 public class GitBranchCommand extends AbstractGitCommand implements BranchCommand {
@@ -72,8 +69,6 @@ public class GitBranchCommand extends AbstractGitCommand implements BranchComman
       eventBus.post(new PreReceiveRepositoryHookEvent(hookEvent));
       Ref ref = git.branchCreate().setStartPoint(request.getParentBranch()).setName(request.getNewBranch()).call();
       eventBus.post(new PostReceiveRepositoryHookEvent(hookEvent));
-      // Clear cache synchronously to avoid branch not found in invalid cache
-      eventBus.post(new BranchCreatedEvent(repository, request.getNewBranch()));
       return Branch.normalBranch(request.getNewBranch(), GitUtil.getId(ref.getObjectId()));
     } catch (GitAPIException | IOException ex) {
       throw new InternalRepositoryException(repository, "could not create branch " + request.getNewBranch(), ex);

--- a/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/GitBranchCommandTest.java
+++ b/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/GitBranchCommandTest.java
@@ -104,7 +104,8 @@ public class GitBranchCommandTest extends AbstractGitCommandTestBase {
   @Test
   public void shouldThrowExceptionWhenDeletingDefaultBranch() {
     String branchToBeDeleted = "master";
-    assertThrows(CannotDeleteDefaultBranchException.class, () -> createCommand().deleteOrClose(branchToBeDeleted));
+    GitBranchCommand command = createCommand();
+    assertThrows(CannotDeleteDefaultBranchException.class, () -> command.deleteOrClose(branchToBeDeleted));
   }
 
   private GitBranchCommand createCommand() {
@@ -130,7 +131,6 @@ public class GitBranchCommandTest extends AbstractGitCommandTestBase {
     List<Object> events = captor.getAllValues();
     assertThat(events.get(0)).isInstanceOf(PreReceiveRepositoryHookEvent.class);
     assertThat(events.get(1)).isInstanceOf(PostReceiveRepositoryHookEvent.class);
-    assertThat(events.get(2)).isInstanceOf(BranchCreatedEvent.class);
 
     PreReceiveRepositoryHookEvent event = (PreReceiveRepositoryHookEvent) events.get(0);
     assertThat(event.getContext().getBranchProvider().getCreatedOrModified()).containsExactly("new_branch");


### PR DESCRIPTION
## Proposed changes

After merging this pr the repository caches are cleared synchronously, to avoid problems with workflows which are creating branches and fetching them right after creation.

The pr will also fix the missing BranchCreatedEvent for mercurial repositories.

### Your checklist for this pull request

- [X] PR is well described
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests
- [X] CHANGELOG.md updated

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
