### PR TITLE
Align ActionBar items horizontal and enforce correct margin between them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+### Fixed
+- Align actionbar item horizontal and enforce correct margin between them ([#1358](https://github.com/scm-manager/scm-manager/pull/1358))
+
 ## [2.6.1] - 2020-09-30
 ### Fixed
 - Not found error when using browse command in empty hg repository ([#1355](https://github.com/scm-manager/scm-manager/pull/1355))

--- a/scm-ui/ui-components/src/Breadcrumb.tsx
+++ b/scm-ui/ui-components/src/Breadcrumb.tsx
@@ -48,9 +48,22 @@ const HomeIcon = styled(Icon)`
   line-height: 1.5rem;
 `;
 
-const ActionWrapper = styled.div`
+const ActionBar = styled.div`
   align-self: center;
-  padding-right: 1rem;
+  
+  /* order actionbar items horizontal */
+  display: flex;
+  justify-content: flex-start;
+ 
+  /* ensure space between action bar items */
+  & > * {
+    /* 
+     * We have to use important, because plugins could use field or control classes like the editor-plugin does.
+     * Those classes overwrite the margin which is ok, if the plugin is the only one which is using the actionbar.
+     * But it looks terrible if another plugin use the actionbar, which does not use field and control classes.
+     */
+    margin: 0 0.75rem 0 0 !important;
+  }
 `;
 
 class Breadcrumb extends React.Component<Props> {
@@ -102,7 +115,7 @@ class Breadcrumb extends React.Component<Props> {
             </ul>
           </FlexStartNav>
           {binder.hasExtension("repos.sources.actionbar") && (
-            <ActionWrapper>
+            <ActionBar>
               <ExtensionPoint
                 name="repos.sources.actionbar"
                 props={{
@@ -115,7 +128,7 @@ class Breadcrumb extends React.Component<Props> {
                 }}
                 renderAll={true}
               />
-            </ActionWrapper>
+            </ActionBar>
           )}
         </div>
         <hr className="is-marginless" />


### PR DESCRIPTION
## Proposed changes

If the editor plugin and the archive plugin are installed the action bar looks terrible.

![Screenshot 2020-10-01 at 15 13 13](https://user-images.githubusercontent.com/493333/94893596-dd9bbf80-0487-11eb-99d2-7bf3f7efcc35.png)

This patch will align all child elements of the action bar horizontal and enforces the correct margin between them.

### Your checklist for this pull request

- [X] PR is well described
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] CHANGELOG.md updated
- [X] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
