### PR TITLE
Fix language detection of files with interpreter parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show the date of the last commit for branches in the frontend ([#1439](https://github.com/scm-manager/scm-manager/pull/1439))
 - Unify and add description to key view across user settings ([#1440](https://github.com/scm-manager/scm-manager/pull/1440))
 
+### Fixed
+- Language detection of files with interpreter parameters e.g.: `#!/usr/bin/make -f` ([#1450](https://github.com/scm-manager/scm-manager/issues/1450))
+
 ## [2.10.1] - 2020-11-24
 ### Fixed
 - Improved logging of failures during plugin installation ([#1442](https://github.com/scm-manager/scm-manager/pull/1442))

--- a/scm-webapp/pom.xml
+++ b/scm-webapp/pom.xml
@@ -315,7 +315,7 @@
     <dependency>
       <groupId>com.github.sdorra</groupId>
       <artifactId>spotter-core</artifactId>
-      <version>3.0.0</version>
+      <version>3.0.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Proposed changes

Update spotter to version 3.0.1 in order to fix language detection of files with a shebang which contains a parameter e.g. /usr/bin/make -f

### Your checklist for this pull request

- [X] PR is well described
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [X] CHANGELOG.md updated
- [X] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [X] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
