### PR TITLE
Set core log level for scm by environment

### DIFF
--- a/docs/en/administration/logging.md
+++ b/docs/en/administration/logging.md
@@ -33,3 +33,7 @@ The location of the file depends also on the type of installation.
 | Windows | $EXTRACT_PATH/scm-server/conf/logging.xml |
 
 **$EXTRACT_PATH** is the path were you etract the content of the package.
+
+You can set the log level for scm to `TRACE`, `DEBUG`, `INFO`, `WARN` or `ERROR`
+by setting the environment variable `SCM_CORE_LOG_LEVEL` to one of these values.
+The default value is `INFO`.

--- a/gradle/changelog/set_log_level_by_environment.yaml
+++ b/gradle/changelog/set_log_level_by_environment.yaml
@@ -1,0 +1,2 @@
+- type: added
+  description: Set core scm log level by environment variable ([#1531](https://github.com/scm-manager/scm-manager/pull/1531))

--- a/scm-packaging/deb/src/main/fs/etc/scm/logging.xml
+++ b/scm-packaging/deb/src/main/fs/etc/scm/logging.xml
@@ -60,39 +60,41 @@
     <encoder>
       <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%-10X{transaction_id}] %-5level %logger - %msg%n</pattern>
     </encoder>
-    
+
   </appender>
 
-  <logger name="sonia.scm" level="INFO" />
-  <logger name="com.cloudogu.scm" level="INFO" />
+  <variable name="SCM_CORE_LOG_LEVEL" value="${SCM_CORE_LOG_LEVEL:-INFO}" />
+
+  <logger name="sonia.scm" level="${SCM_CORE_LOG_LEVEL}" />
+  <logger name="com.cloudogu.scm" level="${SCM_CORE_LOG_LEVEL}" />
 
   <!-- suppress massive gzip logging -->
   <logger name="sonia.scm.filter.GZipFilter" level="WARN" />
   <logger name="sonia.scm.filter.GZipResponseStream" level="WARN" />
-  
+
   <logger name="sonia.scm.util.ServiceUtil" level="WARN" />
-  
+
   <!-- event bus -->
   <logger name="sonia.scm.event.LegmanScmEventBus" level="INFO" />
-  
+
   <!-- shiro -->
   <!--
   <logger name="org.apache.shiro" level="INFO" />
   <logger name="org.apache.shiro.authc.pam.ModularRealmAuthenticator" level="DEBUG" />
   -->
-  
+
   <!-- svnkit -->
   <!--
   <logger name="svnkit" level="WARN" />
   <logger name="svnkit.network" level="DEBUG" />
   <logger name="svnkit.fsfs" level="WARN" />
   -->
-  
+
   <!-- javahg -->
   <!--
   <logger name="com.aragost.javahg" level="DEBUG" />
   -->
-  
+
   <!-- ehcache -->
   <!--
   <logger name="net.sf.ehcache" level="DEBUG" />

--- a/scm-packaging/docker/src/main/fs/etc/scm/logging.xml
+++ b/scm-packaging/docker/src/main/fs/etc/scm/logging.xml
@@ -42,8 +42,10 @@
 
   </appender>
 
-  <logger name="sonia.scm" level="INFO" />
-  <logger name="com.cloudogu.scm" level="INFO" />
+  <variable name="SCM_CORE_LOG_LEVEL" value="${SCM_CORE_LOG_LEVEL:-INFO}" />
+
+  <logger name="sonia.scm" level="${SCM_CORE_LOG_LEVEL}" />
+  <logger name="com.cloudogu.scm" level="${SCM_CORE_LOG_LEVEL}" />
 
   <!-- suppress massive gzip logging -->
   <logger name="sonia.scm.filter.GZipFilter" level="WARN" />

--- a/scm-packaging/rpm/src/main/fs/etc/scm/logging.xml
+++ b/scm-packaging/rpm/src/main/fs/etc/scm/logging.xml
@@ -60,39 +60,41 @@
     <encoder>
       <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%-10X{transaction_id}] %-5level %logger - %msg%n</pattern>
     </encoder>
-    
+
   </appender>
 
