### PR TITLE
Merge repository permissions on import

### DIFF
--- a/gradle/changelog/import_repository_permissions.yaml
+++ b/gradle/changelog/import_repository_permissions.yaml
@@ -1,0 +1,3 @@
+- type: added
+  description: Import repository permissions from repository archive ([#1520](https://github.com/scm-manager/scm-manager/pull/1520))
+

--- a/scm-webapp/src/main/java/sonia/scm/importexport/RepositoryImportPermissionMerger.java
+++ b/scm-webapp/src/main/java/sonia/scm/importexport/RepositoryImportPermissionMerger.java
@@ -1,0 +1,54 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.importexport;
+
+import sonia.scm.repository.RepositoryPermission;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.function.Predicate;
+
+class RepositoryImportPermissionMerger {
+
+  public Collection<RepositoryPermission> merge(Collection<RepositoryPermission> existingPermissions,
+                                                Collection<RepositoryPermission> importedPermissions) {
+    HashSet<RepositoryPermission> permissions = new HashSet<>(existingPermissions);
+    importedPermissions
+      .stream()
+      .filter(permissionDoesNotExistYet(permissions))
+      .forEach(permissions::add);
+
+    return permissions;
+  }
+
+  private Predicate<RepositoryPermission> permissionDoesNotExistYet(HashSet<RepositoryPermission> permissions) {
+    return importedPermission ->
+      permissions.stream()
+        .noneMatch(existingPermission ->
+          existingPermission.getName().equals(importedPermission.getName())
+            && existingPermission.isGroupPermission() == importedPermission.isGroupPermission()
+        );
+  }
+}

--- a/scm-webapp/src/main/java/sonia/scm/importexport/RepositoryMetadataXmlGenerator.java
+++ b/scm-webapp/src/main/java/sonia/scm/importexport/RepositoryMetadataXmlGenerator.java
@@ -25,6 +25,7 @@
 package sonia.scm.importexport;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import sonia.scm.ContextEntry;
 import sonia.scm.repository.Repository;
@@ -57,9 +58,10 @@ class RepositoryMetadataXmlGenerator {
 
   @AllArgsConstructor
   @NoArgsConstructor
+  @Getter
   @XmlRootElement(name = "metadata")
   @XmlAccessorType(XmlAccessType.FIELD)
-  private static class RepositoryMetadata {
+  static class RepositoryMetadata {
 
     private String namespace;
     private String name;

--- a/scm-webapp/src/test/java/sonia/scm/importexport/FullScmRepositoryImporterTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/importexport/FullScmRepositoryImporterTest.java
@@ -36,6 +36,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import sonia.scm.repository.Repository;
 import sonia.scm.repository.RepositoryManager;
+import sonia.scm.repository.RepositoryPermission;
 import sonia.scm.repository.RepositoryTestData;
 import sonia.scm.repository.api.ImportFailedException;
 import sonia.scm.repository.api.RepositoryService;
@@ -47,13 +48,13 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -105,9 +106,13 @@ class FullScmRepositoryImporterTest {
   void shouldImportScmRepositoryArchive() throws IOException {
     when(compatibilityChecker.check(any())).thenReturn(true);
     when(repositoryManager.create(eq(REPOSITORY), any())).thenReturn(REPOSITORY);
+    Collection<RepositoryPermission> existingPermissions = REPOSITORY.getPermissions();
 
     Repository repository = fullImporter.importFromStream(REPOSITORY, Resources.getResource("sonia/scm/repository/import/scm-import.tar.gz").openStream());
     assertThat(repository).isEqualTo(REPOSITORY);
     verify(storeImporter).importFromTarArchive(eq(REPOSITORY), any(InputStream.class));
+    verify(repositoryManager).modify(REPOSITORY);
+    Collection<RepositoryPermission> updatedPermissions = REPOSITORY.getPermissions();
+    assertThat(updatedPermissions).isNotEqualTo(existingPermissions);
   }
 }

--- a/scm-webapp/src/test/java/sonia/scm/importexport/RepositoryImportPermissionMergerTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/importexport/RepositoryImportPermissionMergerTest.java
@@ -1,0 +1,125 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.importexport;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Test;
+import sonia.scm.repository.RepositoryPermission;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RepositoryImportPermissionMergerTest {
+
+  private final RepositoryImportPermissionMerger merger = new RepositoryImportPermissionMerger();
+
+  @Test
+  void shouldReturnExistingPermissionsIfNoImportedPermissions() {
+    RepositoryPermission owner = new RepositoryPermission("owner", ImmutableSet.of("*"), false);
+    Collection<RepositoryPermission> existing = ImmutableSet.of(owner);
+    Collection<RepositoryPermission> imported = Collections.emptySet();
+
+    Collection<RepositoryPermission> result = merger.merge(existing, imported);
+
+    assertThat(result)
+      .hasSize(1)
+      .contains(owner);
+  }
+
+  @Test
+  void shouldReturnMergedPermissions() {
+    RepositoryPermission owner = new RepositoryPermission("owner", ImmutableSet.of("*"), false);
+    RepositoryPermission trillian = new RepositoryPermission("trillian", ImmutableSet.of("read"), false);
+    Collection<RepositoryPermission> existing = ImmutableSet.of(owner);
+    Collection<RepositoryPermission> imported = ImmutableSet.of(trillian);
+
+    Collection<RepositoryPermission> result = merger.merge(existing, imported);
+
+    assertThat(result)
+      .hasSize(2)
+      .contains(owner)
+      .contains(trillian);
+  }
+
+  @Test
+  void shouldReturnOnlyMergePermissionIfNotExistYet() {
+    RepositoryPermission owner = new RepositoryPermission("owner", ImmutableSet.of("*"), false);
+    RepositoryPermission trillian = new RepositoryPermission("trillian", ImmutableSet.of("read", "write"), false);
+    RepositoryPermission importedOwner = new RepositoryPermission("owner", ImmutableSet.of("read, write"), false);
+    RepositoryPermission importedTrillian = new RepositoryPermission("trillian", ImmutableSet.of("read"), false);
+
+    Collection<RepositoryPermission> existing = ImmutableSet.of(owner, trillian);
+    Collection<RepositoryPermission> imported = ImmutableSet.of(importedOwner, importedTrillian);
+
+    Collection<RepositoryPermission> result = merger.merge(existing, imported);
+
+    assertThat(result)
+      .hasSize(2)
+      .contains(owner)
+      .contains(trillian)
+      .doesNotContain(importedOwner)
+      .doesNotContain(importedTrillian);
+  }
+
+  @Test
+  void shouldAddPermissionWithSameNameIfOneIsGroupPermission() {
+    RepositoryPermission owner = new RepositoryPermission("owner", ImmutableSet.of("*"), false);
+    RepositoryPermission trillian = new RepositoryPermission("trillian", ImmutableSet.of("read", "write"), false);
+    RepositoryPermission importedOwner = new RepositoryPermission("owner", ImmutableSet.of("read, write"), true);
+    RepositoryPermission importedTrillian = new RepositoryPermission("trillian", ImmutableSet.of("read"), true);
+
+    Collection<RepositoryPermission> existing = ImmutableSet.of(owner, trillian);
+    Collection<RepositoryPermission> imported = ImmutableSet.of(importedOwner, importedTrillian);
+
+    Collection<RepositoryPermission> result = merger.merge(existing, imported);
+
+    assertThat(result)
+      .hasSize(4)
+      .contains(owner)
+      .contains(trillian)
+      .contains(importedOwner)
+      .contains(importedTrillian);
+  }
+
+  @Test
+  void shouldNotAddPermissionMultipleTimes() {
+    RepositoryPermission owner = new RepositoryPermission("owner", ImmutableSet.of("*"), false);
+    RepositoryPermission importedTrillian1 = new RepositoryPermission("trillian", ImmutableSet.of("read, write"), false);
+    RepositoryPermission importedTrillian2 = new RepositoryPermission("trillian", ImmutableSet.of("read"), false);
+
+    Collection<RepositoryPermission> existing = ImmutableSet.of(owner);
+    Collection<RepositoryPermission> imported = ImmutableSet.of(importedTrillian1, importedTrillian2);
+
+    Collection<RepositoryPermission> result = merger.merge(existing, imported);
+
+    assertThat(result)
+      .hasSize(2)
+      .contains(owner)
+      .contains(importedTrillian1)
+      .doesNotContain(importedTrillian2);
+  }
+}


### PR DESCRIPTION
## Proposed changes

On repository import from repository archive the existing permissions and the repository permissions from the archive will be merged. If permissions conflict the existing permission will is keep. 

### Your checklist for this pull request

- [x] PR is well described and the description can be used as commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
