### PR TITLE
Fix handling of snapshot plugin dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Centralise syntax highlighting ([#1382](https://github.com/scm-manager/scm-manager/pull/1382))
 
+### Fixed
+- Handling of snapshot plugin dependencies ([#1384](https://github.com/scm-manager/scm-manager/pull/1384))
+
 ## [2.6.3] - 2020-10-16
 ### Fixed
 - Missing default permission to manage public gpg keys ([#1377](https://github.com/scm-manager/scm-manager/pull/1377))

--- a/scm-core/src/main/java/sonia/scm/version/Version.java
+++ b/scm-core/src/main/java/sonia/scm/version/Version.java
@@ -31,6 +31,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ComparisonChain;
 
 import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 //~--- JDK imports ------------------------------------------------------------
 
@@ -42,6 +44,8 @@ import java.util.Locale;
  */
 public final class Version implements Comparable<Version>
 {
+
+  private static final Pattern MAVEN_UNIQUE_SNAPSHOT = Pattern.compile("-[0-9]{8}\\.[0-9]{6}-[0-9]+");
 
   /**
    * Constructs a new version object
@@ -388,10 +392,15 @@ public final class Version implements Comparable<Version>
   {
     String qualifier = qualifierPart.trim().toLowerCase(Locale.ENGLISH);
 
-    if (qualifier.contains("snapshot"))
-    {
+    if (qualifier.contains("snapshot")) {
       snapshot = true;
       qualifier = qualifier.replace("snapshot", "");
+    } else {
+      Matcher matcher = MAVEN_UNIQUE_SNAPSHOT.matcher(qualifier);
+      if (matcher.matches()) {
+        snapshot = true;
+        qualifier = matcher.replaceAll("-");
+      }
     }
 
     if (qualifier.length() > 0)

--- a/scm-core/src/test/java/sonia/scm/version/VersionTest.java
+++ b/scm-core/src/test/java/sonia/scm/version/VersionTest.java
@@ -145,4 +145,11 @@ class VersionTest {
   void testUnparseable() {
     assertThrows(VersionParseException.class, () -> Version.parse("aaaa"));
   }
+
+  @Test
+  void shouldDetectUniqueMavenSnapshotVersion() {
+    Version version = Version.parse("1.0.0-20201022.094711-15");
+    assertThat(version.isSnapshot()).isTrue();
+    assertThat(version).hasToString("1.0.0-SNAPSHOT");
+  }
 }

--- a/scm-webapp/src/test/java/sonia/scm/plugin/PluginInstallationVerifierTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/plugin/PluginInstallationVerifierTest.java
@@ -146,6 +146,17 @@ class PluginInstallationVerifierTest {
 
   @Test
   @SuppressWarnings("squid:S2699") // we are happy if no exception is thrown
+  void shouldVerifyPluginWithSnapshotDependencies() {
+    matchConditions();
+
+    PluginInstallationContext context = mockInstallationOf(IID_PLUGIN, "1.0.0-SNAPSHOT");
+    mockDependingOf(IID_PLUGIN, "1.0.0-20201022.094711-15");
+
+    PluginInstallationVerifier.verify(context, descriptor);
+  }
+
+  @Test
+  @SuppressWarnings("squid:S2699") // we are happy if no exception is thrown
   void shouldVerifyPluginWithOptionalDependency() {
     matchConditions();
 


### PR DESCRIPTION
## Proposed changes

This pr will fix handling of plugins which are depending on snapshot versions of other plugins. The problem is that maven creates a unique snapshot version e.g.: `1.0.0-20201022.094711-15`, which is not matched the version in the dependency `1.0.0-SNAPSHOT`.

### Your checklist for this pull request

- [X] PR is well described
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests
- [X] CHANGELOG.md updated
- [X] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