-  <logger name="sonia.scm" level="INFO" />
-  <logger name="com.cloudogu.scm" level="INFO" />
+  <variable name="SCM_CORE_LOG_LEVEL" value="${SCM_CORE_LOG_LEVEL:-INFO}" />
+
+  <logger name="sonia.scm" level="${SCM_CORE_LOG_LEVEL}" />
+  <logger name="com.cloudogu.scm" level="${SCM_CORE_LOG_LEVEL}" />
 
   <!-- suppress massive gzip logging -->
   <logger name="sonia.scm.filter.GZipFilter" level="WARN" />
   <logger name="sonia.scm.filter.GZipResponseStream" level="WARN" />
-  
+
   <logger name="sonia.scm.util.ServiceUtil" level="WARN" />
-  
+
   <!-- event bus -->
   <logger name="sonia.scm.event.LegmanScmEventBus" level="INFO" />
-  
+
   <!-- shiro -->
   <!--
   <logger name="org.apache.shiro" level="INFO" />
   <logger name="org.apache.shiro.authc.pam.ModularRealmAuthenticator" level="DEBUG" />
   -->
-  
+
   <!-- svnkit -->
   <!--
   <logger name="svnkit" level="WARN" />
   <logger name="svnkit.network" level="DEBUG" />
   <logger name="svnkit.fsfs" level="WARN" />
   -->
-  
+
   <!-- javahg -->
   <!--
   <logger name="com.aragost.javahg" level="DEBUG" />
   -->
-  
+
   <!-- ehcache -->
   <!--
   <logger name="net.sf.ehcache" level="DEBUG" />

--- a/scm-packaging/unix/src/main/fs/conf/logging.xml
+++ b/scm-packaging/unix/src/main/fs/conf/logging.xml
@@ -62,39 +62,41 @@
     <encoder>
       <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%-10X{transaction_id}] %-5level %logger - %msg%n</pattern>
     </encoder>
-    
+
   </appender>
 
-  <logger name="sonia.scm" level="INFO" />
-  <logger name="com.cloudogu.scm" level="INFO" />
+  <variable name="SCM_CORE_LOG_LEVEL" value="${SCM_CORE_LOG_LEVEL:-INFO}" />
+
+  <logger name="sonia.scm" level="${SCM_CORE_LOG_LEVEL}" />
+  <logger name="com.cloudogu.scm" level="${SCM_CORE_LOG_LEVEL}" />
 
   <!-- suppress massive gzip logging -->
   <logger name="sonia.scm.filter.GZipFilter" level="WARN" />
   <logger name="sonia.scm.filter.GZipResponseStream" level="WARN" />
-  
+
   <logger name="sonia.scm.util.ServiceUtil" level="WARN" />
-  
+
   <!-- event bus -->
   <logger name="sonia.scm.event.LegmanScmEventBus" level="INFO" />
-  
+
   <!-- shiro -->
   <!--
   <logger name="org.apache.shiro" level="INFO" />
   <logger name="org.apache.shiro.authc.pam.ModularRealmAuthenticator" level="DEBUG" />
   -->
-  
+
   <!-- svnkit -->
   <!--
   <logger name="svnkit" level="WARN" />
   <logger name="svnkit.network" level="DEBUG" />
   <logger name="svnkit.fsfs" level="WARN" />
   -->
-  
+
   <!-- javahg -->
   <!--
   <logger name="com.aragost.javahg" level="DEBUG" />
   -->
-  
+
   <!-- ehcache -->
   <!--
   <logger name="net.sf.ehcache" level="DEBUG" />

--- a/scm-packaging/windows/src/main/fs/conf/logging.xml
+++ b/scm-packaging/windows/src/main/fs/conf/logging.xml
@@ -53,8 +53,10 @@
     </encoder>
   </appender>
 
-  <logger name="sonia.scm" level="INFO" />
-  <logger name="com.cloudogu.scm" level="INFO" />
+  <variable name="SCM_CORE_LOG_LEVEL" value="${SCM_CORE_LOG_LEVEL:-INFO}" />
+
+  <logger name="sonia.scm" level="${SCM_CORE_LOG_LEVEL}" />
+  <logger name="com.cloudogu.scm" level="${SCM_CORE_LOG_LEVEL}" />
 
   <!-- suppress massive gzip logging -->
   <logger name="sonia.scm.filter.GZipFilter" level="WARN" />


### PR DESCRIPTION
## Proposed changes

This reads the environment variable 'SCM_CORE_LOG_LEVEL' in
the logback configuration and uses this value to set
the log level for 'sonia.scm' and 'com.cloudogu.scm'.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described and the description can be used as commit message on squash
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [x] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
