### PR TITLE
Fix unit tests on Java 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -204,7 +204,7 @@ String developmentBranch
 String mainBranch
 
 Maven setupMavenBuild() {
-  MavenWrapperInDocker mvn = new MavenWrapperInDocker(this, "scmmanager/java-build:8u275-b01")
+  MavenWrapperInDocker mvn = new MavenWrapperInDocker(this, "scmmanager/java-build:11.0.9_11.1")
   mvn.enableDockerHost = true
 
   // disable logging durring the build

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -22,7 +22,7 @@
 # SOFTWARE.
 #
 
-FROM adoptopenjdk/openjdk8:x86_64-debian-jdk8u275-b01
+FROM adoptopenjdk/openjdk11:x86_64-debian-jdk-11.0.9_11.1
 
 ENV DOCKER_VERSION=19.03.8 \
     DOCKER_CHANNEL=stable \

--- a/build/Makefile
+++ b/build/Makefile
@@ -1,4 +1,4 @@
-VERSION:=8u275-b01
+VERSION:=11.0.9_11.1
 
 .PHONY:build
 build:

--- a/pom.xml
+++ b/pom.xml
@@ -608,7 +608,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.0</version>
+        <version>3.0.0-M5</version>
         <configuration>
           <!--
           skips surefire tests without skipping failsafe tests.
@@ -909,7 +909,7 @@
 
   <properties>
     <!-- test libraries -->
-    <mockito.version>3.6.0</mockito.version>
+    <mockito.version>3.6.28</mockito.version>
     <hamcrest.version>2.1</hamcrest.version>
     <junit.version>5.7.0</junit.version>
 

--- a/scm-webapp/src/main/java/sonia/scm/web/i18n/I18nServlet.java
+++ b/scm-webapp/src/main/java/sonia/scm/web/i18n/I18nServlet.java
@@ -138,7 +138,6 @@ public class I18nServlet extends HttpServlet {
     return context.getStage() == Stage.PRODUCTION;
   }
 
-  @VisibleForTesting
   private Optional<JsonNode> collectJsonFile(String path) throws IOException {
     LOG.debug("Collect plugin translations from path {} for every plugin", path);
     JsonNode mergedJsonNode = null;


### PR DESCRIPTION
## Proposed changes

Fix unit tests on Java 11

The unit test I18nServlet and MultiParentClassLoaderTest are failing on Java 11.
This is because they mock ClassLoaders which cause a jvm error.

The following tickets describe the problem in more detail:

- https://bugs.openjdk.java.net/browse/JDK-8254969
- https://github.com/mockito/mockito/issues/2043
- https://github.com/mockito/mockito/issues/1696

### Your checklist for this pull request
- [X] PR is well described and the description can be used as commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests
- [ ] CHANGELOG.md updated
- [X] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [X] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [X] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [X] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
