### PR TITLE
Fix syntax highlighting for go files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Handling of snapshot plugin dependencies ([#1384](https://github.com/scm-manager/scm-manager/pull/1384))
+- SyntaxHighlighting for GoLang ([#1386](https://github.com/scm-manager/scm-manager/pull/1386))
 
 ## [2.6.3] - 2020-10-16
 ### Fixed

--- a/scm-ui/ui-components/src/SyntaxHighlighter.tsx
+++ b/scm-ui/ui-components/src/SyntaxHighlighter.tsx
@@ -24,6 +24,7 @@
 import React from "react";
 
 import { PrismAsyncLight as ReactSyntaxHighlighter } from "react-syntax-highlighter";
+import { defaultLanguage, determineLanguage } from "./languages";
 // eslint-disable-next-line no-restricted-imports
 import highlightingTheme from "./syntax-highlighting";
 
@@ -33,27 +34,20 @@ type Props = {
   showLineNumbers?: boolean;
 };
 
-const defaultLanguage = "text";
-
 class SyntaxHighlighter extends React.Component<Props> {
   static defaultProps: Partial<Props> = {
     language: defaultLanguage,
     showLineNumbers: true
   };
 
-  getLanguage = () => {
-    const { language } = this.props;
-    if (language) {
-      return language;
-    }
-    return defaultLanguage;
-  };
-
   render() {
-    const { showLineNumbers } = this.props;
-    const language = this.getLanguage();
+    const { showLineNumbers, language } = this.props;
     return (
-      <ReactSyntaxHighlighter showLineNumbers={showLineNumbers} language={language} style={highlightingTheme}>
+      <ReactSyntaxHighlighter
+        showLineNumbers={showLineNumbers}
+        language={determineLanguage(language)}
+        style={highlightingTheme}
+      >
         {this.props.value}
       </ReactSyntaxHighlighter>
     );

--- a/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
+++ b/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
@@ -39,6 +39,7 @@ exports[`Storyshots Annotate Default 1`] = `
       }
     >
       <code
+        className="language-go"
         style={
           Object {
             "MozHyphens": "none",
@@ -591,6 +592,7 @@ exports[`Storyshots Annotate With Avatars 1`] = `
       }
     >
       <code
+        className="language-go"
         style={
           Object {
             "MozHyphens": "none",
@@ -46772,6 +46774,7 @@ exports[`Storyshots MarkdownView Code without Lang 1`] = `
         }
       >
         <code
+          className="language-text"
           style={
             Object {
               "MozHyphens": "none",
@@ -46794,39 +46797,21 @@ exports[`Storyshots MarkdownView Code without Lang 1`] = `
             }
           }
         >
-          <code
+          <span
+            className="linenumber react-syntax-highlighter-line-number"
             style={
               Object {
-                "MozHyphens": "none",
-                "MozTabSize": "4",
-                "OTabSize": "4",
-                "WebkitHyphens": "none",
-                "color": "#363636",
-                "direction": "ltr",
-                "float": "left",
-                "fontFamily": "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
-                "fontSize": "13px",
-                "hyphens": "none",
-                "lineHeight": "1.5",
-                "msHyphens": "none",
-                "paddingRight": "10px",
-                "tabSize": "4",
-                "textAlign": "left",
-                "textShadow": "none",
-                "whiteSpace": "pre",
-                "wordBreak": "normal",
-                "wordSpacing": "normal",
+                "color": "#9a9a9a",
+                "display": "inline-block",
+                "minWidth": "1em",
+                "paddingRight": "1em",
+                "textAlign": "right",
+                "userSelect": "none",
               }
             }
           >
-            <span
-              className="react-syntax-highlighter-line-number"
-              style={Object {}}
-            >
-              1
-
-            </span>
-          </code>
+            1
+          </span>
           <span
             style={Object {}}
           >
@@ -47695,6 +47680,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
           </span>
         </code>
         <code
+          className="language-go"
           style={
             Object {
               "MozHyphens": "none",
@@ -48004,6 +47990,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
         }
       >
         <code
+          className="language-xml"
           style={
             Object {
               "MozHyphens": "none",
@@ -48026,195 +48013,23 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             }
           }
         >
-          <code
+          <span
+            className="linenumber react-syntax-highlighter-line-number"
             style={
               Object {
-                "MozHyphens": "none",
-                "MozTabSize": "4",
-                "OTabSize": "4",
-                "WebkitHyphens": "none",
-                "color": "#363636",
-                "direction": "ltr",
-                "float": "left",
-                "fontFamily": "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
-                "fontSize": "13px",
-                "hyphens": "none",
-                "lineHeight": "1.5",
-                "msHyphens": "none",
-                "paddingRight": "10px",
-                "tabSize": "4",
-                "textAlign": "left",
-                "textShadow": "none",
-                "whiteSpace": "pre",
-                "wordBreak": "normal",
-                "wordSpacing": "normal",
+                "color": "#9a9a9a",
+                "display": "inline-block",
+                "minWidth": "2em",
+                "paddingRight": "1em",
+                "textAlign": "right",
+                "userSelect": "none",
               }
             }
           >
-            <span
-              className="react-syntax-highlighter-line-number"
-              style={Object {}}
-            >
-              1
-
-            </span>
-            <span
-              className="react-syntax-highlighter-line-number"
-              style={Object {}}
-            >
-              2
-
-            </span>
-            <span
-              className="react-syntax-highlighter-line-number"
-              style={Object {}}
-            >
-              3
-
-            </span>
-            <span
-              className="react-syntax-highlighter-line-number"
-              style={Object {}}
-            >
-              4
-
-            </span>
-            <span
-              className="react-syntax-highlighter-line-number"
-              style={Object {}}
-            >
-              5
-
-            </span>
-            <span
-              className="react-syntax-highlighter-line-number"
-              style={Object {}}
-            >
-              6
-
-            </span>
-            <span
-              className="react-syntax-highlighter-line-number"
-              style={Object {}}
-            >
-              7
-
-            </span>
-            <span
-              className="react-syntax-highlighter-line-number"
-              style={Object {}}
-            >
-              8
-
-            </span>
-            <span
-              className="react-syntax-highlighter-line-number"
-              style={Object {}}
-            >
-              9
-
-            </span>
-            <span
-              className="react-syntax-highlighter-line-number"
-              style={Object {}}
-            >
-              10
-
-            </span>
-            <span
-              className="react-syntax-highlighter-line-number"
-              style={Object {}}
-            >
-              11
-
-            </span>
-            <span
-              className="react-syntax-highlighter-line-number"
-              style={Object {}}
-            >
-              12
-
-            </span>
-            <span
-              className="react-syntax-highlighter-line-number"
-              style={Object {}}
-            >
-              13
-
-            </span>
-            <span
-              className="react-syntax-highlighter-line-number"
-              style={Object {}}
-            >
-              14
-
-            </span>
-            <span
-              className="react-syntax-highlighter-line-number"
-              style={Object {}}
-            >
-              15
-
-            </span>
-            <span
-              className="react-syntax-highlighter-line-number"
-              style={Object {}}
-            >
-              16
-
-            </span>
-            <span
-              className="react-syntax-highlighter-line-number"
-              style={Object {}}
-            >
-              17
-
-            </span>
-            <span
-              className="react-syntax-highlighter-line-number"
-              style={Object {}}
-            >
-              18
-
-            </span>
-            <span
-              className="react-syntax-highlighter-line-number"
-              style={Object {}}
-            >
-              19
-
-            </span>
-            <span
-              className="react-syntax-highlighter-line-number"
-              style={Object {}}
-            >
-              20
-
-            </span>
-            <span
-              className="react-syntax-highlighter-line-number"
-              style={Object {}}
-            >
-              21
-
-            </span>
-            <span
-              className="react-syntax-highlighter-line-number"
-              style={Object {}}
-            >
-              22
-
-            </span>
-            <span
-              className="react-syntax-highlighter-line-number"
-              style={Object {}}
-            >
-              23
-
-            </span>
-          </code>
+            1
+          </span>
           <span
-            className="token token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48224,7 +48039,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48244,7 +48059,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
              
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#005f9a",
@@ -48254,7 +48069,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             [...]
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48269,19 +48084,79 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             
 
           </span>
+          <span
+            className="linenumber react-syntax-highlighter-line-number"
+            style={
+              Object {
+                "color": "#9a9a9a",
+                "display": "inline-block",
+                "minWidth": "2em",
+                "paddingRight": "1em",
+                "textAlign": "right",
+                "userSelect": "none",
+              }
+            }
+          >
+            2
+          </span>
           
 
+          <span
+            className="linenumber react-syntax-highlighter-line-number"
+            style={
+              Object {
+                "color": "#9a9a9a",
+                "display": "inline-block",
+                "minWidth": "2em",
+                "paddingRight": "1em",
+                "textAlign": "right",
+                "userSelect": "none",
+              }
+            }
+          >
+            3
+          </span>
             [...]
 
+          <span
+            className="linenumber react-syntax-highlighter-line-number"
+            style={
+              Object {
+                "color": "#9a9a9a",
+                "display": "inline-block",
+                "minWidth": "2em",
+                "paddingRight": "1em",
+                "textAlign": "right",
+                "userSelect": "none",
+              }
+            }
+          >
+            4
+          </span>
           
 
+          <span
+            className="linenumber react-syntax-highlighter-line-number"
+            style={
+              Object {
+                "color": "#9a9a9a",
+                "display": "inline-block",
+                "minWidth": "2em",
+                "paddingRight": "1em",
+                "textAlign": "right",
+                "userSelect": "none",
+              }
+            }
+          >
+            5
+          </span>
           <span
             style={Object {}}
           >
               
           </span>
           <span
-            className="token token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48291,7 +48166,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48301,7 +48176,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             build
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48317,12 +48192,27 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
 
           </span>
           <span
+            className="linenumber react-syntax-highlighter-line-number"
+            style={
+              Object {
+                "color": "#9a9a9a",
+                "display": "inline-block",
+                "minWidth": "2em",
+                "paddingRight": "1em",
+                "textAlign": "right",
+                "userSelect": "none",
+              }
+            }
+          >
+            6
+          </span>
+          <span
             style={Object {}}
           >
                 
           </span>
           <span
-            className="token token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48332,7 +48222,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48342,7 +48232,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             plugins
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48357,19 +48247,79 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             
 
           </span>
+          <span
+            className="linenumber react-syntax-highlighter-line-number"
+            style={
+              Object {
+                "color": "#9a9a9a",
+                "display": "inline-block",
+                "minWidth": "2em",
+                "paddingRight": "1em",
+                "textAlign": "right",
+                "userSelect": "none",
+              }
+            }
+          >
+            7
+          </span>
           
 
+          <span
+            className="linenumber react-syntax-highlighter-line-number"
+            style={
+              Object {
+                "color": "#9a9a9a",
+                "display": "inline-block",
+                "minWidth": "2em",
+                "paddingRight": "1em",
+                "textAlign": "right",
+                "userSelect": "none",
+              }
+            }
+          >
+            8
+          </span>
                 [...]
 
+          <span
+            className="linenumber react-syntax-highlighter-line-number"
+            style={
+              Object {
+                "color": "#9a9a9a",
+                "display": "inline-block",
+                "minWidth": "2em",
+                "paddingRight": "1em",
+                "textAlign": "right",
+                "userSelect": "none",
+              }
+            }
+          >
+            9
+          </span>
           
 
+          <span
+            className="linenumber react-syntax-highlighter-line-number"
+            style={
+              Object {
+                "color": "#9a9a9a",
+                "display": "inline-block",
+                "minWidth": "2em",
+                "paddingRight": "1em",
+                "textAlign": "right",
+                "userSelect": "none",
+              }
+            }
+          >
+            10
+          </span>
           <span
             style={Object {}}
           >
                   
           </span>
           <span
-            className="token token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48379,7 +48329,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48389,7 +48339,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             plugin
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48405,12 +48355,27 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
 
           </span>
           <span
+            className="linenumber react-syntax-highlighter-line-number"
+            style={
+              Object {
+                "color": "#9a9a9a",
+                "display": "inline-block",
+                "minWidth": "2em",
+                "paddingRight": "1em",
+                "textAlign": "right",
+                "userSelect": "none",
+              }
+            }
+          >
+            11
+          </span>
+          <span
             style={Object {}}
           >
                     
           </span>
           <span
-            className="token token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48420,7 +48385,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48430,7 +48395,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             groupId
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48445,7 +48410,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             org.apache.maven.plugins
           </span>
           <span
-            className="token token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48455,7 +48420,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;/
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48465,7 +48430,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             groupId
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48481,12 +48446,27 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
 
           </span>
           <span
+            className="linenumber react-syntax-highlighter-line-number"
+            style={
+              Object {
+                "color": "#9a9a9a",
+                "display": "inline-block",
+                "minWidth": "2em",
+                "paddingRight": "1em",
+                "textAlign": "right",
+                "userSelect": "none",
+              }
+            }
+          >
+            12
+          </span>
+          <span
             style={Object {}}
           >
                     
           </span>
           <span
-            className="token token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48496,7 +48476,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48506,7 +48486,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             artifactId
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48521,7 +48501,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             maven-enforcer-plugin
           </span>
           <span
-            className="token token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48531,7 +48511,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;/
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48541,7 +48521,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             artifactId
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48557,12 +48537,27 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
 
           </span>
           <span
+            className="linenumber react-syntax-highlighter-line-number"
+            style={
+              Object {
+                "color": "#9a9a9a",
+                "display": "inline-block",
+                "minWidth": "2em",
+                "paddingRight": "1em",
+                "textAlign": "right",
+                "userSelect": "none",
+              }
+            }
+          >
+            13
+          </span>
+          <span
             style={Object {}}
           >
                   
           </span>
           <span
-            className="token token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48572,7 +48567,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;/
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48582,7 +48577,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             plugin
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48596,6 +48591,21 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
           >
             
 
+          </span>
+          <span
+            className="linenumber react-syntax-highlighter-line-number"
+            style={
+              Object {
+                "color": "#9a9a9a",
+                "display": "inline-block",
+                "minWidth": "2em",
+                "paddingRight": "1em",
+                "textAlign": "right",
+                "userSelect": "none",
+              }
+            }
+          >
+            14
           </span>
           <span
             style={Object {}}
@@ -48603,7 +48613,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
                   
           </span>
           <span
-            className="token token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48613,7 +48623,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48623,7 +48633,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             plugin
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48639,12 +48649,27 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
 
           </span>
           <span
+            className="linenumber react-syntax-highlighter-line-number"
+            style={
+              Object {
+                "color": "#9a9a9a",
+                "display": "inline-block",
+                "minWidth": "2em",
+                "paddingRight": "1em",
+                "textAlign": "right",
+                "userSelect": "none",
+              }
+            }
+          >
+            15
+          </span>
+          <span
             style={Object {}}
           >
                     
           </span>
           <span
-            className="token token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48654,7 +48679,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48664,7 +48689,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             groupId
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48679,7 +48704,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             org.codehaus.mojo
           </span>
           <span
-            className="token token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48689,7 +48714,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;/
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48699,7 +48724,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             groupId
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48715,12 +48740,27 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
 
           </span>
           <span
+            className="linenumber react-syntax-highlighter-line-number"
+            style={
+              Object {
+                "color": "#9a9a9a",
+                "display": "inline-block",
+                "minWidth": "2em",
+                "paddingRight": "1em",
+                "textAlign": "right",
+                "userSelect": "none",
+              }
+            }
+          >
+            16
+          </span>
+          <span
             style={Object {}}
           >
                     
           </span>
           <span
-            className="token token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48730,7 +48770,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48740,7 +48780,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             artifactId
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48755,7 +48795,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             animal-sniffer-maven-plugin
           </span>
           <span
-            className="token token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48765,7 +48805,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;/
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48775,7 +48815,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             artifactId
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48791,12 +48831,27 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
 
           </span>
           <span
+            className="linenumber react-syntax-highlighter-line-number"
+            style={
+              Object {
+                "color": "#9a9a9a",
+                "display": "inline-block",
+                "minWidth": "2em",
+                "paddingRight": "1em",
+                "textAlign": "right",
+                "userSelect": "none",
+              }
+            }
+          >
+            17
+          </span>
+          <span
             style={Object {}}
           >
                   
           </span>
           <span
-            className="token token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48806,7 +48861,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;/
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48816,7 +48871,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             plugin
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48832,12 +48887,27 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
 
           </span>
           <span
+            className="linenumber react-syntax-highlighter-line-number"
+            style={
+              Object {
+                "color": "#9a9a9a",
+                "display": "inline-block",
+                "minWidth": "2em",
+                "paddingRight": "1em",
+                "textAlign": "right",
+                "userSelect": "none",
+              }
+            }
+          >
+            18
+          </span>
+          <span
             style={Object {}}
           >
                 
           </span>
           <span
-            className="token token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48847,7 +48917,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;/
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48857,7 +48927,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             plugins
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48873,12 +48943,27 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
 
           </span>
           <span
+            className="linenumber react-syntax-highlighter-line-number"
+            style={
+              Object {
+                "color": "#9a9a9a",
+                "display": "inline-block",
+                "minWidth": "2em",
+                "paddingRight": "1em",
+                "textAlign": "right",
+                "userSelect": "none",
+              }
+            }
+          >
+            19
+          </span>
+          <span
             style={Object {}}
           >
               
           </span>
           <span
-            className="token token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48888,7 +48973,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;/
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48898,7 +48983,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             build
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48913,19 +48998,79 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             
 
           </span>
+          <span
+            className="linenumber react-syntax-highlighter-line-number"
+            style={
+              Object {
+                "color": "#9a9a9a",
+                "display": "inline-block",
+                "minWidth": "2em",
+                "paddingRight": "1em",
+                "textAlign": "right",
+                "userSelect": "none",
+              }
+            }
+          >
+            20
+          </span>
           
 
+          <span
+            className="linenumber react-syntax-highlighter-line-number"
+            style={
+              Object {
+                "color": "#9a9a9a",
+                "display": "inline-block",
+                "minWidth": "2em",
+                "paddingRight": "1em",
+                "textAlign": "right",
+                "userSelect": "none",
+              }
+            }
+          >
+            21
+          </span>
             [...]
 
+          <span
+            className="linenumber react-syntax-highlighter-line-number"
+            style={
+              Object {
+                "color": "#9a9a9a",
+                "display": "inline-block",
+                "minWidth": "2em",
+                "paddingRight": "1em",
+                "textAlign": "right",
+                "userSelect": "none",
+              }
+            }
+          >
+            22
+          </span>
           
 
+          <span
+            className="linenumber react-syntax-highlighter-line-number"
+            style={
+              Object {
+                "color": "#9a9a9a",
+                "display": "inline-block",
+                "minWidth": "2em",
+                "paddingRight": "1em",
+                "textAlign": "right",
+                "userSelect": "none",
+              }
+            }
+          >
+            23
+          </span>
           <span
             style={Object {}}
           >
             
           </span>
           <span
-            className="token token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48935,7 +49080,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;/
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48945,7 +49090,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             project
           </span>
           <span
-            className="token token"
+            className="token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -49932,6 +50077,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
     }
   >
     <code
+      className="language-go"
       style={
         Object {
           "MozHyphens": "none",
@@ -49954,151 +50100,21 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
         }
       }
     >
-      <code
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
         style={
           Object {
-            "MozHyphens": "none",
-            "MozTabSize": "4",
-            "OTabSize": "4",
-            "WebkitHyphens": "none",
-            "color": "#363636",
-            "direction": "ltr",
-            "float": "left",
-            "fontFamily": "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
-            "fontSize": "13px",
-            "hyphens": "none",
-            "lineHeight": "1.5",
-            "msHyphens": "none",
-            "paddingRight": "10px",
-            "tabSize": "4",
-            "textAlign": "left",
-            "textShadow": "none",
-            "whiteSpace": "pre",
-            "wordBreak": "normal",
-            "wordSpacing": "normal",
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
           }
         }
       >
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          1
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          2
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          3
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          4
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          5
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          6
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          7
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          8
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          9
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          10
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          11
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          12
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          13
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          14
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          15
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          16
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          17
-
-        </span>
-      </code>
+        1
+      </span>
       <span
         className="token"
         style={
@@ -50115,8 +50131,38 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
          main
 
       </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        2
+      </span>
       
 
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        3
+      </span>
       <span
         style={Object {}}
       >
@@ -50154,6 +50200,21 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        4
+      </span>
+      <span
         style={Object {}}
       >
           
@@ -50173,6 +50234,21 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
       >
         
 
+      </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        5
       </span>
       <span
         style={Object {}}
@@ -50196,6 +50272,21 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        6
+      </span>
+      <span
         style={Object {}}
       >
         
@@ -50216,8 +50307,38 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
         
 
       </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        7
+      </span>
       
 
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        8
+      </span>
       <span
         style={Object {}}
       >
@@ -50288,6 +50409,21 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
       >
         
 
+      </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        9
       </span>
       <span
         style={Object {}}
@@ -50471,6 +50607,21 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        10
+      </span>
+      <span
         style={Object {}}
       >
             fmt
@@ -50552,6 +50703,21 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        11
+      </span>
+      <span
         style={Object {}}
       >
           
@@ -50582,8 +50748,38 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
         
 
       </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        12
+      </span>
       
 
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        13
+      </span>
       <span
         style={Object {}}
       >
@@ -50704,6 +50900,21 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
       >
         
 
+      </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        14
       </span>
       <span
         style={Object {}}
@@ -50846,8 +51057,38 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
         
 
       </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        15
+      </span>
       
 
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        16
+      </span>
       <span
         style={Object {}}
       >
@@ -50935,6 +51176,21 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        17
+      </span>
+      <span
         style={Object {}}
       >
         
@@ -50954,6 +51210,21 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
       >
         
 
+      </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        18
       </span>
       
 
@@ -50994,6 +51265,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
     }
   >
     <code
+      className="language-java"
       style={
         Object {
           "MozHyphens": "none",
@@ -51016,249 +51288,21 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         }
       }
     >
-      <code
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
         style={
           Object {
-            "MozHyphens": "none",
-            "MozTabSize": "4",
-            "OTabSize": "4",
-            "WebkitHyphens": "none",
-            "color": "#363636",
-            "direction": "ltr",
-            "float": "left",
-            "fontFamily": "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
-            "fontSize": "13px",
-            "hyphens": "none",
-            "lineHeight": "1.5",
-            "msHyphens": "none",
-            "paddingRight": "10px",
-            "tabSize": "4",
-            "textAlign": "left",
-            "textShadow": "none",
-            "whiteSpace": "pre",
-            "wordBreak": "normal",
-            "wordSpacing": "normal",
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
           }
         }
       >
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          1
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          2
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          3
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          4
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          5
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          6
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          7
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          8
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          9
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          10
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          11
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          12
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          13
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          14
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          15
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          16
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          17
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          18
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          19
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          20
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          21
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          22
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          23
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          24
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          25
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          26
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          27
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          28
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          29
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          30
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          31
-
-        </span>
-      </code>
+        1
+      </span>
       <span
         className="token"
         style={
@@ -51275,13 +51319,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
          
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         com
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51291,7 +51335,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         example
@@ -51312,8 +51356,38 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         
 
       </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        2
+      </span>
       
 
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        3
+      </span>
       <span
         style={Object {}}
       >
@@ -51335,13 +51409,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
          
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         java
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51351,7 +51425,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         io
@@ -51389,6 +51463,21 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        4
+      </span>
+      <span
         style={Object {}}
       >
         
@@ -51409,13 +51498,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
          
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         java
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51425,7 +51514,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         io
@@ -51463,6 +51552,21 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        5
+      </span>
+      <span
         style={Object {}}
       >
         
@@ -51483,13 +51587,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
          
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         java
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51499,7 +51603,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         net
@@ -51536,8 +51640,38 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         
 
       </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        6
+      </span>
       
 
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        7
+      </span>
       <span
         style={Object {}}
       >
@@ -51559,13 +51693,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
          
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         com
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51575,13 +51709,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         sun
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51591,13 +51725,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         net
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51607,7 +51741,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         httpserver
@@ -51645,6 +51779,21 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        8
+      </span>
+      <span
         style={Object {}}
       >
         
@@ -51665,13 +51814,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
          
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         com
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51681,13 +51830,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         sun
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51697,13 +51846,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         net
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51713,7 +51862,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         httpserver
@@ -51751,6 +51900,21 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        9
+      </span>
+      <span
         style={Object {}}
       >
         
@@ -51771,13 +51935,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
          
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         com
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51787,13 +51951,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         sun
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51803,13 +51967,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         net
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51819,7 +51983,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         httpserver
@@ -51856,8 +52020,38 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         
 
       </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        10
+      </span>
       
 
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        11
+      </span>
       <span
         style={Object {}}
       >
@@ -51920,8 +52114,38 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         
 
       </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        12
+      </span>
       
 
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        13
+      </span>
       <span
         style={Object {}}
       >
@@ -52079,6 +52303,21 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
       >
         
 
+      </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        14
       </span>
       <span
         style={Object {}}
@@ -52250,6 +52489,21 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        15
+      </span>
+      <span
         style={Object {}}
       >
             server
@@ -52377,6 +52631,21 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        16
+      </span>
+      <span
         style={Object {}}
       >
             server
@@ -52463,6 +52732,21 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        17
+      </span>
+      <span
         style={Object {}}
       >
             server
@@ -52524,6 +52808,21 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        18
+      </span>
+      <span
         style={Object {}}
       >
           
@@ -52544,8 +52843,38 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         
 
       </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        19
+      </span>
       
 
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        20
+      </span>
       <span
         style={Object {}}
       >
@@ -52635,6 +52964,21 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        21
+      </span>
+      <span
         style={Object {}}
       >
             
@@ -52654,6 +52998,21 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
       >
         
 
+      </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        22
       </span>
       <span
         style={Object {}}
@@ -52779,6 +53138,21 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        23
+      </span>
+      <span
         style={Object {}}
       >
               
@@ -52834,6 +53208,21 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
       >
         
 
+      </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        24
       </span>
       <span
         style={Object {}}
@@ -52962,6 +53351,21 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        25
+      </span>
+      <span
         style={Object {}}
       >
               
@@ -53047,6 +53451,21 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
       >
         
 
+      </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        26
       </span>
       <span
         style={Object {}}
@@ -53155,6 +53574,21 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        27
+      </span>
+      <span
         style={Object {}}
       >
               os
@@ -53216,6 +53650,21 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        28
+      </span>
+      <span
         style={Object {}}
       >
             
@@ -53235,6 +53684,21 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
       >
         
 
+      </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        29
       </span>
       <span
         style={Object {}}
@@ -53257,8 +53721,38 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         
 
       </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        30
+      </span>
       
 
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        31
+      </span>
       <span
         style={Object {}}
       >
@@ -53279,6 +53773,21 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
       >
         
 
+      </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "3em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        32
       </span>
       
 
@@ -53319,6 +53828,7 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
     }
   >
     <code
+      className="language-javascript"
       style={
         Object {
           "MozHyphens": "none",
@@ -53341,81 +53851,21 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
         }
       }
     >
-      <code
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
         style={
           Object {
-            "MozHyphens": "none",
-            "MozTabSize": "4",
-            "OTabSize": "4",
-            "WebkitHyphens": "none",
-            "color": "#363636",
-            "direction": "ltr",
-            "float": "left",
-            "fontFamily": "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
-            "fontSize": "13px",
-            "hyphens": "none",
-            "lineHeight": "1.5",
-            "msHyphens": "none",
-            "paddingRight": "10px",
-            "tabSize": "4",
-            "textAlign": "left",
-            "textShadow": "none",
-            "whiteSpace": "pre",
-            "wordBreak": "normal",
-            "wordSpacing": "normal",
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
           }
         }
       >
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          1
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          2
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          3
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          4
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          5
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          6
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          7
-
-        </span>
-      </code>
+        1
+      </span>
       <span
         className="token"
         style={
@@ -53502,8 +53952,38 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
         
 
       </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        2
+      </span>
       
 
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        3
+      </span>
       <span
         style={Object {}}
       >
@@ -53571,7 +54051,7 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
         req
       </span>
       <span
-        className="token parameter token"
+        className="token parameter"
         style={
           Object {
             "color": "#9a9a9a",
@@ -53616,6 +54096,21 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
       >
         
 
+      </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        4
       </span>
       <span
         style={Object {}}
@@ -53701,7 +54196,7 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
         className="token"
         style={
           Object {
-            "color": "#9a9a9a",
+            "color": "#686868",
           }
         }
       >
@@ -53757,6 +54252,21 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
       >
         
 
+      </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        5
       </span>
       <span
         style={Object {}}
@@ -53830,6 +54340,21 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        6
+      </span>
+      <span
         style={Object {}}
       >
           res
@@ -53889,6 +54414,21 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
       >
         
 
+      </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        7
       </span>
       <span
         style={Object {}}
@@ -53981,6 +54521,21 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
         
 
       </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        8
+      </span>
       
 
     </code>
@@ -54020,6 +54575,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
     }
   >
     <code
+      className="language-python"
       style={
         Object {
           "MozHyphens": "none",
@@ -54042,172 +54598,21 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
         }
       }
     >
-      <code
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
         style={
           Object {
-            "MozHyphens": "none",
-            "MozTabSize": "4",
-            "OTabSize": "4",
-            "WebkitHyphens": "none",
-            "color": "#363636",
-            "direction": "ltr",
-            "float": "left",
-            "fontFamily": "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
-            "fontSize": "13px",
-            "hyphens": "none",
-            "lineHeight": "1.5",
-            "msHyphens": "none",
-            "paddingRight": "10px",
-            "tabSize": "4",
-            "textAlign": "left",
-            "textShadow": "none",
-            "whiteSpace": "pre",
-            "wordBreak": "normal",
-            "wordSpacing": "normal",
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
           }
         }
       >
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          1
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          2
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          3
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          4
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          5
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          6
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          7
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          8
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          9
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          10
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          11
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          12
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          13
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          14
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          15
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          16
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          17
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          18
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          19
-
-        </span>
-        <span
-          className="react-syntax-highlighter-line-number"
-          style={Object {}}
-        >
-          20
-
-        </span>
-      </code>
+        1
+      </span>
       <span
         className="token"
         style={
@@ -54254,8 +54659,38 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
         HTTPServer
 
       </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        2
+      </span>
       
 
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        3
+      </span>
       <span
         style={Object {}}
       >
@@ -54292,8 +54727,38 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
         
 
       </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        4
+      </span>
       
 
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        5
+      </span>
       <span
         style={Object {}}
       >
@@ -54361,8 +54826,38 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
         
 
       </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        6
+      </span>
       
 
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        7
+      </span>
       <span
         style={Object {}}
       >
@@ -54435,6 +54930,21 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        8
+      </span>
+      <span
         style={Object {}}
       >
             self
@@ -54489,6 +54999,21 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
       >
         
 
+      </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        9
       </span>
       <span
         style={Object {}}
@@ -54567,6 +55092,21 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        10
+      </span>
+      <span
         style={Object {}}
       >
             self
@@ -54611,6 +55151,21 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
       >
         
 
+      </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        11
       </span>
       <span
         style={Object {}}
@@ -54684,6 +55239,21 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        12
+      </span>
+      <span
         style={Object {}}
       >
             
@@ -54704,8 +55274,38 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
         
 
       </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        13
+      </span>
       
 
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        14
+      </span>
       <span
         style={Object {}}
       >
@@ -54736,6 +55336,21 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
       >
         
 
+      </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        15
       </span>
       <span
         style={Object {}}
@@ -54844,6 +55459,21 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        16
+      </span>
+      <span
         style={Object {}}
       >
           
@@ -54895,6 +55525,21 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        17
+      </span>
+      <span
         style={Object {}}
       >
           server
@@ -54941,6 +55586,21 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        18
+      </span>
+      <span
         style={Object {}}
       >
         
@@ -54977,6 +55637,21 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
 
       </span>
       <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        19
+      </span>
+      <span
         style={Object {}}
       >
           
@@ -55011,6 +55686,21 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
       >
         
 
+      </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        20
       </span>
       <span
         style={Object {}}
@@ -55073,6 +55763,21 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
         
 
       </span>
+      <span
+        className="linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "color": "#9a9a9a",
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        21
+      </span>
       
 
     </code>
@@ -55112,6 +55817,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
     }
   >
     <code
+      className="language-java"
       style={
         Object {
           "MozHyphens": "none",
@@ -55150,13 +55856,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
          
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         com
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -55166,7 +55872,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         example
@@ -55210,13 +55916,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
          
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         java
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -55226,7 +55932,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         io
@@ -55284,13 +55990,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
          
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         java
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -55300,7 +56006,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         io
@@ -55358,13 +56064,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
          
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         java
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -55374,7 +56080,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         net
@@ -55434,13 +56140,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
          
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         com
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -55450,13 +56156,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         sun
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -55466,13 +56172,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         net
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -55482,7 +56188,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         httpserver
@@ -55540,13 +56246,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
          
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         com
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -55556,13 +56262,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         sun
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -55572,13 +56278,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         net
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -55588,7 +56294,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         httpserver
@@ -55646,13 +56352,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
          
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         com
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -55662,13 +56368,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         sun
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -55678,13 +56384,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         net
       </span>
       <span
-        className="token namespace token"
+        className="token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -55694,7 +56400,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token namespace"
+        className="token"
         style={Object {}}
       >
         httpserver

--- a/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
+++ b/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
@@ -39,7 +39,6 @@ exports[`Storyshots Annotate Default 1`] = `
       }
     >
       <code
-        className="language-go"
         style={
           Object {
             "MozHyphens": "none",
@@ -592,7 +591,6 @@ exports[`Storyshots Annotate With Avatars 1`] = `
       }
     >
       <code
-        className="language-go"
         style={
           Object {
             "MozHyphens": "none",
@@ -46774,7 +46772,6 @@ exports[`Storyshots MarkdownView Code without Lang 1`] = `
         }
       >
         <code
-          className="language-text"
           style={
             Object {
               "MozHyphens": "none",
@@ -46797,21 +46794,39 @@ exports[`Storyshots MarkdownView Code without Lang 1`] = `
             }
           }
         >
-          <span
-            className="linenumber react-syntax-highlighter-line-number"
+          <code
             style={
               Object {
-                "color": "#9a9a9a",
-                "display": "inline-block",
-                "minWidth": "1em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
+                "MozHyphens": "none",
+                "MozTabSize": "4",
+                "OTabSize": "4",
+                "WebkitHyphens": "none",
+                "color": "#363636",
+                "direction": "ltr",
+                "float": "left",
+                "fontFamily": "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
+                "fontSize": "13px",
+                "hyphens": "none",
+                "lineHeight": "1.5",
+                "msHyphens": "none",
+                "paddingRight": "10px",
+                "tabSize": "4",
+                "textAlign": "left",
+                "textShadow": "none",
+                "whiteSpace": "pre",
+                "wordBreak": "normal",
+                "wordSpacing": "normal",
               }
             }
           >
-            1
-          </span>
+            <span
+              className="react-syntax-highlighter-line-number"
+              style={Object {}}
+            >
+              1
+
+            </span>
+          </code>
           <span
             style={Object {}}
           >
@@ -47680,7 +47695,6 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
           </span>
         </code>
         <code
-          className="language-go"
           style={
             Object {
               "MozHyphens": "none",
@@ -47990,7 +48004,6 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
         }
       >
         <code
-          className="language-xml"
           style={
             Object {
               "MozHyphens": "none",
@@ -48013,23 +48026,195 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             }
           }
         >
-          <span
-            className="linenumber react-syntax-highlighter-line-number"
+          <code
             style={
               Object {
-                "color": "#9a9a9a",
-                "display": "inline-block",
-                "minWidth": "2em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
+                "MozHyphens": "none",
+                "MozTabSize": "4",
+                "OTabSize": "4",
+                "WebkitHyphens": "none",
+                "color": "#363636",
+                "direction": "ltr",
+                "float": "left",
+                "fontFamily": "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
+                "fontSize": "13px",
+                "hyphens": "none",
+                "lineHeight": "1.5",
+                "msHyphens": "none",
+                "paddingRight": "10px",
+                "tabSize": "4",
+                "textAlign": "left",
+                "textShadow": "none",
+                "whiteSpace": "pre",
+                "wordBreak": "normal",
+                "wordSpacing": "normal",
               }
             }
           >
-            1
-          </span>
+            <span
+              className="react-syntax-highlighter-line-number"
+              style={Object {}}
+            >
+              1
+
+            </span>
+            <span
+              className="react-syntax-highlighter-line-number"
+              style={Object {}}
+            >
+              2
+
+            </span>
+            <span
+              className="react-syntax-highlighter-line-number"
+              style={Object {}}
+            >
+              3
+
+            </span>
+            <span
+              className="react-syntax-highlighter-line-number"
+              style={Object {}}
+            >
+              4
+
+            </span>
+            <span
+              className="react-syntax-highlighter-line-number"
+              style={Object {}}
+            >
+              5
+
+            </span>
+            <span
+              className="react-syntax-highlighter-line-number"
+              style={Object {}}
+            >
+              6
+
+            </span>
+            <span
+              className="react-syntax-highlighter-line-number"
+              style={Object {}}
+            >
+              7
+
+            </span>
+            <span
+              className="react-syntax-highlighter-line-number"
+              style={Object {}}
+            >
+              8
+
+            </span>
+            <span
+              className="react-syntax-highlighter-line-number"
+              style={Object {}}
+            >
+              9
+
+            </span>
+            <span
+              className="react-syntax-highlighter-line-number"
+              style={Object {}}
+            >
+              10
+
+            </span>
+            <span
+              className="react-syntax-highlighter-line-number"
+              style={Object {}}
+            >
+              11
+
+            </span>
+            <span
+              className="react-syntax-highlighter-line-number"
+              style={Object {}}
+            >
+              12
+
+            </span>
+            <span
+              className="react-syntax-highlighter-line-number"
+              style={Object {}}
+            >
+              13
+
+            </span>
+            <span
+              className="react-syntax-highlighter-line-number"
+              style={Object {}}
+            >
+              14
+
+            </span>
+            <span
+              className="react-syntax-highlighter-line-number"
+              style={Object {}}
+            >
+              15
+
+            </span>
+            <span
+              className="react-syntax-highlighter-line-number"
+              style={Object {}}
+            >
+              16
+
+            </span>
+            <span
+              className="react-syntax-highlighter-line-number"
+              style={Object {}}
+            >
+              17
+
+            </span>
+            <span
+              className="react-syntax-highlighter-line-number"
+              style={Object {}}
+            >
+              18
+
+            </span>
+            <span
+              className="react-syntax-highlighter-line-number"
+              style={Object {}}
+            >
+              19
+
+            </span>
+            <span
+              className="react-syntax-highlighter-line-number"
+              style={Object {}}
+            >
+              20
+
+            </span>
+            <span
+              className="react-syntax-highlighter-line-number"
+              style={Object {}}
+            >
+              21
+
+            </span>
+            <span
+              className="react-syntax-highlighter-line-number"
+              style={Object {}}
+            >
+              22
+
+            </span>
+            <span
+              className="react-syntax-highlighter-line-number"
+              style={Object {}}
+            >
+              23
+
+            </span>
+          </code>
           <span
-            className="token"
+            className="token token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48039,7 +48224,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48059,7 +48244,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
              
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#005f9a",
@@ -48069,7 +48254,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             [...]
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48084,79 +48269,19 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             
 
           </span>
-          <span
-            className="linenumber react-syntax-highlighter-line-number"
-            style={
-              Object {
-                "color": "#9a9a9a",
-                "display": "inline-block",
-                "minWidth": "2em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
-              }
-            }
-          >
-            2
-          </span>
           
 
-          <span
-            className="linenumber react-syntax-highlighter-line-number"
-            style={
-              Object {
-                "color": "#9a9a9a",
-                "display": "inline-block",
-                "minWidth": "2em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
-              }
-            }
-          >
-            3
-          </span>
             [...]
 
-          <span
-            className="linenumber react-syntax-highlighter-line-number"
-            style={
-              Object {
-                "color": "#9a9a9a",
-                "display": "inline-block",
-                "minWidth": "2em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
-              }
-            }
-          >
-            4
-          </span>
           
 
-          <span
-            className="linenumber react-syntax-highlighter-line-number"
-            style={
-              Object {
-                "color": "#9a9a9a",
-                "display": "inline-block",
-                "minWidth": "2em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
-              }
-            }
-          >
-            5
-          </span>
           <span
             style={Object {}}
           >
               
           </span>
           <span
-            className="token"
+            className="token token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48166,7 +48291,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48176,7 +48301,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             build
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48192,27 +48317,12 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
 
           </span>
           <span
-            className="linenumber react-syntax-highlighter-line-number"
-            style={
-              Object {
-                "color": "#9a9a9a",
-                "display": "inline-block",
-                "minWidth": "2em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
-              }
-            }
-          >
-            6
-          </span>
-          <span
             style={Object {}}
           >
                 
           </span>
           <span
-            className="token"
+            className="token token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48222,7 +48332,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48232,7 +48342,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             plugins
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48247,79 +48357,19 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             
 
           </span>
-          <span
-            className="linenumber react-syntax-highlighter-line-number"
-            style={
-              Object {
-                "color": "#9a9a9a",
-                "display": "inline-block",
-                "minWidth": "2em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
-              }
-            }
-          >
-            7
-          </span>
           
 
-          <span
-            className="linenumber react-syntax-highlighter-line-number"
-            style={
-              Object {
-                "color": "#9a9a9a",
-                "display": "inline-block",
-                "minWidth": "2em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
-              }
-            }
-          >
-            8
-          </span>
                 [...]
 
-          <span
-            className="linenumber react-syntax-highlighter-line-number"
-            style={
-              Object {
-                "color": "#9a9a9a",
-                "display": "inline-block",
-                "minWidth": "2em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
-              }
-            }
-          >
-            9
-          </span>
           
 
-          <span
-            className="linenumber react-syntax-highlighter-line-number"
-            style={
-              Object {
-                "color": "#9a9a9a",
-                "display": "inline-block",
-                "minWidth": "2em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
-              }
-            }
-          >
-            10
-          </span>
           <span
             style={Object {}}
           >
                   
           </span>
           <span
-            className="token"
+            className="token token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48329,7 +48379,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48339,7 +48389,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             plugin
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48355,27 +48405,12 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
 
           </span>
           <span
-            className="linenumber react-syntax-highlighter-line-number"
-            style={
-              Object {
-                "color": "#9a9a9a",
-                "display": "inline-block",
-                "minWidth": "2em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
-              }
-            }
-          >
-            11
-          </span>
-          <span
             style={Object {}}
           >
                     
           </span>
           <span
-            className="token"
+            className="token token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48385,7 +48420,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48395,7 +48430,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             groupId
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48410,7 +48445,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             org.apache.maven.plugins
           </span>
           <span
-            className="token"
+            className="token token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48420,7 +48455,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;/
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48430,7 +48465,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             groupId
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48446,27 +48481,12 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
 
           </span>
           <span
-            className="linenumber react-syntax-highlighter-line-number"
-            style={
-              Object {
-                "color": "#9a9a9a",
-                "display": "inline-block",
-                "minWidth": "2em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
-              }
-            }
-          >
-            12
-          </span>
-          <span
             style={Object {}}
           >
                     
           </span>
           <span
-            className="token"
+            className="token token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48476,7 +48496,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48486,7 +48506,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             artifactId
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48501,7 +48521,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             maven-enforcer-plugin
           </span>
           <span
-            className="token"
+            className="token token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48511,7 +48531,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;/
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48521,7 +48541,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             artifactId
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48537,27 +48557,12 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
 
           </span>
           <span
-            className="linenumber react-syntax-highlighter-line-number"
-            style={
-              Object {
-                "color": "#9a9a9a",
-                "display": "inline-block",
-                "minWidth": "2em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
-              }
-            }
-          >
-            13
-          </span>
-          <span
             style={Object {}}
           >
                   
           </span>
           <span
-            className="token"
+            className="token token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48567,7 +48572,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;/
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48577,7 +48582,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             plugin
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48591,21 +48596,6 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
           >
             
 
-          </span>
-          <span
-            className="linenumber react-syntax-highlighter-line-number"
-            style={
-              Object {
-                "color": "#9a9a9a",
-                "display": "inline-block",
-                "minWidth": "2em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
-              }
-            }
-          >
-            14
           </span>
           <span
             style={Object {}}
@@ -48613,7 +48603,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
                   
           </span>
           <span
-            className="token"
+            className="token token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48623,7 +48613,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48633,7 +48623,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             plugin
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48649,27 +48639,12 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
 
           </span>
           <span
-            className="linenumber react-syntax-highlighter-line-number"
-            style={
-              Object {
-                "color": "#9a9a9a",
-                "display": "inline-block",
-                "minWidth": "2em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
-              }
-            }
-          >
-            15
-          </span>
-          <span
             style={Object {}}
           >
                     
           </span>
           <span
-            className="token"
+            className="token token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48679,7 +48654,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48689,7 +48664,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             groupId
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48704,7 +48679,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             org.codehaus.mojo
           </span>
           <span
-            className="token"
+            className="token token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48714,7 +48689,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;/
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48724,7 +48699,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             groupId
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48740,27 +48715,12 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
 
           </span>
           <span
-            className="linenumber react-syntax-highlighter-line-number"
-            style={
-              Object {
-                "color": "#9a9a9a",
-                "display": "inline-block",
-                "minWidth": "2em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
-              }
-            }
-          >
-            16
-          </span>
-          <span
             style={Object {}}
           >
                     
           </span>
           <span
-            className="token"
+            className="token token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48770,7 +48730,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48780,7 +48740,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             artifactId
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48795,7 +48755,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             animal-sniffer-maven-plugin
           </span>
           <span
-            className="token"
+            className="token token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48805,7 +48765,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;/
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48815,7 +48775,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             artifactId
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48831,27 +48791,12 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
 
           </span>
           <span
-            className="linenumber react-syntax-highlighter-line-number"
-            style={
-              Object {
-                "color": "#9a9a9a",
-                "display": "inline-block",
-                "minWidth": "2em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
-              }
-            }
-          >
-            17
-          </span>
-          <span
             style={Object {}}
           >
                   
           </span>
           <span
-            className="token"
+            className="token token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48861,7 +48806,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;/
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48871,7 +48816,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             plugin
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48887,27 +48832,12 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
 
           </span>
           <span
-            className="linenumber react-syntax-highlighter-line-number"
-            style={
-              Object {
-                "color": "#9a9a9a",
-                "display": "inline-block",
-                "minWidth": "2em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
-              }
-            }
-          >
-            18
-          </span>
-          <span
             style={Object {}}
           >
                 
           </span>
           <span
-            className="token"
+            className="token token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48917,7 +48847,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;/
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48927,7 +48857,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             plugins
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48943,27 +48873,12 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
 
           </span>
           <span
-            className="linenumber react-syntax-highlighter-line-number"
-            style={
-              Object {
-                "color": "#9a9a9a",
-                "display": "inline-block",
-                "minWidth": "2em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
-              }
-            }
-          >
-            19
-          </span>
-          <span
             style={Object {}}
           >
               
           </span>
           <span
-            className="token"
+            className="token token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48973,7 +48888,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;/
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -48983,7 +48898,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             build
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -48998,79 +48913,19 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             
 
           </span>
-          <span
-            className="linenumber react-syntax-highlighter-line-number"
-            style={
-              Object {
-                "color": "#9a9a9a",
-                "display": "inline-block",
-                "minWidth": "2em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
-              }
-            }
-          >
-            20
-          </span>
           
 
-          <span
-            className="linenumber react-syntax-highlighter-line-number"
-            style={
-              Object {
-                "color": "#9a9a9a",
-                "display": "inline-block",
-                "minWidth": "2em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
-              }
-            }
-          >
-            21
-          </span>
             [...]
 
-          <span
-            className="linenumber react-syntax-highlighter-line-number"
-            style={
-              Object {
-                "color": "#9a9a9a",
-                "display": "inline-block",
-                "minWidth": "2em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
-              }
-            }
-          >
-            22
-          </span>
           
 
-          <span
-            className="linenumber react-syntax-highlighter-line-number"
-            style={
-              Object {
-                "color": "#9a9a9a",
-                "display": "inline-block",
-                "minWidth": "2em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
-              }
-            }
-          >
-            23
-          </span>
           <span
             style={Object {}}
           >
             
           </span>
           <span
-            className="token"
+            className="token token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -49080,7 +48935,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             &lt;/
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#2c99c7",
@@ -49090,7 +48945,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             project
           </span>
           <span
-            className="token"
+            className="token token"
             style={
               Object {
                 "color": "#9a9a9a",
@@ -50077,7 +49932,6 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
     }
   >
     <code
-      className="language-go"
       style={
         Object {
           "MozHyphens": "none",
@@ -50100,21 +49954,151 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
         }
       }
     >
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
+      <code
         style={
           Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
+            "MozHyphens": "none",
+            "MozTabSize": "4",
+            "OTabSize": "4",
+            "WebkitHyphens": "none",
+            "color": "#363636",
+            "direction": "ltr",
+            "float": "left",
+            "fontFamily": "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
+            "fontSize": "13px",
+            "hyphens": "none",
+            "lineHeight": "1.5",
+            "msHyphens": "none",
+            "paddingRight": "10px",
+            "tabSize": "4",
+            "textAlign": "left",
+            "textShadow": "none",
+            "whiteSpace": "pre",
+            "wordBreak": "normal",
+            "wordSpacing": "normal",
           }
         }
       >
-        1
-      </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          1
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          2
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          3
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          4
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          5
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          6
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          7
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          8
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          9
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          10
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          11
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          12
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          13
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          14
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          15
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          16
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          17
+
+        </span>
+      </code>
       <span
         className="token"
         style={
@@ -50131,38 +50115,8 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
          main
 
       </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        2
-      </span>
       
 
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        3
-      </span>
       <span
         style={Object {}}
       >
@@ -50200,21 +50154,6 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        4
-      </span>
-      <span
         style={Object {}}
       >
           
@@ -50234,21 +50173,6 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
       >
         
 
-      </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        5
       </span>
       <span
         style={Object {}}
@@ -50272,21 +50196,6 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        6
-      </span>
-      <span
         style={Object {}}
       >
         
@@ -50307,38 +50216,8 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
         
 
       </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        7
-      </span>
       
 
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        8
-      </span>
       <span
         style={Object {}}
       >
@@ -50409,21 +50288,6 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
       >
         
 
-      </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        9
       </span>
       <span
         style={Object {}}
@@ -50607,21 +50471,6 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        10
-      </span>
-      <span
         style={Object {}}
       >
             fmt
@@ -50703,21 +50552,6 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        11
-      </span>
-      <span
         style={Object {}}
       >
           
@@ -50748,38 +50582,8 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
         
 
       </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        12
-      </span>
       
 
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        13
-      </span>
       <span
         style={Object {}}
       >
@@ -50900,21 +50704,6 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
       >
         
 
-      </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        14
       </span>
       <span
         style={Object {}}
@@ -51057,38 +50846,8 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
         
 
       </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        15
-      </span>
       
 
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        16
-      </span>
       <span
         style={Object {}}
       >
@@ -51176,21 +50935,6 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        17
-      </span>
-      <span
         style={Object {}}
       >
         
@@ -51210,21 +50954,6 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
       >
         
 
-      </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        18
       </span>
       
 
@@ -51265,7 +50994,6 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
     }
   >
     <code
-      className="language-java"
       style={
         Object {
           "MozHyphens": "none",
@@ -51288,21 +51016,249 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         }
       }
     >
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
+      <code
         style={
           Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
+            "MozHyphens": "none",
+            "MozTabSize": "4",
+            "OTabSize": "4",
+            "WebkitHyphens": "none",
+            "color": "#363636",
+            "direction": "ltr",
+            "float": "left",
+            "fontFamily": "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
+            "fontSize": "13px",
+            "hyphens": "none",
+            "lineHeight": "1.5",
+            "msHyphens": "none",
+            "paddingRight": "10px",
+            "tabSize": "4",
+            "textAlign": "left",
+            "textShadow": "none",
+            "whiteSpace": "pre",
+            "wordBreak": "normal",
+            "wordSpacing": "normal",
           }
         }
       >
-        1
-      </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          1
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          2
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          3
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          4
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          5
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          6
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          7
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          8
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          9
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          10
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          11
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          12
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          13
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          14
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          15
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          16
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          17
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          18
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          19
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          20
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          21
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          22
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          23
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          24
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          25
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          26
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          27
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          28
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          29
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          30
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          31
+
+        </span>
+      </code>
       <span
         className="token"
         style={
@@ -51319,13 +51275,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
          
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         com
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51335,7 +51291,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         example
@@ -51356,38 +51312,8 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         
 
       </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        2
-      </span>
       
 
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        3
-      </span>
       <span
         style={Object {}}
       >
@@ -51409,13 +51335,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
          
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         java
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51425,7 +51351,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         io
@@ -51463,21 +51389,6 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        4
-      </span>
-      <span
         style={Object {}}
       >
         
@@ -51498,13 +51409,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
          
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         java
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51514,7 +51425,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         io
@@ -51552,21 +51463,6 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        5
-      </span>
-      <span
         style={Object {}}
       >
         
@@ -51587,13 +51483,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
          
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         java
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51603,7 +51499,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         net
@@ -51640,38 +51536,8 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         
 
       </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        6
-      </span>
       
 
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        7
-      </span>
       <span
         style={Object {}}
       >
@@ -51693,13 +51559,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
          
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         com
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51709,13 +51575,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         sun
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51725,13 +51591,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         net
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51741,7 +51607,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         httpserver
@@ -51779,21 +51645,6 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        8
-      </span>
-      <span
         style={Object {}}
       >
         
@@ -51814,13 +51665,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
          
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         com
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51830,13 +51681,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         sun
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51846,13 +51697,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         net
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51862,7 +51713,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         httpserver
@@ -51900,21 +51751,6 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        9
-      </span>
-      <span
         style={Object {}}
       >
         
@@ -51935,13 +51771,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
          
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         com
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51951,13 +51787,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         sun
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51967,13 +51803,13 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         net
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -51983,7 +51819,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         httpserver
@@ -52020,38 +51856,8 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         
 
       </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        10
-      </span>
       
 
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        11
-      </span>
       <span
         style={Object {}}
       >
@@ -52114,38 +51920,8 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         
 
       </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        12
-      </span>
       
 
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        13
-      </span>
       <span
         style={Object {}}
       >
@@ -52303,21 +52079,6 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
       >
         
 
-      </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        14
       </span>
       <span
         style={Object {}}
@@ -52489,21 +52250,6 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        15
-      </span>
-      <span
         style={Object {}}
       >
             server
@@ -52631,21 +52377,6 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        16
-      </span>
-      <span
         style={Object {}}
       >
             server
@@ -52732,21 +52463,6 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        17
-      </span>
-      <span
         style={Object {}}
       >
             server
@@ -52808,21 +52524,6 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        18
-      </span>
-      <span
         style={Object {}}
       >
           
@@ -52843,38 +52544,8 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         
 
       </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        19
-      </span>
       
 
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        20
-      </span>
       <span
         style={Object {}}
       >
@@ -52964,21 +52635,6 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        21
-      </span>
-      <span
         style={Object {}}
       >
             
@@ -52998,21 +52654,6 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
       >
         
 
-      </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        22
       </span>
       <span
         style={Object {}}
@@ -53138,21 +52779,6 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        23
-      </span>
-      <span
         style={Object {}}
       >
               
@@ -53208,21 +52834,6 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
       >
         
 
-      </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        24
       </span>
       <span
         style={Object {}}
@@ -53351,21 +52962,6 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        25
-      </span>
-      <span
         style={Object {}}
       >
               
@@ -53451,21 +53047,6 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
       >
         
 
-      </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        26
       </span>
       <span
         style={Object {}}
@@ -53574,21 +53155,6 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        27
-      </span>
-      <span
         style={Object {}}
       >
               os
@@ -53650,21 +53216,6 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        28
-      </span>
-      <span
         style={Object {}}
       >
             
@@ -53684,21 +53235,6 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
       >
         
 
-      </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        29
       </span>
       <span
         style={Object {}}
@@ -53721,38 +53257,8 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         
 
       </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        30
-      </span>
       
 
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        31
-      </span>
       <span
         style={Object {}}
       >
@@ -53773,21 +53279,6 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
       >
         
 
-      </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "3em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        32
       </span>
       
 
@@ -53828,7 +53319,6 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
     }
   >
     <code
-      className="language-javascript"
       style={
         Object {
           "MozHyphens": "none",
@@ -53851,21 +53341,81 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
         }
       }
     >
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
+      <code
         style={
           Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
+            "MozHyphens": "none",
+            "MozTabSize": "4",
+            "OTabSize": "4",
+            "WebkitHyphens": "none",
+            "color": "#363636",
+            "direction": "ltr",
+            "float": "left",
+            "fontFamily": "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
+            "fontSize": "13px",
+            "hyphens": "none",
+            "lineHeight": "1.5",
+            "msHyphens": "none",
+            "paddingRight": "10px",
+            "tabSize": "4",
+            "textAlign": "left",
+            "textShadow": "none",
+            "whiteSpace": "pre",
+            "wordBreak": "normal",
+            "wordSpacing": "normal",
           }
         }
       >
-        1
-      </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          1
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          2
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          3
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          4
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          5
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          6
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          7
+
+        </span>
+      </code>
       <span
         className="token"
         style={
@@ -53952,38 +53502,8 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
         
 
       </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        2
-      </span>
       
 
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        3
-      </span>
       <span
         style={Object {}}
       >
@@ -54051,7 +53571,7 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
         req
       </span>
       <span
-        className="token parameter"
+        className="token parameter token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -54096,21 +53616,6 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
       >
         
 
-      </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        4
       </span>
       <span
         style={Object {}}
@@ -54196,7 +53701,7 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
         className="token"
         style={
           Object {
-            "color": "#686868",
+            "color": "#9a9a9a",
           }
         }
       >
@@ -54252,21 +53757,6 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
       >
         
 
-      </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        5
       </span>
       <span
         style={Object {}}
@@ -54340,21 +53830,6 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        6
-      </span>
-      <span
         style={Object {}}
       >
           res
@@ -54414,21 +53889,6 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
       >
         
 
-      </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        7
       </span>
       <span
         style={Object {}}
@@ -54521,21 +53981,6 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
         
 
       </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        8
-      </span>
       
 
     </code>
@@ -54575,7 +54020,6 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
     }
   >
     <code
-      className="language-python"
       style={
         Object {
           "MozHyphens": "none",
@@ -54598,21 +54042,172 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
         }
       }
     >
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
+      <code
         style={
           Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
+            "MozHyphens": "none",
+            "MozTabSize": "4",
+            "OTabSize": "4",
+            "WebkitHyphens": "none",
+            "color": "#363636",
+            "direction": "ltr",
+            "float": "left",
+            "fontFamily": "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
+            "fontSize": "13px",
+            "hyphens": "none",
+            "lineHeight": "1.5",
+            "msHyphens": "none",
+            "paddingRight": "10px",
+            "tabSize": "4",
+            "textAlign": "left",
+            "textShadow": "none",
+            "whiteSpace": "pre",
+            "wordBreak": "normal",
+            "wordSpacing": "normal",
           }
         }
       >
-        1
-      </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          1
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          2
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          3
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          4
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          5
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          6
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          7
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          8
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          9
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          10
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          11
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          12
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          13
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          14
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          15
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          16
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          17
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          18
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          19
+
+        </span>
+        <span
+          className="react-syntax-highlighter-line-number"
+          style={Object {}}
+        >
+          20
+
+        </span>
+      </code>
       <span
         className="token"
         style={
@@ -54659,38 +54254,8 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
         HTTPServer
 
       </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        2
-      </span>
       
 
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        3
-      </span>
       <span
         style={Object {}}
       >
@@ -54727,38 +54292,8 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
         
 
       </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        4
-      </span>
       
 
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        5
-      </span>
       <span
         style={Object {}}
       >
@@ -54826,38 +54361,8 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
         
 
       </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        6
-      </span>
       
 
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        7
-      </span>
       <span
         style={Object {}}
       >
@@ -54930,21 +54435,6 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        8
-      </span>
-      <span
         style={Object {}}
       >
             self
@@ -54999,21 +54489,6 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
       >
         
 
-      </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        9
       </span>
       <span
         style={Object {}}
@@ -55092,21 +54567,6 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        10
-      </span>
-      <span
         style={Object {}}
       >
             self
@@ -55151,21 +54611,6 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
       >
         
 
-      </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        11
       </span>
       <span
         style={Object {}}
@@ -55239,21 +54684,6 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        12
-      </span>
-      <span
         style={Object {}}
       >
             
@@ -55274,38 +54704,8 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
         
 
       </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        13
-      </span>
       
 
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        14
-      </span>
       <span
         style={Object {}}
       >
@@ -55336,21 +54736,6 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
       >
         
 
-      </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        15
       </span>
       <span
         style={Object {}}
@@ -55459,21 +54844,6 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        16
-      </span>
-      <span
         style={Object {}}
       >
           
@@ -55525,21 +54895,6 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        17
-      </span>
-      <span
         style={Object {}}
       >
           server
@@ -55586,21 +54941,6 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        18
-      </span>
-      <span
         style={Object {}}
       >
         
@@ -55637,21 +54977,6 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
 
       </span>
       <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        19
-      </span>
-      <span
         style={Object {}}
       >
           
@@ -55686,21 +55011,6 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
       >
         
 
-      </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        20
       </span>
       <span
         style={Object {}}
@@ -55763,21 +55073,6 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
         
 
       </span>
-      <span
-        className="linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "#9a9a9a",
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        21
-      </span>
       
 
     </code>
@@ -55817,7 +55112,6 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
     }
   >
     <code
-      className="language-java"
       style={
         Object {
           "MozHyphens": "none",
@@ -55856,13 +55150,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
          
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         com
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -55872,7 +55166,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         example
@@ -55916,13 +55210,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
          
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         java
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -55932,7 +55226,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         io
@@ -55990,13 +55284,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
          
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         java
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -56006,7 +55300,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         io
@@ -56064,13 +55358,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
          
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         java
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -56080,7 +55374,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         net
@@ -56140,13 +55434,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
          
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         com
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -56156,13 +55450,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         sun
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -56172,13 +55466,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         net
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -56188,7 +55482,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         httpserver
@@ -56246,13 +55540,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
          
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         com
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -56262,13 +55556,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         sun
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -56278,13 +55572,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         net
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -56294,7 +55588,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         httpserver
@@ -56352,13 +55646,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
          
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         com
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -56368,13 +55662,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         sun
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -56384,13 +55678,13 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         net
       </span>
       <span
-        className="token"
+        className="token namespace token"
         style={
           Object {
             "color": "#9a9a9a",
@@ -56400,7 +55694,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         .
       </span>
       <span
-        className="token"
+        className="token namespace"
         style={Object {}}
       >
         httpserver

--- a/scm-ui/ui-components/src/languages.test.ts
+++ b/scm-ui/ui-components/src/languages.test.ts
@@ -21,43 +21,32 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import styled from "styled-components";
-import SyntaxHighlighter from "./SyntaxHighlighter";
 
-import JavaHttpServer from "./__resources__/HttpServer.java";
-import GoHttpServer from "./__resources__/HttpServer.go";
-import JsHttpServer from "./__resources__/HttpServer.js";
-import PyHttpServer from "./__resources__/HttpServer.py";
+import { determineLanguage } from "./languages";
 
-const Spacing = styled.div`
-  padding: 1em;
-`;
+describe("syntax highlighter", () => {
+  it("should return the language as it is", () => {
+    const java = determineLanguage("java");
+    expect(java).toBe("java");
+  });
 
-storiesOf("SyntaxHighlighter", module)
-  .add("Java", () => (
-    <Spacing>
-      <SyntaxHighlighter language="java" value={JavaHttpServer} />
-    </Spacing>
-  ))
-  .add("Go", () => (
-    <Spacing>
-      <SyntaxHighlighter language="golang" value={GoHttpServer} />
-    </Spacing>
-  ))
-  .add("Javascript", () => (
-    <Spacing>
-      <SyntaxHighlighter language="javascript" value={JsHttpServer} />
-    </Spacing>
-  ))
-  .add("Python", () => (
-    <Spacing>
-      <SyntaxHighlighter language="python" value={PyHttpServer} />
-    </Spacing>
-  ))
-  .add("Without line numbers", () => (
-    <Spacing>
-      <SyntaxHighlighter language="java" value={JavaHttpServer} showLineNumbers={false} />
-    </Spacing>
-  ));
+  it("should lower case the language", () => {
+    const java = determineLanguage("Java");
+    expect(java).toBe("java");
+  });
+
+  it("should return text if language is undefied", () => {
+    const lang = determineLanguage();
+    expect(lang).toBe("text");
+  });
+
+  it("should return text if language is an empty string", () => {
+    const lang = determineLanguage("");
+    expect(lang).toBe("text");
+  });
+
+  it("should use alias go for golang", () => {
+    const go = determineLanguage("golang");
+    expect(go).toBe("go");
+  });
+});

--- a/scm-ui/ui-components/src/languages.ts
+++ b/scm-ui/ui-components/src/languages.ts
@@ -21,43 +21,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import styled from "styled-components";
-import SyntaxHighlighter from "./SyntaxHighlighter";
 
-import JavaHttpServer from "./__resources__/HttpServer.java";
-import GoHttpServer from "./__resources__/HttpServer.go";
-import JsHttpServer from "./__resources__/HttpServer.js";
-import PyHttpServer from "./__resources__/HttpServer.py";
+// this aliases are only to map from spotter detection to prismjs
+const languageAliases: { [key: string]: string } = {
+  golang: "go"
+};
 
-const Spacing = styled.div`
-  padding: 1em;
-`;
+export const defaultLanguage = "text";
 
-storiesOf("SyntaxHighlighter", module)
-  .add("Java", () => (
-    <Spacing>
-      <SyntaxHighlighter language="java" value={JavaHttpServer} />
-    </Spacing>
-  ))
-  .add("Go", () => (
-    <Spacing>
-      <SyntaxHighlighter language="golang" value={GoHttpServer} />
-    </Spacing>
-  ))
-  .add("Javascript", () => (
-    <Spacing>
-      <SyntaxHighlighter language="javascript" value={JsHttpServer} />
-    </Spacing>
-  ))
-  .add("Python", () => (
-    <Spacing>
-      <SyntaxHighlighter language="python" value={PyHttpServer} />
-    </Spacing>
-  ))
-  .add("Without line numbers", () => (
-    <Spacing>
-      <SyntaxHighlighter language="java" value={JavaHttpServer} showLineNumbers={false} />
-    </Spacing>
-  ));
+export const determineLanguage = (language?: string) => {
+  if (!language) {
+    return defaultLanguage;
+  }
+  const lang = language.toLowerCase();
+  if (languageAliases[lang]) {
+    return languageAliases[lang];
+  }
+  return lang;
+};

--- a/scm-ui/ui-components/src/repos/TokenizedDiffView.tsx
+++ b/scm-ui/ui-components/src/repos/TokenizedDiffView.tsx
@@ -26,6 +26,7 @@ import styled from "styled-components";
 // @ts-ignore we have no typings for react-diff-view
 import { Diff, useTokenizeWorker } from "react-diff-view";
 import { File } from "./DiffTypes";
+import { determineLanguage } from "../languages";
 
 // styling for the diff tokens
 // this must be aligned with th style, which is used in the SyntaxHighlighter component
@@ -86,17 +87,10 @@ type Props = {
   className?: string;
 };
 
-const determineLanguage = (file: File) => {
-  if (file.language) {
-    return file.language.toLowerCase();
-  }
-  return "text";
-};
-
 const TokenizedDiffView: FC<Props> = ({ file, viewType, className, children }) => {
   const { tokens } = useTokenizeWorker(tokenize, {
     hunks: file.hunks,
-    language: determineLanguage(file)
+    language: determineLanguage(file.language)
   });
 
   return (

--- a/scm-ui/ui-components/src/repos/annotate/Annotate.stories.tsx
+++ b/scm-ui/ui-components/src/repos/annotate/Annotate.stories.tsx
@@ -67,7 +67,7 @@ const commitImplementMain = {
 };
 
 const source: AnnotatedSource = {
-  language: "go",
+  language: "golang",
   lines: [
     {
       lineNumber: 1,

--- a/scm-ui/ui-components/src/repos/annotate/Annotate.tsx
+++ b/scm-ui/ui-components/src/repos/annotate/Annotate.tsx
@@ -35,6 +35,7 @@ import { DateInput } from "../../useDateFormatter";
 import Popover from "./Popover";
 import AnnotateLine from "./AnnotateLine";
 import { Action } from "./actions";
+import { determineLanguage } from "../../languages";
 
 type Props = {
   source: AnnotatedSource;
@@ -147,7 +148,7 @@ const Annotate: FC<Props> = ({ source, repository, baseDate }) => {
       {popover}
       <ReactSyntaxHighlighter
         showLineNumbers={false}
-        language={source.language ? source.language : "text"}
+        language={determineLanguage(source.language)}
         style={highlightingTheme}
         renderer={defaultRenderer}
       >


### PR DESCRIPTION
## Proposed changes

Fixes syntax highlighting for go files. The problem is that spotter return golang as language name, but prismjs and refractor using go as name. This pr will map the name golang to go for the syntax highlighter.

### Your checklist for this pull request

- [X] PR is well described
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests
- [X] CHANGELOG.md updated
- [X] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
