### PR TITLE
Bugfix/secure hg hook callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Create _authenticated group on setup ([#1396](https://github.com/scm-manager/scm-manager/pull/1396))
 - The name of the initial git branch can be configured and is set to `main` by default ([#1399](https://github.com/scm-manager/scm-manager/pull/1399))
 
+### Changed
+- Block mercurial push if no hook url could be configured ([#1411](https://github.com/scm-manager/scm-manager/pull/1411))
+
 ### Fixed
 - Internal server error for git sub modules without tree object ([#1397](https://github.com/scm-manager/scm-manager/pull/1397))
 - Do not expose subversion commit with id 0 ([#1395](https://github.com/scm-manager/scm-manager/pull/1395))
@@ -20,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support anonymous file download through rest api for non-browser clients (e.g. curl or postman) when anonymous mode is set to protocol-only ([#1402](https://github.com/scm-manager/scm-manager/pull/1402))
 - SVN diff with property changes ([#1400](https://github.com/scm-manager/scm-manager/pull/1400))
 - Branches link in repository overview ([#1404](https://github.com/scm-manager/scm-manager/pull/1404))
+- Vulnerability in Mercurial hook url auto configuration ([#1411](https://github.com/scm-manager/scm-manager/pull/1411))
 
 ## [2.8.0] - 2020-10-27
 ### Added

--- a/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/HgHookManager.java
+++ b/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/HgHookManager.java
@@ -135,6 +135,10 @@ public class HgHookManager {
     return accessTokenBuilderFactory.create().build();
   }
 
+  // the security issue claims the usage of user controlled data (headers from request),
+  // but this is safe now because we check the url with a challenge and a signature.
+  // see isUrlWorking for more details.
+  @SuppressWarnings("javasecurity:S5144")
   private void buildHookUrl(HttpServletRequest request) {
     if (configuration.isForceBaseUrl()) {
       LOG.debug("create hook url from configured base url because force base url is enabled");

--- a/scm-plugins/scm-hg-plugin/src/main/resources/sonia/scm/python/scmhooks.py
+++ b/scm-plugins/scm-hg-plugin/src/main/resources/sonia/scm/python/scmhooks.py
@@ -122,7 +122,6 @@ def callback(ui, repo, hooktype, node=None):
       abort = callHookUrl(ui, repo, hooktype, node)
     else:
       ui.warn(b"ERROR: scm-manager hooks are disabled, please check your configuration and the scm-manager log for details\n")
-      abort = False
   else:
     ui.warn(b"changeset node is not available")
   return abort

--- a/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/HgHookManagerTest.java
+++ b/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/HgHookManagerTest.java
@@ -1,0 +1,81 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.repository;
+
+import com.google.inject.util.Providers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sonia.scm.config.ScmConfiguration;
+import sonia.scm.net.ahc.AdvancedHttpClient;
+import sonia.scm.security.AccessTokenBuilderFactory;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class HgHookManagerTest {
+
+  @Mock
+  private HttpServletRequest request;
+
+  @Mock
+  private AdvancedHttpClient httpClient;
+
+  @Mock
+  private AccessTokenBuilderFactory accessTokenBuilderFactory;
+
+  private HgHookManager hookManager;
+
+  @BeforeEach
+  void setUpObjectUnderTest() {
+    hookManager = new HgHookManager(
+      new ScmConfiguration(), Providers.of(request), httpClient, accessTokenBuilderFactory
+    );
+  }
+
+  @Test
+  void shouldReturnSignature() {
+    String signature = hookManager.sign("hello");
+    System.out.println(signature);
+    assertThat(signature).isNotEqualTo("hello");
+  }
+
+  @Test
+  void shouldReturnTrueForValidSignature() {
+    String signature = hookManager.sign("challenge");
+    assertThat(hookManager.verify("challenge", signature)).isTrue();
+  }
+
+  @Test
+  void shouldReturnForInvalidSignature() {
+    String signature = hookManager.sign("challenge");
+    assertThat(hookManager.verify("other", signature)).isFalse();
+  }
+
+}

--- a/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/web/HgHookCallbackServletTest.java
+++ b/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/web/HgHookCallbackServletTest.java
@@ -21,33 +21,59 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.web;
 
-import org.junit.Test;
+import com.google.inject.util.Providers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sonia.scm.repository.HgContext;
+import sonia.scm.repository.HgHookManager;
 import sonia.scm.repository.HgRepositoryHandler;
+import sonia.scm.repository.spi.HookEventFacade;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static sonia.scm.web.HgHookCallbackServlet.PARAM_REPOSITORYID;
+import static org.mockito.Mockito.*;
+import static sonia.scm.web.HgHookCallbackServlet.*;
 
-public class HgHookCallbackServletTest {
+@ExtendWith(MockitoExtension.class)
+class HgHookCallbackServletTest {
+
+  @Mock
+  private HttpServletRequest request;
+
+  @Mock
+  private HttpServletResponse response;
+
+  @Mock
+  private HgRepositoryHandler repositoryHandler;
+
+  @Mock
+  private HgHookManager hookManager;
+
+  @Mock
+  private HgContext context;
+
+  private HgHookCallbackServlet servlet;
+
+  @BeforeEach
+  void setUpObjectUnderTest() {
+    servlet = new HgHookCallbackServlet(null, repositoryHandler, hookManager, Providers.of(context));
+  }
 
   @Test
-  public void shouldExtractCorrectRepositoryId() throws ServletException, IOException {
-    HgRepositoryHandler handler = mock(HgRepositoryHandler.class);
-    HgHookCallbackServlet servlet = new HgHookCallbackServlet(null, handler, null, null);
-    HttpServletRequest request = mock(HttpServletRequest.class);
-    HttpServletResponse response = mock(HttpServletResponse.class);
-
+  void shouldExtractCorrectRepositoryId() throws ServletException, IOException {
     when(request.getContextPath()).thenReturn("http://example.com/scm");
     when(request.getRequestURI()).thenReturn("http://example.com/scm/hook/hg/pretxnchangegroup");
     String path = "/tmp/hg/12345";
@@ -56,5 +82,50 @@ public class HgHookCallbackServletTest {
     servlet.doPost(request, response);
 
     verify(response, never()).sendError(anyInt());
+  }
+
+  @Test
+  void shouldReturnWithSignedChallenge() throws IOException, ServletException {
+    when(request.getMethod()).thenReturn("GET");
+    when(request.getParameter(PARAM_PING)).thenReturn("true");
+    when(request.getParameter(PARAM_CHALLENGE)).thenReturn("awesome-challenge");
+    when(hookManager.sign("awesome-challenge")).thenReturn("challenge-awesome");
+
+    StringWriter writer = new StringWriter();
+    when(response.getWriter()).thenReturn(new PrintWriter(writer, true));
+
+    servlet.service(request, response);
+
+    verify(response).setStatus(200);
+    assertThat(writer).hasToString("challenge-awesome");
+  }
+
+  @Test
+  void shouldReturnStatus400WithoutChallenge() throws IOException, ServletException {
+    when(request.getMethod()).thenReturn("GET");
+    when(request.getParameter(PARAM_PING)).thenReturn("true");
+
+    servlet.service(request, response);
+
+    verify(response).setStatus(400);
+  }
+
+  @Test
+  void shouldReturnStatus404OnGetWithoutPingParameter() throws IOException, ServletException {
+    when(request.getMethod()).thenReturn("GET");
+
+    servlet.service(request, response);
+
+    verify(response).setStatus(404);
+  }
+
+  @Test
+  void shouldReturnStatus404OnGetWithNonTruePingParameter() throws IOException, ServletException {
+    when(request.getMethod()).thenReturn("GET");
+    when(request.getParameter(PARAM_PING)).thenReturn("other");
+
+    servlet.service(request, response);
+
+    verify(response).setStatus(404);
   }
 }


### PR DESCRIPTION
## Proposed changes

The [HgHookManager](https://github.com/scm-manager/scm-manager/blob/c2ef568e547a4960dee82c2de07ee306b37d68eb/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/HgHookManager.java#L193) tries to find the URL of the SCM-Manager instance on the first mercurial write request.
This is necessary because it is not always as easy as http://localhost:8080 due to different environments and configurations.
Among other things, the URL is taken from the request headers `Host` or `X-Forwarded-Host`. Theoretically an attacker could send one of these headers with a request to manipulate the HgHookManager to send the ping request to a server of the attacker. If this server responds as expected by the HgHookManager, the SCM Manager sends all Mercurial Hook data to the attacker's server from that point on.

To close the gap the HgHookManager send now a temporary challenge with the ping request and the callback servlets answers with a signature of this challenge. With this answer the HgHookManager is able to verify the signature and can now trust that the instance it SCM-Manager.

Furthermore if the HgHookManager could not find a valid Hook URL, SCM-Manager does not allow any mercurial push anymore. Because otherwise it is possible to bypass security relevant mechanisms e.g: BranchWP).

### Your checklist for this pull request

- [X] PR is well described
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests
- [X] CHANGELOG.md updated

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
