### PR TITLE
Fix missing default permission for managing public gpg keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Generation of email addresses for users, where none is configured ([#1370](https://github.com/scm-manager/scm-manager/pull/1370))
 
+### Fixed
+- Missing default permission to manage public gpg keys ([#1377](https://github.com/scm-manager/scm-manager/pull/1377))
+
 ## [2.7.1] - 2020-10-14
 ### Fixed
 - Null Pointer Exception on anonymous migration with deleted repositories ([#1371](https://github.com/scm-manager/scm-manager/pull/1371))

--- a/scm-webapp/src/main/java/sonia/scm/security/DefaultAuthorizationCollector.java
+++ b/scm-webapp/src/main/java/sonia/scm/security/DefaultAuthorizationCollector.java
@@ -251,6 +251,7 @@ public class DefaultAuthorizationCollector implements AuthorizationCollector
       builder.add(getGroupAutocompletePermission());
       builder.add(getChangeOwnPasswordPermission(user));
       builder.add(getApiKeyPermission(user));
+      builder.add(getPublicKeyPermission(user));
     }
 
     SimpleAuthorizationInfo info = new SimpleAuthorizationInfo(ImmutableSet.of(Role.USER));
@@ -265,6 +266,10 @@ public class DefaultAuthorizationCollector implements AuthorizationCollector
 
   private String getChangeOwnPasswordPermission(User user) {
     return UserPermissions.changePassword(user).asShiroString();
+  }
+
+  private String getPublicKeyPermission(User user) {
+    return UserPermissions.changePublicKeys(user).asShiroString();
   }
 
   private String getApiKeyPermission(User user) {

--- a/scm-webapp/src/test/java/sonia/scm/security/DefaultAuthorizationCollectorTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/security/DefaultAuthorizationCollectorTest.java
@@ -167,8 +167,8 @@ public class DefaultAuthorizationCollectorTest {
 
     AuthorizationInfo authInfo = collector.collect();
     assertThat(authInfo.getRoles(), Matchers.contains(Role.USER));
-    assertThat(authInfo.getStringPermissions(), hasSize(5));
-    assertThat(authInfo.getStringPermissions(), containsInAnyOrder("user:autocomplete", "group:autocomplete", "user:changePassword:trillian", "user:read:trillian", "user:changeApiKeys:trillian"));
+    assertThat(authInfo.getStringPermissions(), hasSize(6));
+    assertThat(authInfo.getStringPermissions(), containsInAnyOrder("user:autocomplete", "group:autocomplete", "user:changePassword:trillian", "user:read:trillian", "user:changeApiKeys:trillian", "user:changePublicKeys:trillian"));
     assertThat(authInfo.getObjectPermissions(), nullValue());
   }
 
@@ -212,7 +212,7 @@ public class DefaultAuthorizationCollectorTest {
     AuthorizationInfo authInfo = collector.collect();
     assertThat(authInfo.getRoles(), Matchers.containsInAnyOrder(Role.USER));
     assertThat(authInfo.getObjectPermissions(), nullValue());
-    assertThat(authInfo.getStringPermissions(), containsInAnyOrder("user:autocomplete", "group:autocomplete", "user:changePassword:trillian", "repository:read,pull:one", "repository:read,pull,push:two", "user:read:trillian", "user:changeApiKeys:trillian"));
+    assertThat(authInfo.getStringPermissions(), containsInAnyOrder("user:autocomplete", "group:autocomplete", "user:changePassword:trillian", "repository:read,pull:one", "repository:read,pull,push:two", "user:read:trillian", "user:changeApiKeys:trillian", "user:changePublicKeys:trillian"));
   }
 
   /**
@@ -244,7 +244,7 @@ public class DefaultAuthorizationCollectorTest {
     AuthorizationInfo authInfo = collector.collect();
     assertThat(authInfo.getRoles(), Matchers.containsInAnyOrder(Role.USER));
     assertThat(authInfo.getObjectPermissions(), nullValue());
-    assertThat(authInfo.getStringPermissions(), containsInAnyOrder("user:autocomplete", "group:autocomplete", "user:changePassword:trillian", "repository:read,pull:one", "repository:read,pull,push:two", "user:read:trillian", "user:changeApiKeys:trillian"));
+    assertThat(authInfo.getStringPermissions(), containsInAnyOrder("user:autocomplete", "group:autocomplete", "user:changePassword:trillian", "repository:read,pull:one", "repository:read,pull,push:two", "user:read:trillian", "user:changeApiKeys:trillian", "user:changePublicKeys:trillian"));
   }
 
   /**
@@ -288,7 +288,9 @@ public class DefaultAuthorizationCollectorTest {
       "repository:system:one",
       "repository:group:two",
       "user:read:trillian",
-      "user:changeApiKeys:trillian"));
+      "user:changeApiKeys:trillian",
+      "user:changePublicKeys:trillian"
+    ));
   }
 
   /**
@@ -335,7 +337,7 @@ public class DefaultAuthorizationCollectorTest {
     AuthorizationInfo authInfo = collector.collect();
     assertThat(authInfo.getRoles(), Matchers.containsInAnyOrder(Role.USER));
     assertThat(authInfo.getObjectPermissions(), nullValue());
-    assertThat(authInfo.getStringPermissions(), containsInAnyOrder("one:one", "two:two", "user:read:trillian", "user:autocomplete", "group:autocomplete", "user:changePassword:trillian", "user:changeApiKeys:trillian"));
+    assertThat(authInfo.getStringPermissions(), containsInAnyOrder("one:one", "two:two", "user:read:trillian", "user:autocomplete", "group:autocomplete", "user:changePassword:trillian", "user:changeApiKeys:trillian", "user:changePublicKeys:trillian"));
   }
 
   private void authenticate(User user, String group, String... groups) {


### PR DESCRIPTION
## Proposed changes

Fixes missing default permission to manage public keys. This leads to errors on commits via the editor or review plugin without admin permissions.

### Your checklist for this pull request

- [X] PR is well described
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests
- [X] CHANGELOG.md updated
- [X] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
