### PR TITLE
Reduce time spend in configuration phase

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,7 @@ pipeline {
       }
       steps {
         withPublishEnivronment {
-          gradle "publish"
+          gradle "-Pdistribution publish"
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -107,6 +107,20 @@ Then you can attach a debugger on port 5005.
 The port can be changed by using the `--debug-port` e.g.: `--debug-port=5006`.
 If you want to wait until a debugger is attached, before SCM-Manager starts you can use the `--debug-wait` option.
 
+### Distribution
+
+SCM-Manager provides various modules to deploy SCM-Manager on differnt platforms (e.g. Docker, Helm, RPM, DEB, Windows).
+Those modules are not build by default. 
+To build the distribution modules specify the `distribution` property e.g.:
+
+```bash
+# on unix
+./gradlew -Pdistribution distribution
+
+# on windows
+gradlew.bat -Pdistribution distribution
+```
+
 ### Properties for publishing
 
 The publishing process requires the following properties for authentication and signing.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -67,11 +67,17 @@ include 'scm-dao-xml'
 include 'scm-webapp'
 include 'scm-server'
 include 'scm-it'
-include 'scm-packaging:unix'
-include 'scm-packaging:windows'
-include 'scm-packaging:deb'
-include 'scm-packaging:rpm'
-include 'scm-packaging:docker'
-include 'scm-packaging:helm'
-include 'scm-packaging:release-yaml'
+
+// Do not add scm-packaging modules to every build,
+// These modules drastically increase the time Gradle spends in the configuration phase.
+// To build a distribution of SCM-Manager you have to pass -Pdistribution
+if (settings.hasProperty("distribution")) {
+  include 'scm-packaging:unix'
+  include 'scm-packaging:windows'
+  include 'scm-packaging:deb'
+  include 'scm-packaging:rpm'
+  include 'scm-packaging:docker'
+  include 'scm-packaging:helm'
+  include 'scm-packaging:release-yaml'
+}
 


### PR DESCRIPTION
## Proposed changes

Do not add scm-packaging modules to every build.
These modules drastically increase the time Gradle spends in the configuration phase.
To build a distribution of SCM-Manager pass -Pdistribution.
Upgrade Gradle to 6.8.2.

### Your checklist for this pull request

- [X] PR is well described and the description can be used as commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [X] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [X] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
