### PR TITLE
Fix branches link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Internal server error for git sub modules without tree object ([#1397](https://github.com/scm-manager/scm-manager/pull/1397))
 - Do not expose subversion commit with id 0 ([#1395](https://github.com/scm-manager/scm-manager/pull/1395))
 - SVN diff with property changes ([#1400](https://github.com/scm-manager/scm-manager/pull/1400))
+- Branches link in repository overview ([#1404](https://github.com/scm-manager/scm-manager/pull/1404))
 
 ## [2.8.0] - 2020-10-27
 ### Added

--- a/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
+++ b/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
@@ -50436,7 +50436,7 @@ exports[`Storyshots RepositoryEntry Avatar EP 1`] = `
         >
           <a
             className="RepositoryEntryLink__PointerEventsLink-sc-1hpqj0w-0 iZuqoP level-item"
-            href="/repo/hitchhiker/heartOfGold/branches"
+            href="/repo/hitchhiker/heartOfGold/branches/"
             onClick={[Function]}
           >
             <i
@@ -50550,7 +50550,7 @@ exports[`Storyshots RepositoryEntry Before Title EP 1`] = `
         >
           <a
             className="RepositoryEntryLink__PointerEventsLink-sc-1hpqj0w-0 iZuqoP level-item"
-            href="/repo/hitchhiker/heartOfGold/branches"
+            href="/repo/hitchhiker/heartOfGold/branches/"
             onClick={[Function]}
           >
             <i
@@ -50661,7 +50661,7 @@ exports[`Storyshots RepositoryEntry Default 1`] = `
         >
           <a
             className="RepositoryEntryLink__PointerEventsLink-sc-1hpqj0w-0 iZuqoP level-item"
-            href="/repo/hitchhiker/heartOfGold/branches"
+            href="/repo/hitchhiker/heartOfGold/branches/"
             onClick={[Function]}
           >
             <i
@@ -50772,7 +50772,7 @@ exports[`Storyshots RepositoryEntry Quick Link EP 1`] = `
         >
           <a
             className="RepositoryEntryLink__PointerEventsLink-sc-1hpqj0w-0 iZuqoP level-item"
-            href="/repo/hitchhiker/heartOfGold/branches"
+            href="/repo/hitchhiker/heartOfGold/branches/"
             onClick={[Function]}
           >
             <i

--- a/scm-ui/ui-components/src/repos/RepositoryEntry.tsx
+++ b/scm-ui/ui-components/src/repos/RepositoryEntry.tsx
@@ -44,7 +44,7 @@ class RepositoryEntry extends React.Component<Props> {
 
   renderBranchesLink = (repository: Repository, repositoryLink: string) => {
     if (repository._links["branches"]) {
-      return <RepositoryEntryLink icon="code-branch" to={repositoryLink + "/branches"} />;
+      return <RepositoryEntryLink icon="code-branch" to={repositoryLink + "/branches/"} />;
     }
     return null;
   };


### PR DESCRIPTION
## Proposed changes

Fixes the branches link in the cardbord view for repositories. Without a trailing '/' further links like 'create' will lead to
illegal links because they will not be appended but will replace the 'branches' part.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [x] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
