### PR TITLE
Use repository specific work dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Directory name for git LFS files ([#1504](https://github.com/scm-manager/scm-manager/pull/1504))
+- Temporary data for repositories is kept in the repository directory, not in a global directory ([#1510](https://github.com/scm-manager/scm-manager/pull/1510))
 - Migrate integration tests to bdd ([#1497](https://github.com/scm-manager/scm-manager/pull/1497))
 - Layout of proxy settings ([#1502](https://github.com/scm-manager/scm-manager/pull/1502))
 - Apply test ids to production builds for usage in e2e tests ([#1499](https://github.com/scm-manager/scm-manager/pull/1499))

--- a/scm-core/src/main/java/sonia/scm/repository/api/ModifyCommandBuilder.java
+++ b/scm-core/src/main/java/sonia/scm/repository/api/ModifyCommandBuilder.java
@@ -81,9 +81,9 @@ public class ModifyCommandBuilder {
 
   private final ModifyCommandRequest request = new ModifyCommandRequest();
 
-  ModifyCommandBuilder(ModifyCommand command, WorkdirProvider workdirProvider, @Nullable EMail eMail) {
+  ModifyCommandBuilder(ModifyCommand command, WorkdirProvider workdirProvider, String repositoryId, @Nullable EMail eMail) {
     this.command = command;
-    this.workdir = workdirProvider.createNewWorkdir();
+    this.workdir = workdirProvider.createNewWorkdir(repositoryId);
     this.eMail = eMail;
   }
 

--- a/scm-core/src/main/java/sonia/scm/repository/api/RepositoryService.java
+++ b/scm-core/src/main/java/sonia/scm/repository/api/RepositoryService.java
@@ -444,7 +444,7 @@ public final class RepositoryService implements Closeable {
     LOG.debug("create modify command for repository {}",
       repository.getNamespaceAndName());
 
-    return new ModifyCommandBuilder(provider.getModifyCommand(), workdirProvider, eMail);
+    return new ModifyCommandBuilder(provider.getModifyCommand(), workdirProvider, repository.getId(), eMail);
   }
 
   /**

--- a/scm-core/src/main/java/sonia/scm/repository/work/NoneCachingWorkingCopyPool.java
+++ b/scm-core/src/main/java/sonia/scm/repository/work/NoneCachingWorkingCopyPool.java
@@ -46,7 +46,7 @@ public class NoneCachingWorkingCopyPool implements WorkingCopyPool {
 
   @Override
   public <R, W> WorkingCopy<R, W> getWorkingCopy(SimpleWorkingCopyFactory<R, W, ?>.WorkingCopyContext context) {
-    return context.initialize(workdirProvider.createNewWorkdir());
+    return context.initialize(workdirProvider.createNewWorkdir(context.getScmRepository().getId()));
   }
 
   @Override

--- a/scm-core/src/main/java/sonia/scm/repository/work/SimpleCachingWorkingCopyPool.java
+++ b/scm-core/src/main/java/sonia/scm/repository/work/SimpleCachingWorkingCopyPool.java
@@ -96,7 +96,7 @@ public class SimpleCachingWorkingCopyPool implements WorkingCopyPool {
 
   private <R, W> WorkingCopy<R, W> createNewWorkingCopy(SimpleWorkingCopyFactory<R, W, ?>.WorkingCopyContext workingCopyContext) {
     Stopwatch stopwatch = Stopwatch.createStarted();
-    File newWorkdir = workdirProvider.createNewWorkdir();
+    File newWorkdir = workdirProvider.createNewWorkdir(workingCopyContext.getScmRepository().getId());
     WorkingCopy<R, W> parentAndClone = workingCopyContext.initialize(newWorkdir);
     LOG.debug("initialized new workdir for {} in path {} in {}", workingCopyContext.getScmRepository(), newWorkdir, stopwatch.stop());
     return parentAndClone;

--- a/scm-core/src/main/java/sonia/scm/repository/work/WorkdirCreationException.java
+++ b/scm-core/src/main/java/sonia/scm/repository/work/WorkdirCreationException.java
@@ -31,6 +31,10 @@ public class WorkdirCreationException extends ExceptionWithContext {
 
   public static final String CODE = "3tS0mjSoo1";
 
+  public WorkdirCreationException(String path) {
+    super(ContextEntry.ContextBuilder.entity("Path", path).build(), "Could not create directory " + path);
+  }
+
   public WorkdirCreationException(String path, Exception cause) {
     super(ContextEntry.ContextBuilder.entity("Path", path).build(), "Could not create directory " + path, cause);
   }

--- a/scm-core/src/main/java/sonia/scm/repository/work/WorkdirProvider.java
+++ b/scm-core/src/main/java/sonia/scm/repository/work/WorkdirProvider.java
@@ -65,8 +65,11 @@ public class WorkdirProvider {
   }
 
   private File createWorkDir(File baseDirectory) {
+    // recreate base directory when it may be deleted (see https://github.com/scm-manager/scm-manager/issues/1493 for example)
+    if (!baseDirectory.exists() && !baseDirectory.mkdirs()) {
+      throw new WorkdirCreationException(baseDirectory.toString());
+    }
     try {
-      baseDirectory.mkdirs(); // recreate base directory when it may be deleted (see https://github.com/scm-manager/scm-manager/issues/1493 for example)
       return Files.createTempDirectory(baseDirectory.toPath(),"work-").toFile();
     } catch (IOException e) {
       throw new WorkdirCreationException(baseDirectory.toString(), e);

--- a/scm-core/src/test/java/sonia/scm/repository/api/ModifyCommandBuilderTest.java
+++ b/scm-core/src/test/java/sonia/scm/repository/api/ModifyCommandBuilderTest.java
@@ -83,8 +83,7 @@ class ModifyCommandBuilderTest {
   @BeforeEach
   void initWorkdir(@TempDir Path temp) throws IOException {
     workdir = Files.createDirectory(temp.resolve("workdir"));
-    lenient().when(workdirProvider.createNewWorkdir("1" +
-      "")).thenReturn(workdir.toFile());
+    lenient().when(workdirProvider.createNewWorkdir("1")).thenReturn(workdir.toFile());
     commandBuilder = new ModifyCommandBuilder(command, workdirProvider, "1", new EMail(SCM_CONFIGURATION));
   }
 

--- a/scm-core/src/test/java/sonia/scm/repository/api/ModifyCommandBuilderTest.java
+++ b/scm-core/src/test/java/sonia/scm/repository/api/ModifyCommandBuilderTest.java
@@ -83,8 +83,9 @@ class ModifyCommandBuilderTest {
   @BeforeEach
   void initWorkdir(@TempDir Path temp) throws IOException {
     workdir = Files.createDirectory(temp.resolve("workdir"));
-    lenient().when(workdirProvider.createNewWorkdir()).thenReturn(workdir.toFile());
-    commandBuilder = new ModifyCommandBuilder(command, workdirProvider, new EMail(SCM_CONFIGURATION));
+    lenient().when(workdirProvider.createNewWorkdir("1" +
+      "")).thenReturn(workdir.toFile());
+    commandBuilder = new ModifyCommandBuilder(command, workdirProvider, "1", new EMail(SCM_CONFIGURATION));
   }
 
   @BeforeEach

--- a/scm-core/src/test/java/sonia/scm/repository/work/SimpleCachingWorkingCopyPoolTest.java
+++ b/scm-core/src/test/java/sonia/scm/repository/work/SimpleCachingWorkingCopyPoolTest.java
@@ -38,6 +38,7 @@ import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -68,7 +69,7 @@ class SimpleCachingWorkingCopyPoolTest {
   @Test
   void shouldCreateNewWorkdirForTheFirstRequest(@TempDir Path temp) {
     when(workingCopyContext.getScmRepository()).thenReturn(REPOSITORY);
-    when(workdirProvider.createNewWorkdir()).thenReturn(temp.toFile());
+    when(workdirProvider.createNewWorkdir(anyString())).thenReturn(temp.toFile());
 
     WorkingCopy<?, ?> workdir = simpleCachingWorkingCopyPool.getWorkingCopy(workingCopyContext);
 
@@ -78,7 +79,7 @@ class SimpleCachingWorkingCopyPoolTest {
   @Test
   void shouldCreateWorkdirOnlyOnceForTheSameRepository(@TempDir Path temp) throws SimpleWorkingCopyFactory.ReclaimFailedException {
     when(workingCopyContext.getScmRepository()).thenReturn(REPOSITORY);
-    when(workdirProvider.createNewWorkdir()).thenReturn(temp.toFile());
+    when(workdirProvider.createNewWorkdir(anyString())).thenReturn(temp.toFile());
 
     WorkingCopy<?, ?> firstWorkdir = simpleCachingWorkingCopyPool.getWorkingCopy(workingCopyContext);
     simpleCachingWorkingCopyPool.contextClosed(workingCopyContext, firstWorkdir.getDirectory());
@@ -96,7 +97,7 @@ class SimpleCachingWorkingCopyPoolTest {
     firstDirectory.mkdirs();
     File secondDirectory = temp.resolve("second").toFile();
     secondDirectory.mkdirs();
-    when(workdirProvider.createNewWorkdir()).thenReturn(
+    when(workdirProvider.createNewWorkdir(anyString())).thenReturn(
       firstDirectory,
       secondDirectory);
 

--- a/scm-core/src/test/java/sonia/scm/repository/work/SimpleWorkingCopyFactoryTest.java
+++ b/scm-core/src/test/java/sonia/scm/repository/work/SimpleWorkingCopyFactoryTest.java
@@ -64,7 +64,7 @@ public class SimpleWorkingCopyFactoryTest {
 
   @Before
   public void initFactory() throws IOException {
-    WorkdirProvider workdirProvider = new WorkdirProvider(temporaryFolder.newFolder(), repositoryLocationResolver);
+    WorkdirProvider workdirProvider = new WorkdirProvider(temporaryFolder.newFolder(), repositoryLocationResolver, false);
     WorkingCopyPool configurableTestWorkingCopyPool = new WorkingCopyPool() {
       @Override
       public <R, W> WorkingCopy<R, W> getWorkingCopy(SimpleWorkingCopyFactory<R, W, ?>.WorkingCopyContext context) {

--- a/scm-core/src/test/java/sonia/scm/repository/work/SimpleWorkingCopyFactoryTest.java
+++ b/scm-core/src/test/java/sonia/scm/repository/work/SimpleWorkingCopyFactoryTest.java
@@ -29,16 +29,20 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import sonia.scm.repository.Repository;
+import sonia.scm.repository.RepositoryLocationResolver;
 import sonia.scm.repository.RepositoryProvider;
 import sonia.scm.util.IOUtil;
 
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class SimpleWorkingCopyFactoryTest {
 
@@ -51,6 +55,8 @@ public class SimpleWorkingCopyFactoryTest {
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
   private SimpleWorkingCopyFactory<Closeable, Closeable, Context> simpleWorkingCopyFactory;
 
+  private final RepositoryLocationResolver repositoryLocationResolver = mock(RepositoryLocationResolver.class);
+
   private String initialBranchForLastCloneCall;
 
   private boolean workdirIsCached = false;
@@ -58,11 +64,11 @@ public class SimpleWorkingCopyFactoryTest {
 
   @Before
   public void initFactory() throws IOException {
-    WorkdirProvider workdirProvider = new WorkdirProvider(temporaryFolder.newFolder());
+    WorkdirProvider workdirProvider = new WorkdirProvider(temporaryFolder.newFolder(), repositoryLocationResolver);
     WorkingCopyPool configurableTestWorkingCopyPool = new WorkingCopyPool() {
       @Override
       public <R, W> WorkingCopy<R, W> getWorkingCopy(SimpleWorkingCopyFactory<R, W, ?>.WorkingCopyContext context) {
-        workdir = workdirProvider.createNewWorkdir();
+        workdir = workdirProvider.createNewWorkdir(context.getScmRepository().getId());
         return context.initialize(workdir);
       }
 
@@ -99,6 +105,10 @@ public class SimpleWorkingCopyFactoryTest {
         workingCopy.close();
       }
     };
+
+    RepositoryLocationResolver.RepositoryLocationResolverInstance instanceMock = mock(RepositoryLocationResolver.RepositoryLocationResolverInstance.class);
+    when(repositoryLocationResolver.forClass(Path.class)).thenReturn(instanceMock);
+    when(instanceMock.getLocation(anyString())).thenAnswer(invocation -> temporaryFolder.newFolder(invocation.getArgument(0, String.class)).toPath());
   }
 
   @Test

--- a/scm-core/src/test/java/sonia/scm/repository/work/WorkdirProviderTest.java
+++ b/scm-core/src/test/java/sonia/scm/repository/work/WorkdirProviderTest.java
@@ -1,0 +1,93 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.repository.work;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sonia.scm.repository.RepositoryLocationResolver;
+import sonia.scm.repository.RepositoryLocationResolver.RepositoryLocationResolverInstance;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WorkdirProviderTest {
+
+  @Mock
+  private RepositoryLocationResolver repositoryLocationResolver;
+  @Mock
+  private RepositoryLocationResolverInstance<Path> repositoryLocationResolverInstance;
+
+  @BeforeEach
+  void initResolver(@TempDir Path temp) {
+    lenient().when(repositoryLocationResolver.forClass(Path.class)).thenReturn(repositoryLocationResolverInstance);
+  }
+
+  @Test
+  void shouldUseGlobalTempDirectory(@TempDir Path temp) {
+    WorkdirProvider provider = new WorkdirProvider(temp.toFile(), repositoryLocationResolver, true);
+
+    File newWorkdir = provider.createNewWorkdir();
+
+    assertThat(newWorkdir).exists();
+    assertThat(newWorkdir).hasParent(temp.toFile());
+    verify(repositoryLocationResolverInstance, never()).getLocation(anyString());
+  }
+
+  @Test
+  void shouldUseRepositorySpecificDirectory(@TempDir Path temp) {
+    when(repositoryLocationResolverInstance.getLocation("42")).thenReturn(temp.resolve("repo-dir"));
+
+    WorkdirProvider provider = new WorkdirProvider(temp.toFile(), repositoryLocationResolver, true);
+
+    File newWorkdir = provider.createNewWorkdir("42");
+
+    assertThat(newWorkdir).exists();
+    assertThat(newWorkdir.getParentFile()).hasName("work");
+    assertThat(newWorkdir.getParentFile().getParentFile()).hasName("repo-dir");
+  }
+
+  @Test
+  void shouldUseGlobalDirectoryIfExplicitlySet(@TempDir Path temp) {
+    WorkdirProvider provider = new WorkdirProvider(temp.toFile(), repositoryLocationResolver, false);
+
+    File newWorkdir = provider.createNewWorkdir("42");
+
+    assertThat(newWorkdir).exists();
+    assertThat(newWorkdir).hasParent(temp.toFile());
+    verify(repositoryLocationResolverInstance, never()).getLocation(anyString());
+  }
+}

--- a/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/GitMergeCommandTest.java
+++ b/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/GitMergeCommandTest.java
@@ -29,16 +29,12 @@ import com.github.sdorra.shiro.SubjectAware;
 import org.apache.shiro.subject.SimplePrincipalCollection;
 import org.apache.shiro.subject.Subject;
 import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.errors.CanceledException;
 import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.lib.CommitBuilder;
-import org.eclipse.jgit.lib.GpgSignature;
 import org.eclipse.jgit.lib.GpgSigner;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.transport.CredentialsProvider;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -520,7 +516,7 @@ public class GitMergeCommandTest extends AbstractGitCommandTestBase {
   }
 
   private GitMergeCommand createCommand(Consumer<Git> interceptor) {
-    return new GitMergeCommand(createContext(), new SimpleGitWorkingCopyFactory(new NoneCachingWorkingCopyPool(new WorkdirProvider()))) {
+    return new GitMergeCommand(createContext(), new SimpleGitWorkingCopyFactory(new NoneCachingWorkingCopyPool(new WorkdirProvider(repositoryLocationResolver)))) {
       @Override
       <R, W extends GitCloneWorker<R>> R inClone(Function<Git, W> workerSupplier, GitWorkingCopyFactory workingCopyFactory, String initialBranch) {
         Function<Git, W> interceptedWorkerSupplier = git -> {

--- a/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/GitMergeCommand_Conflict_Test.java
+++ b/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/GitMergeCommand_Conflict_Test.java
@@ -92,7 +92,7 @@ public class GitMergeCommand_Conflict_Test extends AbstractGitCommandTestBase {
   }
 
   private MergeConflictResult computeMergeConflictResult(String branchToMerge, String targetBranch) {
-    GitMergeCommand gitMergeCommand = new GitMergeCommand(createContext(), new SimpleGitWorkingCopyFactory(new NoneCachingWorkingCopyPool(new WorkdirProvider())));
+    GitMergeCommand gitMergeCommand = new GitMergeCommand(createContext(), new SimpleGitWorkingCopyFactory(new NoneCachingWorkingCopyPool(new WorkdirProvider(repositoryLocationResolver))));
     MergeCommandRequest mergeCommandRequest = new MergeCommandRequest();
     mergeCommandRequest.setBranchToMerge(branchToMerge);
     mergeCommandRequest.setTargetBranch(targetBranch);

--- a/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/GitModifyCommandTestBase.java
+++ b/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/GitModifyCommandTestBase.java
@@ -72,7 +72,7 @@ class GitModifyCommandTestBase extends AbstractGitCommandTestBase {
   GitModifyCommand createCommand() {
     return new GitModifyCommand(
       createContext(),
-      new SimpleGitWorkingCopyFactory(new NoneCachingWorkingCopyPool(new WorkdirProvider())),
+      new SimpleGitWorkingCopyFactory(new NoneCachingWorkingCopyPool(new WorkdirProvider(repositoryLocationResolver))),
       lfsBlobStoreFactory,
       createGitRepositoryConfigStoreProvider());
   }

--- a/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/SimpleGitWorkingCopyFactoryTest.java
+++ b/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/SimpleGitWorkingCopyFactoryTest.java
@@ -68,7 +68,7 @@ public class SimpleGitWorkingCopyFactoryTest extends AbstractGitCommandTestBase 
     GitRepositoryHandler gitRepositoryHandler = mock(GitRepositoryHandler.class);
     proto = new ScmTransportProtocol(of(GitTestHelper.createConverterFactory()), of(hookEventFacade), of(gitRepositoryHandler));
     Transport.register(proto);
-    workdirProvider = new WorkdirProvider(temporaryFolder.newFolder(), repositoryLocationResolver);
+    workdirProvider = new WorkdirProvider(temporaryFolder.newFolder(), repositoryLocationResolver, false);
   }
 
   @Test

--- a/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/SimpleGitWorkingCopyFactoryTest.java
+++ b/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/SimpleGitWorkingCopyFactoryTest.java
@@ -34,7 +34,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import sonia.scm.repository.GitChangesetConverterFactory;
 import sonia.scm.repository.GitRepositoryHandler;
 import sonia.scm.repository.GitTestHelper;
 import sonia.scm.repository.PreProcessorUtil;
@@ -69,7 +68,7 @@ public class SimpleGitWorkingCopyFactoryTest extends AbstractGitCommandTestBase 
     GitRepositoryHandler gitRepositoryHandler = mock(GitRepositoryHandler.class);
     proto = new ScmTransportProtocol(of(GitTestHelper.createConverterFactory()), of(hookEventFacade), of(gitRepositoryHandler));
     Transport.register(proto);
-    workdirProvider = new WorkdirProvider(temporaryFolder.newFolder());
+    workdirProvider = new WorkdirProvider(temporaryFolder.newFolder(), repositoryLocationResolver);
   }
 
   @Test

--- a/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/spi/HgBranchCommandTest.java
+++ b/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/spi/HgBranchCommandTest.java
@@ -25,7 +25,6 @@
 package sonia.scm.repository.spi;
 
 import com.aragost.javahg.commands.PullCommand;
-import com.google.inject.util.Providers;
 import org.junit.Before;
 import org.junit.Test;
 import sonia.scm.repository.Branch;
@@ -46,7 +45,7 @@ public class HgBranchCommandTest extends AbstractHgCommandTestBase {
   @Before
   public void initWorkingCopyFactory() {
 
-    workingCopyFactory = new SimpleHgWorkingCopyFactory(new NoneCachingWorkingCopyPool(new WorkdirProvider())) {
+    workingCopyFactory = new SimpleHgWorkingCopyFactory(new NoneCachingWorkingCopyPool(new WorkdirProvider(repositoryLocationResolver))) {
       @Override
       public void configure(PullCommand pullCommand) {
         // we do not want to configure http hooks in this unit test

--- a/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/spi/HgModifyCommandTest.java
+++ b/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/spi/HgModifyCommandTest.java
@@ -51,7 +51,7 @@ public class HgModifyCommandTest extends AbstractHgCommandTestBase {
 
   @Before
   public void initHgModifyCommand() {
-    SimpleHgWorkingCopyFactory workingCopyFactory = new SimpleHgWorkingCopyFactory(new NoneCachingWorkingCopyPool(new WorkdirProvider())) {
+    SimpleHgWorkingCopyFactory workingCopyFactory = new SimpleHgWorkingCopyFactory(new NoneCachingWorkingCopyPool(new WorkdirProvider(repositoryLocationResolver))) {
       @Override
       public void configure(com.aragost.javahg.commands.PullCommand pullCommand) {
         // we do not want to configure http hooks in this unit test

--- a/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/spi/HgTagCommandTest.java
+++ b/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/spi/HgTagCommandTest.java
@@ -25,10 +25,8 @@
 package sonia.scm.repository.spi;
 
 import com.aragost.javahg.commands.PullCommand;
-import com.google.inject.util.Providers;
 import org.junit.Before;
 import org.junit.Test;
-import sonia.scm.repository.HgTestUtil;
 import sonia.scm.repository.Tag;
 import sonia.scm.repository.api.TagCreateRequest;
 import sonia.scm.repository.api.TagDeleteRequest;
@@ -46,7 +44,7 @@ public class HgTagCommandTest extends AbstractHgCommandTestBase {
   @Before
   public void initWorkingCopyFactory() {
 
-    workingCopyFactory = new SimpleHgWorkingCopyFactory(new NoneCachingWorkingCopyPool(new WorkdirProvider())) {
+    workingCopyFactory = new SimpleHgWorkingCopyFactory(new NoneCachingWorkingCopyPool(new WorkdirProvider(repositoryLocationResolver))) {
       @Override
       public void configure(PullCommand pullCommand) {
         // we do not want to configure http hooks in this unit test

--- a/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/spi/SimpleHgWorkingCopyFactoryTest.java
+++ b/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/spi/SimpleHgWorkingCopyFactoryTest.java
@@ -25,13 +25,10 @@
 package sonia.scm.repository.spi;
 
 import com.aragost.javahg.Repository;
-import com.google.inject.util.Providers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import sonia.scm.repository.HgEnvironmentBuilder;
-import sonia.scm.repository.HgTestUtil;
 import sonia.scm.repository.work.SimpleCachingWorkingCopyPool;
 import sonia.scm.repository.work.WorkdirProvider;
 import sonia.scm.repository.work.WorkingCopy;
@@ -55,7 +52,7 @@ public class SimpleHgWorkingCopyFactoryTest extends AbstractHgCommandTestBase {
 
   @Before
   public void bindScmProtocol() throws IOException {
-    workdirProvider = new WorkdirProvider(temporaryFolder.newFolder());
+    workdirProvider = new WorkdirProvider(temporaryFolder.newFolder(), repositoryLocationResolver);
     workingCopyFactory = new SimpleHgWorkingCopyFactory(new SimpleCachingWorkingCopyPool(workdirProvider)) {
       @Override
       public void configure(com.aragost.javahg.commands.PullCommand pullCommand) {

--- a/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/spi/SimpleHgWorkingCopyFactoryTest.java
+++ b/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/spi/SimpleHgWorkingCopyFactoryTest.java
@@ -52,7 +52,7 @@ public class SimpleHgWorkingCopyFactoryTest extends AbstractHgCommandTestBase {
 
   @Before
   public void bindScmProtocol() throws IOException {
-    workdirProvider = new WorkdirProvider(temporaryFolder.newFolder(), repositoryLocationResolver);
+    workdirProvider = new WorkdirProvider(temporaryFolder.newFolder(), repositoryLocationResolver, false);
     workingCopyFactory = new SimpleHgWorkingCopyFactory(new SimpleCachingWorkingCopyPool(workdirProvider)) {
       @Override
       public void configure(com.aragost.javahg.commands.PullCommand pullCommand) {

--- a/scm-plugins/scm-svn-plugin/src/test/java/sonia/scm/repository/spi/SimpleSvnWorkingCopyFactoryTest.java
+++ b/scm-plugins/scm-svn-plugin/src/test/java/sonia/scm/repository/spi/SimpleSvnWorkingCopyFactoryTest.java
@@ -49,7 +49,7 @@ public class SimpleSvnWorkingCopyFactoryTest extends AbstractSvnCommandTestBase 
 
   @Before
   public void initWorkDirProvider() throws IOException {
-    workdirProvider = new WorkdirProvider(temporaryFolder.newFolder(), repositoryLocationResolver);
+    workdirProvider = new WorkdirProvider(temporaryFolder.newFolder(), repositoryLocationResolver, false);
   }
 
   @Test

--- a/scm-plugins/scm-svn-plugin/src/test/java/sonia/scm/repository/spi/SimpleSvnWorkingCopyFactoryTest.java
+++ b/scm-plugins/scm-svn-plugin/src/test/java/sonia/scm/repository/spi/SimpleSvnWorkingCopyFactoryTest.java
@@ -49,7 +49,7 @@ public class SimpleSvnWorkingCopyFactoryTest extends AbstractSvnCommandTestBase 
 
   @Before
   public void initWorkDirProvider() throws IOException {
-    workdirProvider = new WorkdirProvider(temporaryFolder.newFolder());
+    workdirProvider = new WorkdirProvider(temporaryFolder.newFolder(), repositoryLocationResolver);
   }
 
   @Test

--- a/scm-plugins/scm-svn-plugin/src/test/java/sonia/scm/repository/spi/SvnModifyCommandTest.java
+++ b/scm-plugins/scm-svn-plugin/src/test/java/sonia/scm/repository/spi/SvnModifyCommandTest.java
@@ -57,7 +57,7 @@ public class SvnModifyCommandTest extends AbstractSvnCommandTestBase {
   @Before
   public void initSvnModifyCommand() {
     context = createContext();
-    workingCopyFactory = new SimpleSvnWorkingCopyFactory(new NoneCachingWorkingCopyPool(new WorkdirProvider(context.getDirectory())));
+    workingCopyFactory = new SimpleSvnWorkingCopyFactory(new NoneCachingWorkingCopyPool(new WorkdirProvider(context.getDirectory(), repositoryLocationResolver)));
     svnModifyCommand = new SvnModifyCommand(context, workingCopyFactory);
   }
 

--- a/scm-plugins/scm-svn-plugin/src/test/java/sonia/scm/repository/spi/SvnModifyCommandTest.java
+++ b/scm-plugins/scm-svn-plugin/src/test/java/sonia/scm/repository/spi/SvnModifyCommandTest.java
@@ -57,7 +57,7 @@ public class SvnModifyCommandTest extends AbstractSvnCommandTestBase {
   @Before
   public void initSvnModifyCommand() {
     context = createContext();
-    workingCopyFactory = new SimpleSvnWorkingCopyFactory(new NoneCachingWorkingCopyPool(new WorkdirProvider(context.getDirectory(), repositoryLocationResolver)));
+    workingCopyFactory = new SimpleSvnWorkingCopyFactory(new NoneCachingWorkingCopyPool(new WorkdirProvider(context.getDirectory(), repositoryLocationResolver, false)));
     svnModifyCommand = new SvnModifyCommand(context, workingCopyFactory);
   }
 

--- a/scm-webapp/src/main/java/sonia/scm/importexport/FullScmRepositoryExporter.java
+++ b/scm-webapp/src/main/java/sonia/scm/importexport/FullScmRepositoryExporter.java
@@ -107,7 +107,7 @@ public class FullScmRepositoryExporter {
   }
 
   private void writeRepository(RepositoryService service, TarArchiveOutputStream taos) throws IOException {
-    File newWorkdir = workdirProvider.createNewWorkdir();
+    File newWorkdir = workdirProvider.createNewWorkdir(service.getRepository().getId());
     try {
       File repositoryFile = Files.createFile(Paths.get(newWorkdir.getPath(), "repository")).toFile();
       try (FileOutputStream repositoryFos = new FileOutputStream(repositoryFile)) {
@@ -124,7 +124,7 @@ public class FullScmRepositoryExporter {
   }
 
   private void writeStoreData(Repository repository, TarArchiveOutputStream taos) throws IOException {
-    File newWorkdir = workdirProvider.createNewWorkdir();
+    File newWorkdir = workdirProvider.createNewWorkdir(repository.getId());
     try {
       File metadata = Files.createFile(Paths.get(newWorkdir.getPath(), "metadata")).toFile();
       try (FileOutputStream metadataFos = new FileOutputStream(metadata)) {

--- a/scm-webapp/src/test/java/sonia/scm/importexport/FullScmRepositoryExporterTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/importexport/FullScmRepositoryExporterTest.java
@@ -87,7 +87,8 @@ class FullScmRepositoryExporterTest {
   void shouldExportEverythingAsTarArchive(@TempDir Path temp) throws IOException {
     BundleCommandBuilder bundleCommandBuilder = mock(BundleCommandBuilder.class);
     when(repositoryService.getBundleCommand()).thenReturn(bundleCommandBuilder);
-    when(workdirProvider.createNewWorkdir()).thenAnswer(invocation -> createWorkDir(temp));
+    when(repositoryService.getRepository()).thenReturn(REPOSITORY);
+    when(workdirProvider.createNewWorkdir(anyString())).thenAnswer(invocation -> createWorkDir(temp, invocation.getArgument(0, String.class)));
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     exporter.export(REPOSITORY, baos);
 
@@ -98,8 +99,8 @@ class FullScmRepositoryExporterTest {
     workDirsCreated.forEach(wd -> assertThat(wd).doesNotExist());
   }
 
-  private File createWorkDir(Path temp) throws IOException {
-    Path newWorkDir = temp.resolve("workDir-" + workDirsCreated.size());
+  private File createWorkDir(Path temp, String repositoryId) throws IOException {
+    Path newWorkDir = temp.resolve("workDir-" + repositoryId);
     workDirsCreated.add(newWorkDir);
     Files.createDirectories(newWorkDir);
     return newWorkDir.toFile();


### PR DESCRIPTION
## Proposed changes

With this change, work dirs are created in the
directory of the repository and no longer in the
global scm work dir directory. This is relevant due
to two facts:

1. Repositories may contain confidential data and therefore
   reside in special directories (that may be mounted on
   special drives). It may be considered a breach when these
   directories are cloned or otherwise copied to global
   temporary drives.
2. Big repositories may overload global temp spaces. It may be
   easier to create special drives with more space for such
   big repositories.

Fixes #1493

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described and the description can be used as commit message on squash
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
