### PR TITLE
Remove unnecessary null check

### DIFF
--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/api/GitHookTagProvider.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/api/GitHookTagProvider.java
@@ -92,21 +92,19 @@ public class GitHookTagProvider implements HookTagProvider {
   }
 
   private Tag createTagFromNewId(RevWalk revWalk, ReceiveCommand rc, String tag) throws IOException {
-    final ObjectId newId = rc.getNewId();
+    ObjectId newId = rc.getNewId();
     return new Tag(tag, getId(unpeelTag(revWalk, newId)), GitUtil.getTagTime(revWalk, newId));
   }
 
   private Tag createTagFromOldId(RevWalk revWalk, ReceiveCommand rc, String tag) throws IOException {
-    final ObjectId oldId = rc.getOldId();
+    ObjectId oldId = rc.getOldId();
     return new Tag(tag, getId(unpeelTag(revWalk, oldId)), GitUtil.getTagTime(revWalk, oldId));
   }
 
   public ObjectId unpeelTag(RevWalk revWalk, ObjectId oldId) throws IOException {
-    final RevObject revObject = revWalk.parseAny(oldId);
+    RevObject revObject = revWalk.parseAny(oldId);
     if (revObject instanceof RevTag) {
       return unpeelTag(revWalk, ((RevTag) revObject).getObject());
-    } else if (revObject == null) {
-      return oldId;
     } else {
       return revObject;
     }


### PR DESCRIPTION
## Proposed changes

The function RevWalk#parseAny indeed never returns null. This check only was there to satisfy the (therefore wrong) unit test.

This fixes a sonar bug.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
