### PR TITLE
Fix initialization bug if master set as default branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Initialization of new git repository with master set as default branch ([#1467](https://github.com/scm-manager/scm-manager/issues/1467) and [#1470](https://github.com/scm-manager/scm-manager/pull/1470))
+
 ## [2.11.0] - 2020-12-04
 
 ### Added

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitModifyCommand.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitModifyCommand.java
@@ -113,11 +113,17 @@ public class GitModifyCommand extends AbstractGitCommand implements ModifyComman
       String branch = StringUtils.isNotBlank(request.getBranch()) ? request.getBranch() : context.getGlobalConfig().getDefaultBranch();
       if (StringUtils.isNotBlank(branch)) {
         try {
-          getClone().checkout().setName(branch).setCreateBranch(true).call();
-          setBranchInConfig(branch);
-        } catch (GitAPIException e) {
+          createBranchIfNotThere(branch);
+        } catch (GitAPIException | IOException e) {
           throw new InternalRepositoryException(repository, "could not create default branch for initial commit", e);
         }
+      }
+    }
+
+    private void createBranchIfNotThere(String branch) throws IOException, GitAPIException {
+      if (!branch.equals(getClone().getRepository().getBranch())) {
+        getClone().checkout().setName(branch).setCreateBranch(true).call();
+        setBranchInConfig(branch);
       }
     }
 

--- a/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/GitModifyCommand_withEmptyRepositoryTest.java
+++ b/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/GitModifyCommand_withEmptyRepositoryTest.java
@@ -38,6 +38,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SuppressWarnings("java:S5976") // using parameterized tests in this class is not useful because we would miss the descriptions
 public class GitModifyCommand_withEmptyRepositoryTest extends GitModifyCommandTestBase {
 
   @Test
@@ -61,6 +62,18 @@ public class GitModifyCommand_withEmptyRepositoryTest extends GitModifyCommandTe
   @Test
   public void shouldCreateCommitOnMasterByDefault() throws IOException, GitAPIException {
     createContext().getGlobalConfig().setDefaultBranch("");
+
+    executeModifyCommand();
+
+    try (Git git = new Git(createContext().open())) {
+      List<Ref> branches = git.branchList().call();
+      assertThat(branches).extracting("name").containsExactly("refs/heads/master");
+    }
+  }
+
+  @Test
+  public void shouldCreateCommitOnMasterIfSetExplicitly() throws IOException, GitAPIException {
+    createContext().getGlobalConfig().setDefaultBranch("master");
 
     executeModifyCommand();
 


### PR DESCRIPTION
## Proposed changes

Fixes #1467 where initialization fails when master is set as default branch.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [ ] CHANGELOG.md updated
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
