### PR TITLE
Make reading feed resilient

### DIFF
--- a/scm-webapp/src/main/java/sonia/scm/admin/ReleaseFeedParser.java
+++ b/scm-webapp/src/main/java/sonia/scm/admin/ReleaseFeedParser.java
@@ -29,25 +29,71 @@ import org.slf4j.LoggerFactory;
 import sonia.scm.net.ahc.AdvancedHttpClient;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
+@Singleton
 public class ReleaseFeedParser {
+
+  public static final int DEFAULT_TIMEOUT_IN_MILLIS = 1000;
 
   private static final Logger LOG = LoggerFactory.getLogger(ReleaseFeedParser.class);
 
   private final AdvancedHttpClient client;
+  private final ExecutorService executorService;
+  private final long timeoutInMillis;
+  private Future<Optional<ReleaseInfo>> releaseInfoFuture;
 
   @Inject
   public ReleaseFeedParser(AdvancedHttpClient client) {
+    this(client, DEFAULT_TIMEOUT_IN_MILLIS);
+  }
+
+  public ReleaseFeedParser(AdvancedHttpClient client, long timeoutInMillis) {
     this.client = client;
+    this.timeoutInMillis = timeoutInMillis;
+    this.executorService = Executors.newSingleThreadExecutor();
   }
 
   Optional<ReleaseInfo> findLatestRelease(String url) {
-    LOG.info("Search for newer versions of SCM-Manager");
-    Optional<ReleaseFeedDto.Release> latestRelease = parseLatestReleaseFromRssFeed(url);
-    return latestRelease.map(release -> new ReleaseInfo(release.getTitle(), release.getLink()));
+    Future<Optional<ReleaseInfo>> currentReleaseInfoFuture;
+    boolean releaseInfoFutureCreated = false;
+    try {
+      synchronized (this) {
+        currentReleaseInfoFuture = this.releaseInfoFuture;
+        if (currentReleaseInfoFuture == null) {
+          currentReleaseInfoFuture = submitRequest(url);
+          this.releaseInfoFuture = currentReleaseInfoFuture;
+          releaseInfoFutureCreated = true;
+        }
+      }
+      try {
+        return currentReleaseInfoFuture.get(timeoutInMillis, TimeUnit.MILLISECONDS);
+      } catch (Exception e) {
+        LOG.error("Could not read release feed", e);
+        return Optional.empty();
+      }
+    } finally {
+      if (releaseInfoFutureCreated) {
+        synchronized (this) {
+          this.releaseInfoFuture = null;
+        }
+      }
+    }
+  }
+
+  private Future<Optional<ReleaseInfo>> submitRequest(String url) {
+    return executorService.submit(() -> {
+      LOG.info("Search for newer versions of SCM-Manager");
+      Optional<ReleaseFeedDto.Release> latestRelease = parseLatestReleaseFromRssFeed(url);
+      return latestRelease.map(release -> new ReleaseInfo(release.getTitle(), release.getLink()));
+    });
   }
 
   private Optional<ReleaseFeedDto.Release> parseLatestReleaseFromRssFeed(String url) {
@@ -55,7 +101,7 @@ public class ReleaseFeedParser {
       ReleaseFeedDto releaseFeed = client.get(url).request().contentFromXml(ReleaseFeedDto.class);
       return filterForLatestRelease(releaseFeed);
     } catch (IOException e) {
-      LOG.error(String.format("Could not parse release feed from %s", url));
+      LOG.error("Could not parse release feed from {}", url, e);
       return Optional.empty();
     }
   }


### PR DESCRIPTION
## Proposed changes

This commit tackles the following issue:
When the release feed takes a long time to read (however), the former
solution would propagete requests to the SCM-Manager to multiple
requests of the specified feed url. This can, in the worst case, cause
a drain of resources like request threads.

We fix this with two actions:
1. We wrap the request itself in an executor with a timeout,
2. We only trigger one request at a time, so that we will not flood
   the feed server with requests.
