### PR TITLE
Migrate store name for git lfs files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Font ttf-dejavu to oci image ([#1498](https://github.com/scm-manager/scm-manager/issues/1498))
 - Add repository import and export with metadata for Subversion ([#1501](https://github.com/scm-manager/scm-manager/pull/1501))
 
+### Changed
+- Directory name for git LFS files ([#1504](https://github.com/scm-manager/scm-manager/pull/1504))
+
 ## [2.12.0] - 2020-12-17
 ### Added
 - Add repository import via dump file for Subversion ([#1471](https://github.com/scm-manager/scm-manager/pull/1471))

--- a/scm-core/src/main/java/sonia/scm/migration/UpdateStep.java
+++ b/scm-core/src/main/java/sonia/scm/migration/UpdateStep.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.migration;
 
 import sonia.scm.plugin.ExtensionPoint;
@@ -50,6 +50,7 @@ import sonia.scm.version.Version;
  * <ul>
  * <li>a {@link sonia.scm.security.KeyGenerator},</li>
  * <li>the {@link sonia.scm.repository.RepositoryLocationResolver},</li>
+ * <li>an {@link sonia.scm.update.RepositoryUpdateIterator},</li>
  * <li>the {@link sonia.scm.io.FileSystem},</li>
  * <li>the {@link sonia.scm.security.CipherHandler},</li>
  * <li>a {@link sonia.scm.store.ConfigurationStoreFactory},</li>
@@ -82,6 +83,8 @@ import sonia.scm.version.Version;
  * </li>
  * </ul>
  * </p>
+ * <p>Mind that an implementation of this class has to be annotated with {@link sonia.scm.plugin.Extension}, so that the
+ * step will be found. </p>
  */
 @ExtensionPoint
 public interface UpdateStep {

--- a/scm-core/src/main/java/sonia/scm/update/RepositoryUpdateIterator.java
+++ b/scm-core/src/main/java/sonia/scm/update/RepositoryUpdateIterator.java
@@ -22,48 +22,21 @@
  * SOFTWARE.
  */
 
-package sonia.scm.web.lfs;
+package sonia.scm.update;
 
-import com.google.inject.Inject;
-import com.google.inject.Singleton;
-import sonia.scm.repository.Repository;
-import sonia.scm.store.BlobStore;
-import sonia.scm.store.BlobStoreFactory;
+import java.util.function.Consumer;
 
 /**
- * Creates {@link BlobStore} objects to store lfs objects.
+ * Implementations of this interface can be used to iterate all repositories in update steps.
  *
- * @author Sebastian Sdorra
- * @since 1.54
+ * @since 2.13.0
  */
-@Singleton
-public class LfsBlobStoreFactory {
-
-  private static final String GIT_LFS_STORE_NAME = "git-lfs";
-
-  private final BlobStoreFactory blobStoreFactory;
+public interface RepositoryUpdateIterator {
 
   /**
-   * Create a new instance.
+   * Calls the given consumer with each repository id.
    *
-   * @param blobStoreFactory blob store factory
+   * @since 2.13.0
    */
-  @Inject
-  public LfsBlobStoreFactory(BlobStoreFactory blobStoreFactory) {
-    this.blobStoreFactory = blobStoreFactory;
-  }
-
-  /**
-   * Provides a {@link BlobStore} corresponding to the SCM Repository.
-   *
-   * @param repository The SCM Repository to provide a LFS {@link BlobStore} for.
-   *
-   * @return blob store for the corresponding scm repository
-   */
-  public BlobStore getLfsBlobStore(Repository repository) {
-    return blobStoreFactory
-        .withName(GIT_LFS_STORE_NAME)
-        .forRepository(repository)
-        .build();
-  }
+  void forEachRepository(Consumer<String> repositoryIdConsumer);
 }

--- a/scm-dao-xml/src/main/java/sonia/scm/store/FileRepositoryUpdateIterator.java
+++ b/scm-dao-xml/src/main/java/sonia/scm/store/FileRepositoryUpdateIterator.java
@@ -22,48 +22,28 @@
  * SOFTWARE.
  */
 
-package sonia.scm.web.lfs;
+package sonia.scm.store;
 
-import com.google.inject.Inject;
-import com.google.inject.Singleton;
-import sonia.scm.repository.Repository;
-import sonia.scm.store.BlobStore;
-import sonia.scm.store.BlobStoreFactory;
+import sonia.scm.repository.RepositoryLocationResolver;
+import sonia.scm.update.RepositoryUpdateIterator;
 
-/**
- * Creates {@link BlobStore} objects to store lfs objects.
- *
- * @author Sebastian Sdorra
- * @since 1.54
- */
-@Singleton
-public class LfsBlobStoreFactory {
+import javax.inject.Inject;
+import java.nio.file.Path;
+import java.util.function.Consumer;
 
-  private static final String GIT_LFS_STORE_NAME = "git-lfs";
+public class FileRepositoryUpdateIterator implements RepositoryUpdateIterator {
 
-  private final BlobStoreFactory blobStoreFactory;
+  private final RepositoryLocationResolver locationResolver;
 
-  /**
-   * Create a new instance.
-   *
-   * @param blobStoreFactory blob store factory
-   */
   @Inject
-  public LfsBlobStoreFactory(BlobStoreFactory blobStoreFactory) {
-    this.blobStoreFactory = blobStoreFactory;
+  public FileRepositoryUpdateIterator(RepositoryLocationResolver locationResolver) {
+    this.locationResolver = locationResolver;
   }
 
-  /**
-   * Provides a {@link BlobStore} corresponding to the SCM Repository.
-   *
-   * @param repository The SCM Repository to provide a LFS {@link BlobStore} for.
-   *
-   * @return blob store for the corresponding scm repository
-   */
-  public BlobStore getLfsBlobStore(Repository repository) {
-    return blobStoreFactory
-        .withName(GIT_LFS_STORE_NAME)
-        .forRepository(repository)
-        .build();
+  @Override
+  public void forEachRepository(Consumer<String> repositoryIdConsumer) {
+    locationResolver
+      .forClass(Path.class)
+      .forAllLocations((repositoryId, path) -> repositoryIdConsumer.accept(repositoryId));
   }
 }

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/web/lfs/RemoveRepositoryIdFromBlobStoreUpdateStep.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/web/lfs/RemoveRepositoryIdFromBlobStoreUpdateStep.java
@@ -1,0 +1,91 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.web.lfs;
+
+import sonia.scm.migration.UpdateException;
+import sonia.scm.migration.UpdateStep;
+import sonia.scm.plugin.Extension;
+import sonia.scm.store.Blob;
+import sonia.scm.store.BlobStore;
+import sonia.scm.store.BlobStoreFactory;
+import sonia.scm.update.RepositoryUpdateIterator;
+import sonia.scm.util.IOUtil;
+import sonia.scm.version.Version;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+
+import static sonia.scm.version.Version.parse;
+
+@Extension
+public class RemoveRepositoryIdFromBlobStoreUpdateStep implements UpdateStep {
+
+  private final RepositoryUpdateIterator repositoryUpdateIterator;
+  private final BlobStoreFactory blobStoreFactory;
+
+  @Inject
+  public RemoveRepositoryIdFromBlobStoreUpdateStep(RepositoryUpdateIterator repositoryUpdateIterator, BlobStoreFactory blobStoreFactory) {
+    this.repositoryUpdateIterator = repositoryUpdateIterator;
+    this.blobStoreFactory = blobStoreFactory;
+  }
+
+  @Override
+  public void doUpdate()  {
+    repositoryUpdateIterator.forEachRepository(this::doUpdate);
+  }
+
+  private void doUpdate(String repositoryId) {
+    BlobStore oldBlobStore = blobStoreFactory.withName(repositoryId + "-git-lfs").forRepository(repositoryId).build();
+    BlobStore newBlobStore = blobStoreFactory.withName("git-lfs").forRepository(repositoryId).build();
+    List<Blob> allBlobs = oldBlobStore.getAll();
+    allBlobs.forEach(
+      blob -> migrateBlob(oldBlobStore, newBlobStore, blob, repositoryId)
+    );
+  }
+
+  private void migrateBlob(BlobStore oldBlobStore, BlobStore newBlobStore, Blob oldBlob, String repositoryId) {
+    try {
+      Blob newBlob = newBlobStore.create(oldBlob.getId());
+      OutputStream outputStream = newBlob.getOutputStream();
+      IOUtil.copy(oldBlob.getInputStream(), outputStream);
+      newBlob.commit();
+      oldBlobStore.remove(oldBlob);
+    } catch (IOException e) {
+      throw new UpdateException(String.format("could not move old lfs blob %s for repository id %s", oldBlob.getId(), repositoryId));
+    }
+  }
+
+  @Override
+  public Version getTargetVersion() {
+    return parse("2.0.1");
+  }
+
+  @Override
+  public String getAffectedDataType() {
+    return "sonia.scm.git.lfs";
+  }
+}

--- a/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/web/lfs/RemoveRepositoryIdFromBlobStoreUpdateStepTest.java
+++ b/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/web/lfs/RemoveRepositoryIdFromBlobStoreUpdateStepTest.java
@@ -1,0 +1,116 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.web.lfs;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sonia.scm.store.Blob;
+import sonia.scm.store.BlobStore;
+import sonia.scm.store.BlobStoreFactory;
+import sonia.scm.update.RepositoryUpdateIterator;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static java.util.Arrays.asList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RemoveRepositoryIdFromBlobStoreUpdateStepTest {
+
+  @Mock
+  private RepositoryUpdateIterator repositoryUpdateIterator;
+  @Mock(answer = Answers.CALLS_REAL_METHODS)
+  private BlobStoreFactory blobStoreFactory;
+  @Mock
+  private BlobStore oldBlobStore;
+  @Mock
+  private BlobStore newBlobStore;
+
+  @InjectMocks
+  private RemoveRepositoryIdFromBlobStoreUpdateStep updateStep;
+
+  private Map<String, ByteArrayOutputStream> blobStreams = new HashMap<>();
+
+  @Test
+  void x() throws IOException {
+    Mockito.doAnswer(invocation -> {
+      invocation.getArgument(0, Consumer.class).accept("repo-id");
+      return null;
+    }).when(repositoryUpdateIterator).forEachRepository(any());
+
+    doReturn(oldBlobStore)
+      .when(blobStoreFactory).getStore(argThat(argument -> argument.getName().startsWith("repo-id")));
+    doReturn(newBlobStore)
+      .when(blobStoreFactory).getStore(argThat(argument -> argument.getName().equals("git-lfs")));
+
+    Blob oldBlob1 = createBlob("blob1");
+    Blob oldBlob2 = createBlob("blob2");
+    when(oldBlobStore.getAll()).thenReturn(asList(oldBlob1, oldBlob2));
+    Blob newBlob1 = createBlob("newBlob1");
+    Blob newBlob2 = createBlob("newBlob2");
+    when(newBlobStore.create("blob1")).thenReturn(newBlob1);
+    when(newBlobStore.create("blob2")).thenReturn(newBlob2);
+
+    updateStep.doUpdate();
+
+    verify(newBlobStore).create("blob1");
+    verify(newBlobStore).create("blob2");
+
+    verify(oldBlobStore).remove(oldBlob1);
+    verify(oldBlobStore).remove(oldBlob2);
+
+    Assertions.assertThat(blobStreams.get("newBlob1")).hasToString("some data for blob1");
+    Assertions.assertThat(blobStreams.get("newBlob2")).hasToString("some data for blob2");
+  }
+
+  private Blob createBlob(String id) throws IOException {
+    Blob blob = mock(Blob.class);
+    lenient().when(blob.getId()).thenReturn(id);
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    blobStreams.put(id, outputStream);
+    lenient().when(blob.getOutputStream()).thenReturn(outputStream);
+    String blobContent = "some data for " + id;
+    lenient().when(blob.getInputStream()).thenReturn(new ByteArrayInputStream(blobContent.getBytes(StandardCharsets.UTF_8)));
+    return blob;
+  }
+}

--- a/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/web/lfs/RemoveRepositoryIdFromBlobStoreUpdateStepTest.java
+++ b/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/web/lfs/RemoveRepositoryIdFromBlobStoreUpdateStepTest.java
@@ -72,7 +72,7 @@ class RemoveRepositoryIdFromBlobStoreUpdateStepTest {
   private Map<String, ByteArrayOutputStream> blobStreams = new HashMap<>();
 
   @Test
-  void x() throws IOException {
+  void migrateBlobsFromOldStoreToNewStore() throws IOException {
     Mockito.doAnswer(invocation -> {
       invocation.getArgument(0, Consumer.class).accept("repo-id");
       return null;

--- a/scm-webapp/src/main/java/sonia/scm/lifecycle/modules/BootstrapModule.java
+++ b/scm-webapp/src/main/java/sonia/scm/lifecycle/modules/BootstrapModule.java
@@ -51,12 +51,14 @@ import sonia.scm.store.ConfigurationStoreFactory;
 import sonia.scm.store.DataStoreFactory;
 import sonia.scm.store.DefaultBlobDirectoryAccess;
 import sonia.scm.store.FileBlobStoreFactory;
+import sonia.scm.store.FileRepositoryUpdateIterator;
 import sonia.scm.store.JAXBConfigurationEntryStoreFactory;
 import sonia.scm.store.JAXBConfigurationStoreFactory;
 import sonia.scm.store.JAXBDataStoreFactory;
 import sonia.scm.store.JAXBPropertyFileAccess;
 import sonia.scm.update.BlobDirectoryAccess;
 import sonia.scm.update.PropertyFileAccess;
+import sonia.scm.update.RepositoryUpdateIterator;
 import sonia.scm.update.UpdateStepRepositoryMetadataAccess;
 import sonia.scm.update.V1PropertyDAO;
 import sonia.scm.update.xml.XmlV1PropertyDAO;
@@ -104,6 +106,7 @@ public class BootstrapModule extends AbstractModule {
     bind(V1PropertyDAO.class, XmlV1PropertyDAO.class);
     bind(PropertyFileAccess.class, JAXBPropertyFileAccess.class);
     bind(BlobDirectoryAccess.class, DefaultBlobDirectoryAccess.class);
+    bind(RepositoryUpdateIterator.class, FileRepositoryUpdateIterator.class);
     bind(new TypeLiteral<UpdateStepRepositoryMetadataAccess<Path>>() {}).to(new TypeLiteral<MetadataStore>() {});
   }
 


### PR DESCRIPTION
## Proposed changes

Changes the directory name for the git LFS blob store by
removing the repository id from the store name.

This is necessary for im- and exports of lfs blob stores,
because the original name had the repository id as a part
of it and therefore the old store would not be found when
the repository is imported with another id.

Existing blob files will be moved to the new store location
by an update step.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described and the description can be used as commit message on squash
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
