### PR TITLE
Downgrade Jenkins JDK version to Java 8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -204,7 +204,7 @@ String developmentBranch
 String mainBranch
 
 Maven setupMavenBuild() {
-  MavenWrapperInDocker mvn = new MavenWrapperInDocker(this, "scmmanager/java-build:11.0.9_11.1")
+  MavenWrapperInDocker mvn = new MavenWrapperInDocker(this, "scmmanager/java-build:8u275-b01")
   mvn.enableDockerHost = true
 
   // disable logging durring the build

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -22,7 +22,7 @@
 # SOFTWARE.
 #
 
-FROM adoptopenjdk/openjdk11:x86_64-debian-jdk-11.0.9_11.1
+FROM adoptopenjdk/openjdk8:x86_64-debian-jdk8u275-b01
 
 ENV DOCKER_VERSION=19.03.8 \
     DOCKER_CHANNEL=stable \

--- a/build/Makefile
+++ b/build/Makefile
@@ -1,4 +1,4 @@
-VERSION:=11.0.9_11.1
+VERSION:=8u275-b01
 
 .PHONY:build
 build:

--- a/scm-webapp/src/test/java/sonia/scm/api/v2/resources/BranchRootResourceTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/api/v2/resources/BranchRootResourceTest.java
@@ -275,7 +275,7 @@ public class BranchRootResourceTest extends RepositoryTestBase {
 
   @Test
   public void shouldNotDeleteBranchIfNotPermitted() throws IOException, URISyntaxException {
-    doThrow(AuthorizationException.class).when(subject).checkPermission("repository:modify:repoId");
+    doThrow(AuthorizationException.class).when(subject).checkPermission("repository:push:repoId");
     when(branchesCommandBuilder.getBranches()).thenReturn(new Branches(Branch.normalBranch("suspicious", "0")));
 
     MockHttpRequest request = MockHttpRequest

--- a/scm-webapp/src/test/java/sonia/scm/api/v2/resources/TagRootResourceTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/api/v2/resources/TagRootResourceTest.java
@@ -325,7 +325,7 @@ public class TagRootResourceTest extends RepositoryTestBase {
 
   @Test
   public void shouldNotDeleteTagIfNotPermitted() throws IOException, URISyntaxException {
-    doThrow(AuthorizationException.class).when(subject).checkPermission("repository:modify:repoId");
+    doThrow(AuthorizationException.class).when(subject).checkPermission("repository:push:repoId");
     Tags tags = new Tags();
     tags.setTags(Collections.singletonList(new Tag("newtag", "592d797cd36432e591416e8b2b98154f4f163411")));
     when(tagsCommandBuilder.getTags()).thenReturn(tags);

--- a/scm-webapp/src/test/java/sonia/scm/security/AuthorizationChangedEventProducerTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/security/AuthorizationChangedEventProducerTest.java
@@ -85,13 +85,13 @@ public class AuthorizationChangedEventProducerTest {
 
   private void assertUserEventIsFired(String username){
     assertNotNull(producer.event);
-    assertTrue(producer.event.isEveryUserAffected());
+    assertFalse(producer.event.isEveryUserAffected());
     assertEquals(username, producer.event.getNameOfAffectedUser());
   }
 
   private void assertGlobalEventIsFired(){
     assertNotNull(producer.event);
-    assertFalse(producer.event.isEveryUserAffected());
+    assertTrue(producer.event.isEveryUserAffected());
   }
 
   /**


### PR DESCRIPTION
## Proposed changes

Downgrade Jenkins JDK version to Java 8

The unit tests cannot run properly with Java 11. We have to downgrade our image to use Java 8 instead until we have fixed this issue.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] PR is well described and the description can be used as commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] Target branch is not master (in most cases develop should bet the target of choice) 

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
