### PR TITLE
Handling of branch with slashes in source view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Missing synchronization during repository creation ([#1328](https://github.com/scm-manager/scm-manager/pull/1328))
 - Missing BranchCreatedEvent for mercurial ([#1334](https://github.com/scm-manager/scm-manager/pull/1334))
 - Branch not found right after creation ([#1334](https://github.com/scm-manager/scm-manager/pull/1334))
+- Handling of branch with slashes in source view ([#1340](https://github.com/scm-manager/scm-manager/pull/1340))
 
 ## [2.5.0] - 2020-09-10
 ### Added

--- a/scm-ui/ui-webapp/src/repos/sources/components/FileTree.tsx
+++ b/scm-ui/ui-webapp/src/repos/sources/components/FileTree.tsx
@@ -109,7 +109,12 @@ class FileTree extends React.Component<Props, State> {
   }
 
   loadMore = () => {
-    this.props.fetchSources(this.props.repository, this.props.revision, this.props.path, this.props.hunks.length);
+    this.props.fetchSources(
+      this.props.repository,
+      decodeURIComponent(this.props.revision),
+      this.props.path,
+      this.props.hunks.length
+    );
   };
 
   renderTruncatedInfo = () => {


### PR DESCRIPTION
## Proposed changes

If data is to be loaded with offset in the sources view and the branch has a slash in the name, an error occurs.

### Your checklist for this pull request

- [x] PR is well described
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [x] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
