### PR TITLE
Add font ttf-dejavu to oci image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Option to create a permanent link to a source file ([#1489](https://github.com/scm-manager/scm-manager/pull/1489))
 - Add markdown codeblock renderer extension point ([#1492](https://github.com/scm-manager/scm-manager/pull/1492))
 - Add Java version to plugin center url ([#1494](https://github.com/scm-manager/scm-manager/pull/1494))
+- Add Font ttf-dejavu to oci image ([#1498](https://github.com/scm-manager/scm-manager/issues/1498))
 
 ## [2.12.0] - 2020-12-17
 ### Added

--- a/scm-packaging/docker/Dockerfile
+++ b/scm-packaging/docker/Dockerfile
@@ -29,7 +29,7 @@ ENV CACHE_DIR=/var/cache/scm/work
 COPY . /
 
 RUN set -x \
- && apk add --no-cache mercurial bash ca-certificates \
+ && apk add --no-cache ttf-dejavu mercurial bash ca-certificates \
  && addgroup -S -g 1000 scm \
  && adduser -S -s /bin/false -G scm -h ${SCM_HOME} -D -H -u 1000 scm \
  && mkdir -p ${SCM_HOME} ${CACHE_DIR} \


### PR DESCRIPTION
## Proposed changes

Add font ttf-dejavu to oci image.
Some plugins may require a font to render graphics, such as the markdown-plantuml plugin.

### Your checklist for this pull request

- [X] PR is well described and the description can be used as commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [X] CHANGELOG.md updated
- [X] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [X] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
