### PR TITLE
Implement new changelog process

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,11 @@ plugins {
   id 'java-platform'
   id 'maven-publish'
   id "org.sonarqube" version "3.0"
+  id "org.scm-manager.changelog" version "0.1.4"
+}
+
+changelog {
+  versionUrlPattern = "https://www.scm-manager.org/download/{0}"
 }
 
 subprojects { s ->

--- a/docs/en/release-process.md
+++ b/docs/en/release-process.md
@@ -19,18 +19,38 @@ Check whether there is an integration branch for the previous release or bugfixe
 git merge origin/support/<support branch>
 ```
 
-## Modify Changelog
+## Update Changelog
 
-Change "Unreleased" header in `CHANGELOG.md` to  `<version> - <current date>`
+The changelog must be updated to reflect the changes for the new release.
+All unreleased changes are stored in the `gradle/changelog` directory.
+The changelog can be updated with the `updateChangelog` gradle task.
+
+```bash
+./gradlew updateChangelog --release=<version>
+```
+
+Now we should manually check if the changelog looks good.
+
+```bash
+git diff CHANGELOG.md
+```
+
+If everything looks fine, we can remove the changelog directory.
+
+```bash
+rm -rf gradle/changelog
+```
 
 ## Create release branch
 
-`git checkout -b release/<version>`
+```bash
+git checkout -b release/<version>
+```
 
 ## Commit version changes
 
-```
-git add CHANGELOG.md
+```bash
+git add CHANGELOG.md gradle/changelog
 git commit -m "Adjust changelog for release <version>"
 ```
 

--- a/gradle/changelog/new_changelog_process.yaml
+++ b/gradle/changelog/new_changelog_process.yaml
@@ -1,0 +1,2 @@
+- type: changed
+  description: Implement new changelog process ([#1517](https://github.com/scm-manager/scm-manager/issues/1517))


### PR DESCRIPTION
## Proposed changes

Adopt the new changelog process, which should avoid CHANGELOG.md merge conflicts.
This change integrates the new [changelog gradle plugin](https://github.com/scm-manager/changelog) to update the CHANGELOG.md during a release and updates the release documentation.

### Your checklist for this pull request

- [X] PR is well described and the description can be used as commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
