### PR TITLE
Fix missing close of hg diff command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Fixed
+- Missing close of hg diff command ([#1417](https://github.com/scm-manager/scm-manager/pull/1417))
 - Error on repository initialization with least-privilege user ([#1414](https://github.com/scm-manager/scm-manager/pull/1414))
 
 ## [2.9.0] - 2020-11-06

--- a/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/spi/HgDiffCommandTest.java
+++ b/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/spi/HgDiffCommandTest.java
@@ -1,0 +1,78 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.repository.spi;
+
+import org.junit.Test;
+import sonia.scm.repository.api.DiffCommandBuilder;
+import sonia.scm.repository.api.DiffFormat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class HgDiffCommandTest extends AbstractHgCommandTestBase {
+
+  @Test
+  public void shouldCreateDiff() throws IOException {
+    String content = diff(cmdContext, "3049df33fdbbded08b707bac3eccd0f7b453c58b");
+    assertThat(content).contains("+e");
+  }
+
+  @Test
+  public void shouldCreateGitDiff() throws IOException {
+    DiffCommandRequest request = new DiffCommandRequest();
+    request.setRevision("3049df33fdbbded08b707bac3eccd0f7b453c58b");
+    request.setFormat(DiffFormat.GIT);
+
+    String content = diff(cmdContext, request);
+    assertThat(content).contains("git");
+  }
+
+  @Test
+  public void shouldCloseContent() throws IOException {
+    HgCommandContext context = spy(cmdContext);
+    String content = diff(context, "a9bacaf1b7fa0cebfca71fed4e59ed69a6319427");
+    assertThat(content).contains("+b");
+    verify(context).close();
+  }
+
+  private String diff(HgCommandContext context, String revision) throws IOException {
+    DiffCommandRequest request = new DiffCommandRequest();
+    request.setRevision(revision);
+    return diff(context, request);
+  }
+
+  private String diff(HgCommandContext context, DiffCommandRequest request) throws IOException {
+    HgDiffCommand diff = new HgDiffCommand(context);
+    DiffCommandBuilder.OutputStreamConsumer consumer = diff.getDiffResult(request);
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    consumer.accept(baos);
+    return baos.toString("UTF-8");
+  }
+
+}


### PR DESCRIPTION
## Proposed changes

The mercurial diff resource does not close the command context, which leads to an open python process which gets never closed.

### Your checklist for this pull request

- [X] PR is well described
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests
- [X] CHANGELOG.md updated
- [X] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [X] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
