### PR TITLE
add null check on parsing svn properties in browsecommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Null Pointer Exception on anonymous migration with deleted repositories ([#1371](https://github.com/scm-manager/scm-manager/pull/1371))
+- Null Pointer Exception on parsing SVN properties ([#1373](https://github.com/scm-manager/scm-manager/pull/1373))
 
 ## [2.7.0] - 2020-10-12
 ### Added

--- a/scm-plugins/scm-svn-plugin/src/main/java/sonia/scm/repository/spi/SvnBrowseCommand.java
+++ b/scm-plugins/scm-svn-plugin/src/main/java/sonia/scm/repository/spi/SvnBrowseCommand.java
@@ -193,23 +193,28 @@ public class SvnBrowseCommand extends AbstractSvnCommand
 
       repository.getDir(entry.getRelativePath(), revision, properties, (Collection) null);
 
-      String[] externals = properties.getStringValue(SVNProperty.EXTERNALS).split("\\r?\\n");
-      for (String external : externals) {
-        String subRepoUrl = "";
-        String subRepoPath = "";
-        for (String externalPart : external.split(" ")) {
-          if (shouldSetExternal(externalPart)) {
-            subRepoUrl = externalPart;
-          } else if (!externalPart.contains("-r")) {
-            subRepoPath = externalPart;
+      String externals = properties.getStringValue(SVNProperty.EXTERNALS);
+
+      if (!Strings.isNullOrEmpty(externals)) {
+        String[] splitExternals = externals.split("\\r?\\n");
+        for (String external : splitExternals) {
+          String subRepoUrl = "";
+          String subRepoPath = "";
+          for (String externalPart : external.split(" ")) {
+            if (shouldSetExternal(externalPart)) {
+              subRepoUrl = externalPart;
+            } else if (!externalPart.contains("-r")) {
+              subRepoPath = externalPart;
+            }
+          }
+
+          if (Util.isNotEmpty(external)) {
+            SubRepository subRepository = new SubRepository(subRepoUrl);
+            fileObject.addChild(createSubRepoDirectory(subRepository, subRepoPath));
           }
         }
-
-        if (Util.isNotEmpty(external)) {
-          SubRepository subRepository = new SubRepository(subRepoUrl);
-          fileObject.addChild(createSubRepoDirectory(subRepository, subRepoPath));
-        }
       }
+
     } catch (SVNException ex) {
       logger.error("could not fetch file properties", ex);
     }

--- a/scm-plugins/scm-svn-plugin/src/test/java/sonia/scm/repository/spi/AbstractSvnCommandTestBase.java
+++ b/scm-plugins/scm-svn-plugin/src/test/java/sonia/scm/repository/spi/AbstractSvnCommandTestBase.java
@@ -21,14 +21,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.repository.spi;
 
 //~--- non-JDK imports --------------------------------------------------------
 
 import org.junit.After;
-
-//~--- JDK imports ------------------------------------------------------------
 
 import java.io.IOException;
 


### PR DESCRIPTION
## Proposed changes

Fix null pointer on parsing svn properties in browse command.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] CHANGELOG.md updated

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
