### PR TITLE
Reduce logging of ApiTokenRealm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Source code fullscreen view ([#1376](https://github.com/scm-manager/scm-manager/pull/1376))
 
 ### Changed
+- Reduce logging of ApiTokenRealm ([#1385](https://github.com/scm-manager/scm-manager/pull/1385))
 - Centralise syntax highlighting ([#1382](https://github.com/scm-manager/scm-manager/pull/1382))
 
 ## [2.6.3] - 2020-10-16

--- a/scm-webapp/src/main/java/sonia/scm/security/ApiKeyRealm.java
+++ b/scm-webapp/src/main/java/sonia/scm/security/ApiKeyRealm.java
@@ -24,6 +24,7 @@
 
 package sonia.scm.security;
 
+import com.google.common.io.BaseEncoding;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.authc.UsernamePasswordToken;
@@ -61,13 +62,14 @@ public class ApiKeyRealm extends AuthenticatingRealm {
   }
 
   @Override
+  @SuppressWarnings("java:S4738") // java.util.Base64 has no canDecode method
   public boolean supports(AuthenticationToken token) {
     if (token instanceof UsernamePasswordToken || token instanceof BearerToken) {
-      boolean containsDot = getPassword(token).contains(".");
-      if (containsDot) {
-        LOG.debug("Ignoring token with at least one dot ('.'); this is probably a JWT token");
+      boolean isBase64 = BaseEncoding.base64().canDecode(getPassword(token));
+      if (!isBase64) {
+        LOG.debug("Ignoring non base 64 token; this is probably a JWT token or a normal password");
       }
-      return !containsDot;
+      return isBase64;
     }
     return false;
   }

--- a/scm-webapp/src/main/java/sonia/scm/security/ApiKeyTokenHandler.java
+++ b/scm-webapp/src/main/java/sonia/scm/security/ApiKeyTokenHandler.java
@@ -62,7 +62,10 @@ class ApiKeyTokenHandler {
     try {
       return of(OBJECT_MAPPER.readValue(decoder.decode(token), Token.class));
     } catch (IOException e) {
-      LOG.debug("failed to read api token, perhaps it is a jwt token or a normal password", e);
+      LOG.debug("failed to read api token, perhaps it is a jwt token or a normal password");
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("failed to parse token", e);
+      }
       return empty();
     }
   }

--- a/scm-webapp/src/main/java/sonia/scm/security/ApiKeyTokenHandler.java
+++ b/scm-webapp/src/main/java/sonia/scm/security/ApiKeyTokenHandler.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.io.Decoder;
 import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.io.DecodingException;
 import io.jsonwebtoken.io.Encoder;
 import io.jsonwebtoken.io.Encoders;
 import lombok.AllArgsConstructor;
@@ -61,7 +62,7 @@ class ApiKeyTokenHandler {
   Optional<Token> readToken(String token) {
     try {
       return of(OBJECT_MAPPER.readValue(decoder.decode(token), Token.class));
-    } catch (IOException e) {
+    } catch (IOException | DecodingException e) {
       LOG.debug("failed to read api token, perhaps it is a jwt token or a normal password");
       if (LOG.isTraceEnabled()) {
         LOG.trace("failed to parse token", e);

--- a/scm-webapp/src/main/java/sonia/scm/security/ApiKeyTokenHandler.java
+++ b/scm-webapp/src/main/java/sonia/scm/security/ApiKeyTokenHandler.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.io.Decoder;
 import io.jsonwebtoken.io.Decoders;
-import io.jsonwebtoken.io.DecodingException;
 import io.jsonwebtoken.io.Encoder;
 import io.jsonwebtoken.io.Encoders;
 import lombok.AllArgsConstructor;
@@ -62,8 +61,8 @@ class ApiKeyTokenHandler {
   Optional<Token> readToken(String token) {
     try {
       return of(OBJECT_MAPPER.readValue(decoder.decode(token), Token.class));
-    } catch (IOException | DecodingException e) {
-      LOG.warn("error reading api token", e);
+    } catch (IOException e) {
+      LOG.debug("failed to read api token, perhaps it is a jwt token or a normal password", e);
       return empty();
     }
   }

--- a/scm-webapp/src/test/java/sonia/scm/security/ApiKeyRealmTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/security/ApiKeyRealmTest.java
@@ -25,6 +25,7 @@
 package sonia.scm.security;
 
 import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.UsernamePasswordToken;
 import org.apache.shiro.authz.AuthorizationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -99,6 +100,15 @@ class ApiKeyRealmTest {
   @Test
   void shouldIgnoreTokensWithDots() {
     BearerToken token = valueOf("this.is.no.api.token");
+
+    boolean supports = realm.supports(token);
+
+    assertThat(supports).isFalse();
+  }
+
+  @Test
+  void shouldIgnoreNonBase64Tokens() {
+    UsernamePasswordToken token = new UsernamePasswordToken("trillian", "My&SecretPassword");
 
     boolean supports = realm.supports(token);
 


### PR DESCRIPTION
## Proposed changes

This pr will reduce the logging of the ApiTokenRealm. The ApiTokenRealm currently floods the log with stacktraces like the following for every normal authentication with username and password.

```text
2020-10-22 13:59:12.105 [qtp1685232414-146] [          ] WARN  sonia.scm.security.ApiKeyTokenHandler - error reading api token
com.fasterxml.jackson.core.JsonParseException: Unexpected character ('±' (code 177)): expected a valid value (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
 at [Source: (byte[])"�ɚvh�"; line: 1, column: 2]
	at com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:1851)
	at com.fasterxml.jackson.core.base.ParserMinimalBase._reportError(ParserMinimalBase.java:707)
	at com.fasterxml.jackson.core.base.ParserMinimalBase._reportUnexpectedChar(ParserMinimalBase.java:632)
```

The change will skip the parsing of username and password tokens, if the token contains non base64 chars. 
It will set the logging for the token parsing to debug.
The stacktrace is only logged if trace logging is enabled.

### Your checklist for this pull request

- [X] PR is well described
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests
- [X] CHANGELOG.md updated
- [X] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
