### PR TITLE
Harmonize logging string for repositories

### DIFF
--- a/scm-core/src/main/java/sonia/scm/repository/PreProcessorUtil.java
+++ b/scm-core/src/main/java/sonia/scm/repository/PreProcessorUtil.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.repository;
 
 //~--- non-JDK imports --------------------------------------------------------
@@ -132,12 +132,12 @@ public class PreProcessorUtil
    */
   public void prepareForReturn(Repository repository, Changeset changeset)
   {
-    logger.trace("prepare changeset {} of repository {} for return", changeset.getId(), repository.getName());
+    logger.trace("prepare changeset {} of repository {} for return", changeset.getId(), repository);
     handlePreProcess(repository, changeset, changesetPreProcessorFactorySet, changesetPreProcessorSet);
   }
 
   public void prepareForReturn(Repository repository, Modifications modifications) {
-    logger.trace("prepare modifications {} of repository {} for return", modifications, repository.getName());
+    logger.trace("prepare modifications {} of repository {} for return", modifications, repository);
     handlePreProcess(repository, modifications, modificationsPreProcessorFactorySet, modificationsPreProcessorSet);
   }
 
@@ -152,7 +152,7 @@ public class PreProcessorUtil
   {
     if (logger.isTraceEnabled())
     {
-      logger.trace("prepare browser result of repository {} for return", repository.getName());
+      logger.trace("prepare browser result of repository {} for return", repository);
     }
 
     PreProcessorHandler<FileObject> handler = new PreProcessorHandler<>(fileObjectPreProcessorFactorySet, fileObjectPreProcessorSet, repository);

--- a/scm-core/src/main/java/sonia/scm/repository/Repository.java
+++ b/scm-core/src/main/java/sonia/scm/repository/Repository.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.repository;
 
 import com.github.sdorra.ssp.PermissionObject;
@@ -352,6 +352,16 @@ public class Repository extends BasicPropertiesAware implements ModelObject, Per
 
   @Override
   public String toString() {
+    String idString = id == null ? "no-id" : id;
+    if (name == null) {
+      return "unnamed repository (" + idString + ")";
+    } else if (namespace == null) {
+      return "no-namespace/" + name + " (" + idString + ")";
+    }
+    return namespace + "/" + name + " (" + id + ")";
+  }
+
+  public String toFullString() {
     return MoreObjects.toStringHelper(this)
       .add("id", id)
       .add("namespace", namespace)

--- a/scm-core/src/main/java/sonia/scm/repository/api/BranchesCommandBuilder.java
+++ b/scm-core/src/main/java/sonia/scm/repository/api/BranchesCommandBuilder.java
@@ -116,7 +116,7 @@ public final class BranchesCommandBuilder
       {
         if (logger.isDebugEnabled())
         {
-          logger.debug("get branches for repository {}", repository.getName());
+          logger.debug("get branches for repository {}", repository);
         }
 
         branches = getBranchesFromCommand();

--- a/scm-core/src/main/java/sonia/scm/repository/api/BundleCommandBuilder.java
+++ b/scm-core/src/main/java/sonia/scm/repository/api/BundleCommandBuilder.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.repository.api;
 
 //~--- non-JDK imports --------------------------------------------------------
@@ -112,7 +112,7 @@ public final class BundleCommandBuilder
   {
     checkNotNull(outputStream, "output stream is required");
 
-    logger.info("bundle {} to output stream", repository.getId());
+    logger.info("bundle {} to output stream", repository);
 
     return bundleCommand.bundle(
       new BundleCommandRequest(asByteSink(outputStream)));

--- a/scm-core/src/main/java/sonia/scm/repository/api/PushCommandBuilder.java
+++ b/scm-core/src/main/java/sonia/scm/repository/api/PushCommandBuilder.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.repository.api;
 
 //~--- non-JDK imports --------------------------------------------------------
@@ -85,7 +85,7 @@ public final class PushCommandBuilder
     subject.isPermitted(RepositoryPermissions.push(remoteRepository).asShiroString());
     //J+
 
-    logger.info("push changes to repository {}", remoteRepository.getId());
+    logger.info("push changes to repository {}", remoteRepository);
 
     request.reset();
     request.setRemoteRepository(remoteRepository);

--- a/scm-core/src/main/java/sonia/scm/repository/api/RepositoryService.java
+++ b/scm-core/src/main/java/sonia/scm/repository/api/RepositoryService.java
@@ -303,7 +303,7 @@ public final class RepositoryService implements Closeable {
    *                                      by the implementation of the repository service provider.
    */
   public ModificationsCommandBuilder getModificationsCommand() {
-    LOG.debug("create modifications command for repository {}", repository.getNamespaceAndName());
+    LOG.debug("create modifications command for repository {}", repository);
     return new ModificationsCommandBuilder(provider.getModificationsCommand(),repository, cacheManager.getCache(ModificationsCommandBuilder.CACHE_NAME), preProcessorUtil);
   }
 

--- a/scm-core/src/main/java/sonia/scm/repository/api/TagsCommandBuilder.java
+++ b/scm-core/src/main/java/sonia/scm/repository/api/TagsCommandBuilder.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.repository.api;
 
 //~--- non-JDK imports --------------------------------------------------------
@@ -119,7 +119,7 @@ public final class TagsCommandBuilder
       {
         if (logger.isDebugEnabled())
         {
-          logger.debug("get tags for repository {}", repository.getName());
+          logger.debug("get tags for repository {}", repository);
         }
 
         tags = getTagsFromCommand();

--- a/scm-core/src/main/java/sonia/scm/repository/api/UnbundleCommandBuilder.java
+++ b/scm-core/src/main/java/sonia/scm/repository/api/UnbundleCommandBuilder.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.repository.api;
 
 //~--- non-JDK imports --------------------------------------------------------
@@ -95,7 +95,7 @@ public final class UnbundleCommandBuilder
     UnbundleCommandRequest request =
       createRequest(Files.asByteSource(inputFile));
 
-    logger.info("unbundle archive {} at {}", inputFile, repository.getId());
+    logger.info("unbundle archive {} at {}", inputFile, repository);
 
     return unbundleCommand.unbundle(request);
   }

--- a/scm-core/src/main/java/sonia/scm/repository/work/SimpleCachingWorkingCopyPool.java
+++ b/scm-core/src/main/java/sonia/scm/repository/work/SimpleCachingWorkingCopyPool.java
@@ -84,10 +84,10 @@ public class SimpleCachingWorkingCopyPool implements WorkingCopyPool {
       Stopwatch stopwatch = Stopwatch.createStarted();
       try {
         WorkingCopy<R, W> reclaimed = workingCopyContext.reclaim(existingWorkdir);
-        LOG.debug("reclaimed workdir for {} in path {} in {}", workingCopyContext.getScmRepository().getNamespaceAndName(), existingWorkdir, stopwatch.stop());
+        LOG.debug("reclaimed workdir for {} in path {} in {}", workingCopyContext.getScmRepository(), existingWorkdir, stopwatch.stop());
         return reclaimed;
       } catch (SimpleWorkingCopyFactory.ReclaimFailedException e) {
-        LOG.debug("failed to reclaim workdir for {} in path {} in {}", workingCopyContext.getScmRepository().getNamespaceAndName(), existingWorkdir, stopwatch.stop(), e);
+        LOG.debug("failed to reclaim workdir for {} in path {} in {}", workingCopyContext.getScmRepository(), existingWorkdir, stopwatch.stop(), e);
         deleteWorkdir(existingWorkdir);
       }
     }
@@ -98,7 +98,7 @@ public class SimpleCachingWorkingCopyPool implements WorkingCopyPool {
     Stopwatch stopwatch = Stopwatch.createStarted();
     File newWorkdir = workdirProvider.createNewWorkdir();
     WorkingCopy<R, W> parentAndClone = workingCopyContext.initialize(newWorkdir);
-    LOG.debug("initialized new workdir for {} in path {} in {}", workingCopyContext.getScmRepository().getNamespaceAndName(), newWorkdir, stopwatch.stop());
+    LOG.debug("initialized new workdir for {} in path {} in {}", workingCopyContext.getScmRepository(), newWorkdir, stopwatch.stop());
     return parentAndClone;
   }
 

--- a/scm-dao-xml/src/main/java/sonia/scm/repository/xml/MetadataStore.java
+++ b/scm-dao-xml/src/main/java/sonia/scm/repository/xml/MetadataStore.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.repository.xml;
 
 import org.slf4j.Logger;
@@ -64,7 +64,7 @@ public class MetadataStore implements UpdateStepRepositoryMetadataAccess<Path> {
   }
 
   void write(Path path, Repository repository) {
-    LOG.trace("write repository metadata of {} to {}", repository.getNamespaceAndName(), path);
+    LOG.trace("write repository metadata of {} to {}", repository, path);
     try {
       Marshaller marshaller = jaxbContext.createMarshaller();
       marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/api/v2/resources/GitRepositoryConfigResource.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/api/v2/resources/GitRepositoryConfigResource.java
@@ -151,7 +151,7 @@ public class GitRepositoryConfigResource {
     ConfigurationStore<GitRepositoryConfig> repositoryConfigStore = getStore(repository);
     GitRepositoryConfig config = repositoryConfigMapper.map(dto);
     repositoryConfigStore.set(config);
-    LOG.info("git default branch of repository {} has changed, sending clear cache event", repository.getNamespaceAndName());
+    LOG.info("git default branch of repository {} has changed, sending clear cache event", repository);
     return Response.noContent().build();
   }
 

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/GitGcTask.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/GitGcTask.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.repository;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -38,16 +38,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Executes git gc on every git repository. Statistics of the gc process are logged to the info level. The task is 
+ * Executes git gc on every git repository. Statistics of the gc process are logged to the info level. The task is
  * disabled by default and must be enabled through the global git configuration.
- * 
+ *
  * @author Sebastian Sdorra
  * @since 1.47
  */
 public class GitGcTask implements Runnable {
 
   private static final String SP = System.getProperty("line.seperator", "\n");
-  
+
   private static final Logger logger = LoggerFactory.getLogger(GitGcTask.class);
 
   private final RepositoryManager repositoryManager;
@@ -74,19 +74,19 @@ public class GitGcTask implements Runnable {
     {
       if (repository.isValid() && repository.isHealthy())
       {
-        logger.info("start git gc for repository {}", repository.getNamespaceAndName());
+        logger.info("start git gc for repository {}", repository);
         Stopwatch sw = Stopwatch.createStarted();
         gc(repository);
-        logger.debug("gc of repository {} has finished after {}", repository.getNamespaceAndName(), sw.stop());
-      } 
-      else 
-      {
-        logger.debug("skip non valid/healthy repository {}", repository.getNamespaceAndName());
+        logger.debug("gc of repository {} has finished after {}", repository, sw.stop());
       }
-    } 
-    else 
+      else
+      {
+        logger.debug("skip non valid/healthy repository {}", repository);
+      }
+    }
+    else
     {
-      logger.trace("skip non git repository {}", repository.getNamespaceAndName());
+      logger.trace("skip non git repository {}", repository);
     }
   }
 
@@ -123,31 +123,31 @@ public class GitGcTask implements Runnable {
       // jgit returns the statistics after gc has finished
       statistics(repository, gcc);
       execute(repository, gcc);
-    } 
-    catch (IOException ex) 
+    }
+    catch (IOException ex)
     {
       logger.warn("failed to open git repository", ex);
-    } 
+    }
     catch (GitAPIException ex)
     {
       logger.warn("failed running git gc command", ex);
     }
-    finally 
+    finally
     {
       if (git != null){
         git.close();
       }
     }
   }
-  
+
   /**
    * Opens the git repository. This method is only visible for testing purposes.
-   * 
+   *
    * @param file repository directory
-   * 
+   *
    * @return git for repository
-   * 
-   * @throws IOException 
+   *
+   * @throws IOException
    */
   @VisibleForTesting
   protected Git open(File file) throws IOException {

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitBrowseCommand.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitBrowseCommand.java
@@ -134,7 +134,7 @@ public class GitBrowseCommand extends AbstractGitCommand
       browserResult = new BrowserResult(revId.getName(), request.getRevision(), getEntry());
       return browserResult;
     } else {
-      logger.warn("could not find head of repository {}, empty?", repository.getNamespaceAndName());
+      logger.warn("could not find head of repository {}, empty?", repository);
       return new BrowserResult(Constants.HEAD, request.getRevision(), createEmptyRoot());
     }
   }
@@ -209,7 +209,7 @@ public class GitBrowseCommand extends AbstractGitCommand
 
   private void updateCache() {
     request.updateCache(browserResult);
-    logger.info("updated browser result for repository {}", repository.getNamespaceAndName());
+    logger.info("updated browser result for repository {}", repository);
   }
 
   private FileObject getEntry() throws IOException {
@@ -330,7 +330,7 @@ public class GitBrowseCommand extends AbstractGitCommand
   private Map<String, SubRepository> getSubRepositories()
     throws IOException {
 
-    logger.debug("read submodules of {} at {}", repository.getName(), revId);
+    logger.debug("read submodules of {} at {}", repository, revId);
 
     try ( ByteArrayOutputStream baos = new ByteArrayOutputStream() ) {
       new GitCatCommand(context, lfsBlobStoreFactory).getContent(repo, revId, PATH_MODULES, baos);
@@ -375,7 +375,7 @@ public class GitBrowseCommand extends AbstractGitCommand
     String oid = lfsPointer.getOid().getName();
     Blob blob = lfsBlobStore.get(oid);
     if (blob == null) {
-      logger.error("lfs blob for lob id {} not found in lfs store of repository {}", oid, repository.getNamespaceAndName());
+      logger.error("lfs blob for lob id {} not found in lfs store of repository {}", oid, repository);
       file.setLength(null);
     } else {
       file.setLength(blob.getSize());

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitCatCommand.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitCatCommand.java
@@ -142,7 +142,7 @@ public class GitCatCommand extends AbstractGitCommand implements CatCommand {
     String oid = lfsPointer.getOid().getName();
     Blob blob = lfsBlobStore.get(oid);
     if (blob == null) {
-      logger.error("lfs blob for lob id {} not found in lfs store of repository {}", oid, repository.getNamespaceAndName());
+      logger.error("lfs blob for lob id {} not found in lfs store of repository {}", oid, repository);
       throw notFound(entity("LFS", oid).in(repository));
     }
     GitUtil.release(revWalk);

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitPullCommand.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitPullCommand.java
@@ -193,7 +193,7 @@ public class GitPullCommand extends AbstractGitPushOrPullCommand
 
   private PullResponse pullFromUrl(PullCommandRequest request)
     throws IOException {
-    logger.debug("pull changes from {} to {}", request.getRemoteUrl(), repository.getId());
+    logger.debug("pull changes from {} to {}", request.getRemoteUrl(), repository);
 
     PullResponse response;
     Git git = Git.wrap(open());

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitPushCommand.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitPushCommand.java
@@ -80,7 +80,7 @@ public class GitPushCommand extends AbstractGitPushOrPullCommand
   {
     String remoteUrl = getRemoteUrl(request);
 
-    logger.debug("push changes from {} to {}", repository.getId(), remoteUrl);
+    logger.debug("push changes from {} to {}", repository, remoteUrl);
 
     return new PushResponse(push(open(), remoteUrl));
   }

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitWorkingCopyInitializer.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitWorkingCopyInitializer.java
@@ -54,7 +54,7 @@ class GitWorkingCopyInitializer {
   }
 
   public ParentAndClone<Repository, Repository> initialize(File target, String initialBranch) {
-    LOG.trace("clone repository {}", context.getRepository().getId());
+    LOG.trace("clone repository {}", context.getRepository());
     Stopwatch stopwatch = Stopwatch.createStarted();
     try {
       Repository clone = Git.cloneRepository()
@@ -78,7 +78,7 @@ class GitWorkingCopyInitializer {
     } catch (GitAPIException | IOException e) {
       throw new InternalRepositoryException(context.getRepository(), "could not clone working copy of repository", e);
     } finally {
-      LOG.trace("took {} to clone repository {}", stopwatch.stop(), context.getRepository().getId());
+      LOG.trace("took {} to clone repository {}", stopwatch.stop(), context.getRepository());
     }
   }
 }

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitWorkingCopyReclaimer.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitWorkingCopyReclaimer.java
@@ -49,7 +49,7 @@ class GitWorkingCopyReclaimer {
   }
 
   public ParentAndClone<Repository, Repository> reclaim(File target, String initialBranch) throws SimpleWorkingCopyFactory.ReclaimFailedException {
-    LOG.trace("reclaim repository {}", context.getRepository().getId());
+    LOG.trace("reclaim repository {}", context.getRepository());
     Stopwatch stopwatch = Stopwatch.createStarted();
     Repository repo = openTarget(target);
     try (Git git = Git.open(target)) {
@@ -63,7 +63,7 @@ class GitWorkingCopyReclaimer {
     } catch (GitAPIException | IOException e) {
       throw new SimpleWorkingCopyFactory.ReclaimFailedException(e);
     } finally {
-      LOG.trace("took {} to reclaim repository {}", stopwatch.stop(), context.getRepository().getId());
+      LOG.trace("took {} to reclaim repository {}", stopwatch.stop(), context.getRepository());
     }
   }
 

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/web/lfs/ScmBlobLfsRepository.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/web/lfs/ScmBlobLfsRepository.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.web.lfs;
 
 import org.eclipse.jgit.lfs.lib.AnyLongObjectId;
@@ -79,7 +79,7 @@ public class ScmBlobLfsRepository implements LargeFileRepository {
   @Override
   public ExpiringAction getDownloadAction(AnyLongObjectId id) {
     if (accessToken == null) {
-      LOG.trace("create access token to download lfs object {} from repository {}", id, repository.getNamespaceAndName());
+      LOG.trace("create access token to download lfs object {} from repository {}", id, repository);
       accessToken = tokenFactory.createReadAccessToken(repository);
     }
     return getAction(id, accessToken);
@@ -88,7 +88,7 @@ public class ScmBlobLfsRepository implements LargeFileRepository {
   @Override
   public ExpiringAction getUploadAction(AnyLongObjectId id, long size) {
     if (accessToken == null) {
-      LOG.trace("create access token to upload lfs object {} to repository {}", id, repository.getNamespaceAndName());
+      LOG.trace("create access token to upload lfs object {} to repository {}", id, repository);
       accessToken = tokenFactory.createWriteAccessToken(repository);
     }
     return getAction(id, accessToken);

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/web/lfs/servlet/LfsServletFactory.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/web/lfs/servlet/LfsServletFactory.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.web.lfs.servlet;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -71,7 +71,7 @@ public class LfsServletFactory {
    * @return The {@link LfsProtocolServlet} to provide the LFS Batch API for a SCM Repository.
    */
   public LfsProtocolServlet createProtocolServletFor(Repository repository, HttpServletRequest request) {
-    LOG.trace("create lfs protocol servlet for repository {}", repository.getNamespaceAndName());
+    LOG.trace("create lfs protocol servlet for repository {}", repository);
     BlobStore blobStore = lfsBlobStoreFactory.getLfsBlobStore(repository);
     String baseUri = buildBaseUri(repository, request);
 
@@ -87,7 +87,7 @@ public class LfsServletFactory {
    * @return The {@link FileLfsServlet} to provide the LFS Upload / Download API for a SCM Repository.
    */
   public HttpServlet createFileLfsServletFor(Repository repository, HttpServletRequest request) {
-    LOG.trace("create lfs file servlet for repository {}", repository.getNamespaceAndName());
+    LOG.trace("create lfs file servlet for repository {}", repository);
     return new ScmFileTransferServlet(lfsBlobStoreFactory.getLfsBlobStore(repository));
   }
 

--- a/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/spi/HgBranchCommand.java
+++ b/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/spi/HgBranchCommand.java
@@ -69,7 +69,7 @@ public class HgBranchCommand extends AbstractWorkingCopyCommand implements Branc
     try (WorkingCopy<com.aragost.javahg.Repository, com.aragost.javahg.Repository> workingCopy = workingCopyFactory.createWorkingCopy(getContext(), branchName)) {
       User currentUser = SecurityUtils.getSubject().getPrincipals().oneByType(User.class);
 
-      LOG.debug("Closing branch '{}' in repository {}", branchName, getRepository().getNamespaceAndName());
+      LOG.debug("Closing branch '{}' in repository {}", branchName, getRepository());
 
       com.aragost.javahg.commands.CommitCommand
         .on(workingCopy.getWorkingRepository())

--- a/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/spi/HgPullCommand.java
+++ b/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/spi/HgPullCommand.java
@@ -58,7 +58,7 @@ public class HgPullCommand extends AbstractHgPushOrPullCommand implements PullCo
     throws IOException {
     String url = getRemoteUrl(request);
 
-    LOG.debug("pull changes from {} to {}", url, getContext().getScmRepository().getId());
+    LOG.debug("pull changes from {} to {}", url, getContext().getScmRepository());
 
     List<Changeset> result;
 

--- a/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/spi/HgPushCommand.java
+++ b/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/spi/HgPushCommand.java
@@ -74,7 +74,7 @@ public class HgPushCommand extends AbstractHgPushOrPullCommand
   {
     String url = getRemoteUrl(request);
 
-    logger.debug("push changes from {} to {}", getRepository().getId(), url);
+    logger.debug("push changes from {} to {}", getRepository(), url);
 
     List<Changeset> result = Collections.EMPTY_LIST;
 

--- a/scm-plugins/scm-svn-plugin/src/main/java/sonia/scm/repository/spi/SvnBrowseCommand.java
+++ b/scm-plugins/scm-svn-plugin/src/main/java/sonia/scm/repository/spi/SvnBrowseCommand.java
@@ -77,7 +77,7 @@ public class SvnBrowseCommand extends AbstractSvnCommand
     long revisionNumber = SvnUtil.getRevisionNumber(request.getRevision(), repository);
 
     if (logger.isDebugEnabled()) {
-      logger.debug("browser repository {} in path \"{}\" at revision {}", repository.getName(), path, revisionNumber);
+      logger.debug("browser repository {} in path \"{}\" at revision {}", repository, path, revisionNumber);
     }
 
     BrowserResult result = null;

--- a/scm-webapp/src/main/java/sonia/scm/debug/DebugHook.java
+++ b/scm-webapp/src/main/java/sonia/scm/debug/DebugHook.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.debug;
 
 import com.github.legman.ReferenceType;
@@ -38,7 +38,7 @@ import javax.inject.Inject;
 
 /**
  * {@link PostReceiveRepositoryHookEvent} which stores receives data and passes it to the {@link DebugService}.
- * 
+ *
  * @author Sebastian Sdorra
  */
 @EagerSingleton
@@ -48,12 +48,12 @@ public final class DebugHook
    * the logger for DebugHook
    */
   private static final Logger LOG = LoggerFactory.getLogger(DebugHook.class);
-  
+
   private final DebugService debugService;
 
   /**
    * Constructs a new instance.
-   * 
+   *
    * @param debugService debug service
    */
   @Inject
@@ -61,23 +61,23 @@ public final class DebugHook
   {
     this.debugService = debugService;
   }
-  
+
   /**
-   * Processes the received {@link PostReceiveRepositoryHookEvent} and transforms it to a {@link DebugHookData} and 
+   * Processes the received {@link PostReceiveRepositoryHookEvent} and transforms it to a {@link DebugHookData} and
    * passes it to the {@link DebugService}.
-   * 
+   *
    * @param event received event
    */
   @Subscribe(referenceType = ReferenceType.STRONG)
   public void processEvent(PostReceiveRepositoryHookEvent event){
-    LOG.trace("store changeset ids from repository", event.getRepository().getId());
-    
+    LOG.trace("store changeset ids from repository {}", event.getRepository());
+
     debugService.put(
       event.getRepository().getNamespaceAndName(),
       new DebugHookData(Collections2.transform(
         event.getContext().getChangesetProvider().getChangesetList(), IDEXTRACTOR)
       ));
   }
-  
+
   private static final Function<Changeset, String> IDEXTRACTOR = (Changeset changeset) -> changeset.getId();
 }

--- a/scm-webapp/src/main/java/sonia/scm/repository/DefaultRepositoryManager.java
+++ b/scm-webapp/src/main/java/sonia/scm/repository/DefaultRepositoryManager.java
@@ -139,7 +139,7 @@ public class DefaultRepositoryManager extends AbstractRepositoryManager {
     repository.setId(keyGenerator.createKey());
     repository.setNamespace(namespaceStrategyProvider.get().createNamespace(repository));
 
-    logger.info("create repository {}/{} of type {} in namespace {}", repository.getNamespace(), repository.getName(), repository.getType(), repository.getNamespace());
+    logger.info("create repository {} of type {}", repository, repository.getType());
 
     return managerDaoAdapter.create(
       repository,
@@ -175,7 +175,7 @@ public class DefaultRepositoryManager extends AbstractRepositoryManager {
 
   @Override
   public void delete(Repository repository) {
-    logger.info("delete repository {}/{} of type {}", repository.getNamespace(), repository.getName(), repository.getType());
+    logger.info("delete repository {} of type {}", repository, repository.getType());
     managerDaoAdapter.delete(
       repository,
       () -> RepositoryPermissions.delete(repository),
@@ -201,7 +201,7 @@ public class DefaultRepositoryManager extends AbstractRepositoryManager {
 
   @Override
   public void modify(Repository repository) {
-    logger.info("modify repository {}/{} of type {}", repository.getNamespace(), repository.getName(), repository.getType());
+    logger.info("modify repository {} of type {}", repository, repository.getType());
 
     managerDaoAdapter.modify(
       repository,

--- a/scm-webapp/src/main/java/sonia/scm/repository/HealthChecker.java
+++ b/scm-webapp/src/main/java/sonia/scm/repository/HealthChecker.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.repository;
 
 import com.github.sdorra.ssp.PermissionActionCheck;
@@ -84,32 +84,32 @@ public final class HealthChecker {
       } else {
         logger.debug(
           "no permissions to execute health check for repository {}",
-          repository.getId());
+          repository);
       }
     }
   }
 
   private void doCheck(Repository repository){
-    logger.info("start health check for repository {}", repository.getName());
+    logger.info("start health check for repository {}", repository);
 
     HealthCheckResult result = HealthCheckResult.healthy();
 
     for (HealthCheck check : checks) {
       logger.trace("execute health check {} for repository {}",
-        check.getClass(), repository.getName());
+        check.getClass(), repository);
       result = result.merge(check.check(repository));
     }
 
     if (result.isUnhealthy()) {
-      logger.warn("repository {} is unhealthy: {}", repository.getName(),
+      logger.warn("repository {} is unhealthy: {}", repository,
         result);
     } else {
-      logger.info("repository {} is healthy", repository.getName());
+      logger.info("repository {} is healthy", repository);
     }
 
     if (!(repository.isHealthy() && result.isHealthy())) {
       logger.trace("store health check results for repository {}",
-        repository.getName());
+        repository);
       repository.setHealthCheckFailures(
         ImmutableList.copyOf(result.getFailures()));
       repositoryManager.modify(repository);

--- a/scm-webapp/src/main/java/sonia/scm/repository/RepositoryInitializer.java
+++ b/scm-webapp/src/main/java/sonia/scm/repository/RepositoryInitializer.java
@@ -70,7 +70,7 @@ public class RepositoryInitializer {
 
       modifyCommandBuilder.setCommitMessage("initialize repository");
       String revision = modifyCommandBuilder.execute();
-      LOG.info("initialized repository {} as revision {}", repository.getNamespaceAndName(), revision);
+      LOG.info("initialized repository {} as revision {}", repository, revision);
 
     } catch (IOException e) {
       throw new InternalRepositoryException(repository, "failed to initialize repository", e);

--- a/scm-webapp/src/main/java/sonia/scm/security/AuthorizationChangedEventProducer.java
+++ b/scm-webapp/src/main/java/sonia/scm/security/AuthorizationChangedEventProducer.java
@@ -162,18 +162,17 @@ public class AuthorizationChangedEventProducer {
     Repository repository = event.getItem();
     if (isAuthorizationDataModified(repository.getPermissions(), event.getItemBeforeModification().getPermissions())) {
       logger.debug(
-        "fire authorization changed event, because the permissions of repository {}/{} have changed", repository.getNamespace(), repository.getName()
+        "fire authorization changed event, because the permissions of repository {} have changed", repository
       );
       fireEventForEveryUser();
     } else if (!event.getItem().getNamespace().equals(event.getItemBeforeModification().getNamespace())) {
       logger.debug(
-        "fire authorization changed event, because the namespace of repository {}/{} has changed", repository.getNamespace(), repository.getName()
+        "fire authorization changed event, because the namespace of repository {} has changed", repository
       );
       fireEventForEveryUser();
     } else {
       logger.debug(
-        "authorization changed event is not fired, because non relevant field of repository {}/{} has changed",
-        repository.getNamespace(), repository.getName()
+        "authorization changed event is not fired, because non relevant field of repository {} has changed", repository
       );
     }
   }

--- a/scm-webapp/src/main/java/sonia/scm/security/DefaultAuthorizationCollector.java
+++ b/scm-webapp/src/main/java/sonia/scm/security/DefaultAuthorizationCollector.java
@@ -208,7 +208,7 @@ public class DefaultAuthorizationCollector implements AuthorizationCollector
 
     if (!hasPermission && logger.isTraceEnabled())
     {
-      logger.trace("no permission for user {} defined at repository {}", user.getName(), repository.getNamespaceAndName());
+      logger.trace("no permission for user {} defined at repository {}", user.getName(), repository);
     }
   }
 

--- a/scm-webapp/src/main/java/sonia/scm/update/repository/PublicFlagUpdateStep.java
+++ b/scm-webapp/src/main/java/sonia/scm/update/repository/PublicFlagUpdateStep.java
@@ -90,7 +90,7 @@ public class PublicFlagUpdateStep implements UpdateStep {
       .forEach(v1Repository -> {
         Repository v2Repository = repositoryDAO.get(v1Repository.getId());
         if (v2Repository != null) {
-          LOG.info("Add RepositoryRole 'READ' to _anonymous user for repository: {} - {}/{}", v2Repository.getId(), v2Repository.getNamespace(), v2Repository.getName());
+          LOG.info("Add RepositoryRole 'READ' to _anonymous user for repository: {}", v2Repository);
           v2Repository.addPermission(new RepositoryPermission(v2AnonymousUser.getId(), "READ", false));
           repositoryDAO.modify(v2Repository);
         } else {

--- a/scm-webapp/src/main/java/sonia/scm/update/repository/XmlRepositoryV1UpdateStep.java
+++ b/scm-webapp/src/main/java/sonia/scm/update/repository/XmlRepositoryV1UpdateStep.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.update.repository;
 
 import com.google.inject.Injector;
@@ -175,7 +175,7 @@ public class XmlRepositoryV1UpdateStep implements CoreUpdateStep {
           v1Repository.getContact(),
           v1Repository.getDescription(),
           createPermissions(v1Repository));
-        LOG.info("creating new repository {} with id {} from old repository {} in directory {}", repository.getNamespaceAndName(), repository.getId(), v1Repository.getName(), newPath);
+        LOG.info("creating new repository {} from old repository {} in directory {}", repository, v1Repository.getName(), newPath);
         repositoryDao.add(repository, newPath);
         propertyStore.put(v1Repository.getId(), v1Repository.getProperties());
       }


### PR DESCRIPTION
## Proposed changes

Harmonizes the representation of repositories in log statements. The `toString()` method in the class `Repository` is changed, so that the repository can be used directly instead of `getNamespaceAndName()` or other handmade logs.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
