### PR TITLE
Enhance trace api with accepted status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Delete branches directly in the UI ([#1422](https://github.com/scm-manager/scm-manager/pull/1422))
 - Lookup command which provides further repository information ([#1415](https://github.com/scm-manager/scm-manager/pull/1415))
 - Include messages from scm protocol in modification or merge errors ([#1420](https://github.com/scm-manager/scm-manager/pull/1420))
+- Enhance trace api to accepted status codes ([#1430](https://github.com/scm-manager/scm-manager/pull/1430))
 
 ### Fixed
 - Missing close of hg diff command ([#1417](https://github.com/scm-manager/scm-manager/pull/1417))

--- a/scm-core/src/main/java/sonia/scm/net/ahc/BaseHttpRequest.java
+++ b/scm-core/src/main/java/sonia/scm/net/ahc/BaseHttpRequest.java
@@ -258,6 +258,22 @@ public abstract class BaseHttpRequest<T extends BaseHttpRequest>
   }
 
   /**
+   * Sets the response codes which should be traced as successful.
+   *
+   * Example: If 400 is set as {@link #acceptedStatusCodes} then all requests
+   * which get a response with status code 400 will be traced as successful (not failed) request
+   *
+   * @param codes status codes which should be traced as successful
+   * @return request instance
+   *
+   * @since 2.10.0
+   */
+  public T acceptStatusCodes(int... codes) {
+    this.acceptedStatusCodes = codes;
+    return self();
+  }
+
+  /**
    * Disables tracing for the request.
    * This should only be done for internal requests.
    *
@@ -312,6 +328,18 @@ public abstract class BaseHttpRequest<T extends BaseHttpRequest>
    */
   public String getSpanKind() {
     return spanKind;
+  }
+
+
+  /**
+   * Returns the response codes which are accepted as successful by tracer.
+   *
+   * @return codes
+   *
+   * @since 2.10.0
+   */
+  public int[] getAcceptedStatus() {
+    return acceptedStatusCodes;
   }
 
   /**
@@ -434,4 +462,7 @@ public abstract class BaseHttpRequest<T extends BaseHttpRequest>
 
   /** kind of span for trace api */
   private String spanKind = "HTTP Request";
+
+  /** codes which will be marked as successful by tracer */
+  private int[] acceptedStatusCodes = new int[]{};
 }

--- a/scm-webapp/src/main/java/sonia/scm/net/ahc/DefaultAdvancedHttpClient.java
+++ b/scm-webapp/src/main/java/sonia/scm/net/ahc/DefaultAdvancedHttpClient.java
@@ -52,6 +52,7 @@ import java.io.OutputStream;
 import java.net.*;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import java.util.Set;
 
 //~--- JDK imports ------------------------------------------------------------
@@ -206,7 +207,7 @@ public class DefaultAdvancedHttpClient extends AdvancedHttpClient
       try {
         DefaultAdvancedHttpResponse response = doRequest(request);
         span.label("status", response.getStatus());
-        if (!response.isSuccessful()) {
+        if (isFailedRequest(request, response)) {
           span.failed();
         }
         return response;
@@ -217,6 +218,13 @@ public class DefaultAdvancedHttpClient extends AdvancedHttpClient
         throw ex;
       }
     }
+  }
+
+  private boolean isFailedRequest(BaseHttpRequest<?> request, AdvancedHttpResponse responseStatus) {
+    if (Arrays.stream(request.getAcceptedStatus()).anyMatch(code -> code == responseStatus.getStatus())) {
+      return false;
+    }
+     return !responseStatus.isSuccessful();
   }
 
   @Nonnull

--- a/scm-webapp/src/test/java/sonia/scm/net/ahc/DefaultAdvancedHttpClientTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/net/ahc/DefaultAdvancedHttpClientTest.java
@@ -317,6 +317,17 @@ public class DefaultAdvancedHttpClientTest
     verify(tracer, never()).span(anyString());
   }
 
+  @Test
+  public void shouldNotTraceRequestIfUntracedResponseCode() throws IOException {
+    when(connection.getResponseCode()).thenReturn(400);
+
+    new AdvancedHttpRequest(client, HttpMethod.GET, "https://www.scm-manager.org").acceptStatusCodes(400).request();
+    verify(tracer).span("HTTP Request");
+    verify(span).label("status", 400);
+    verify(span, never()).failed();
+    verify(span).close();
+  }
+
 
   //~--- set methods ----------------------------------------------------------
 
@@ -328,7 +339,7 @@ public class DefaultAdvancedHttpClientTest
   public void setUp()
   {
     configuration = new ScmConfiguration();
-    transformers = new HashSet<ContentTransformer>();
+    transformers = new HashSet<>();
     client = new TestingAdvacedHttpClient(configuration, transformers);
     when(tracer.span(anyString())).thenReturn(span);
   }

--- a/scm-webapp/src/test/java/sonia/scm/net/ahc/DefaultAdvancedHttpClientTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/net/ahc/DefaultAdvancedHttpClientTest.java
@@ -318,13 +318,24 @@ public class DefaultAdvancedHttpClientTest
   }
 
   @Test
-  public void shouldNotTraceRequestIfUntracedResponseCode() throws IOException {
+  public void shouldNotTraceRequestIfAcceptedResponseCode() throws IOException {
     when(connection.getResponseCode()).thenReturn(400);
 
     new AdvancedHttpRequest(client, HttpMethod.GET, "https://www.scm-manager.org").acceptStatusCodes(400).request();
     verify(tracer).span("HTTP Request");
     verify(span).label("status", 400);
     verify(span, never()).failed();
+    verify(span).close();
+  }
+
+  @Test
+  public void shouldTraceRequestAsFailedIfAcceptedResponseCodeDoesntMatch() throws IOException {
+    when(connection.getResponseCode()).thenReturn(401);
+
+    new AdvancedHttpRequest(client, HttpMethod.GET, "https://www.scm-manager.org").acceptStatusCodes(400).request();
+    verify(tracer).span("HTTP Request");
+    verify(span).label("status", 401);
+    verify(span).failed();
     verify(span).close();
   }
 


### PR DESCRIPTION
Proposed changes

Enhance trace api to set codes which are accepted as successful. This way requests can be traced as successful even if the response code is 4xx or 5xx.

### Your checklist for this pull request

- [x] PR is well described
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
