### PR TITLE
Repository contact information is editable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Add explicit provider setup for bouncy castle ([#1500](https://github.com/scm-manager/scm-manager/pull/1500))
+- Repository contact information is editable ([#1508](https://github.com/scm-manager/scm-manager/pull/1508))
 
 ## [2.12.0] - 2020-12-17
 ### Added

--- a/scm-ui/ui-webapp/src/repos/components/form/RepositoryForm.tsx
+++ b/scm-ui/ui-webapp/src/repos/components/form/RepositoryForm.tsx
@@ -178,12 +178,12 @@ const RepositoryForm: FC<Props> = ({
   };
 
   const submitButton = () => {
-    if (disabled) {
+    if (!isModifiable() && isEditMode()) {
       return null;
     }
     return (
       <Level
-        right={<SubmitButton disabled={!isValid()} loading={loading} label={t("repositoryForm.submitCreate")} />}
+        right={<SubmitButton disabled={!isValid() || loading} loading={loading} label={t("repositoryForm.submitCreate")} />}
       />
     );
   };

--- a/scm-ui/ui-webapp/src/repos/components/form/RepositoryForm.tsx
+++ b/scm-ui/ui-webapp/src/repos/components/form/RepositoryForm.tsx
@@ -78,7 +78,7 @@ const RepositoryForm: FC<Props> = ({
   });
   const [initRepository, setInitRepository] = useState(false);
   const [contextEntries, setContextEntries] = useState({});
-  const [valid, setValid] = useState({ namespaceAndName: false, contact: true });
+  const [valid, setValid] = useState({ namespaceAndName: true, contact: true });
   const [t] = useTranslation("repos");
 
   useEffect(() => {


### PR DESCRIPTION
## Proposed changes

The RepositoryForm is called within the creation and editing of a repository. It contains a validator, which is supposed to check, among other things, whether the namespace and name were specified when the repository is created. This information is missing in the edit mode. I therefore initially set valid.namespaceAndName to true. It is changed to false again before the creation mask becomes active.

### Your checklist for this pull request

- [x] PR is well described and the description can be used as commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
