### PR TITLE
Fix accidentally blocked requests with non ascii characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Empty page on repository namespace filter ([#1476](https://github.com/scm-manager/scm-manager/pull/1476))
 - Usage of namespace filter and search action together on repository overview ([#1476](https://github.com/scm-manager/scm-manager/pull/1476))
 - Fix tooltip arrow height in firefox ([#1479](https://github.com/scm-manager/scm-manager/pull/1479))
+- Accidentally blocked requests with non ascii characters ([#1480](https://github.com/scm-manager/scm-manager/issues/1480) and [#1469](https://github.com/scm-manager/scm-manager/issues/1469))
 
 ## [2.11.1] - 2020-12-07
 ### Fixed

--- a/scm-webapp/src/main/java/sonia/scm/lifecycle/modules/ScmSecurityModule.java
+++ b/scm-webapp/src/main/java/sonia/scm/lifecycle/modules/ScmSecurityModule.java
@@ -27,7 +27,6 @@ package sonia.scm.lifecycle.modules;
 //~--- non-JDK imports --------------------------------------------------------
 
 import com.google.inject.name.Names;
-
 import org.apache.shiro.authc.Authenticator;
 import org.apache.shiro.authc.credential.DefaultPasswordService;
 import org.apache.shiro.authc.credential.PasswordService;
@@ -118,6 +117,10 @@ public class ScmSecurityModule extends ShiroWebModule
 
     // bind constant
     bindConstant().annotatedWith(Names.named("shiro.loginUrl")).to("/index.html");
+
+    // do not block non ascii character,
+    // because this would exclude languages which are non ascii based
+    bindConstant().annotatedWith(Names.named("shiro.blockNonAscii")).to(false);
 
     // disable access to mustache resources
     addFilterChain("/**.mustache", filterConfig(ROLES, "nobody"));


### PR DESCRIPTION
## Proposed changes

Apache Shiro installs a InvalidRequestFilter by default. 
This filter blocks every request which contains non ascii chars. 
This change configures the filter to allow urls with non ascii characters.

Fixes #1469 

### Your checklist for this pull request

- [X] PR is well described and the description can be used as commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [X] CHANGELOG.md updated
- [X] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [X] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
