### PR TITLE
apply test ids to production builds for usage in e2e tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Java version to plugin center url ([#1494](https://github.com/scm-manager/scm-manager/pull/1494))
 - Add Font ttf-dejavu to oci image ([#1498](https://github.com/scm-manager/scm-manager/issues/1498))
 
+### Changed
+- Apply test ids to production builds for usage in e2e tests ([#1499](https://github.com/scm-manager/scm-manager/pull/1499))
+
 ## [2.12.0] - 2020-12-17
 ### Added
 - Add repository import via dump file for Subversion ([#1471](https://github.com/scm-manager/scm-manager/pull/1471))

--- a/scm-ui/ui-components/src/devBuild.ts
+++ b/scm-ui/ui-components/src/devBuild.ts
@@ -22,11 +22,12 @@
  * SOFTWARE.
  */
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore scmStage is set on the index page
 export const isDevBuild = () => (window.scmStage || "").toUpperCase() === "DEVELOPMENT";
 
 export const createAttributesForTesting = (testId?: string) => {
-  if (!testId || !isDevBuild()) {
+  if (!testId) {
     return undefined;
   }
   return {


### PR DESCRIPTION
## Proposed changes

Our e2e tests get executed against production builds and therefore need access to the test-ids. Prior to this change, test-ids were removed in prod builds. 

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described and the description can be used as commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [ ] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
