### PR TITLE
Fix broken mercurial http post args configuration

### DIFF
--- a/gradle/changelog/fix_hg_httppostargs.yaml
+++ b/gradle/changelog/fix_hg_httppostargs.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Fix broken mercurial http post args configuration ([#1532](https://github.com/scm-manager/scm-manager/issues/1532))

--- a/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/DefaultHgEnvironmentBuilder.java
+++ b/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/DefaultHgEnvironmentBuilder.java
@@ -57,8 +57,6 @@ public class DefaultHgEnvironmentBuilder implements HgEnvironmentBuilder {
   @VisibleForTesting
   static final String ENV_REPOSITORY_ID = "SCM_REPOSITORY_ID";
   @VisibleForTesting
-  static final String ENV_HTTP_POST_ARGS = "SCM_HTTP_POST_ARGS";
-  @VisibleForTesting
   static final String ENV_TRANSACTION_ID = "SCM_TRANSACTION_ID";
 
   private final AccessTokenBuilderFactory accessTokenBuilderFactory;
@@ -103,10 +101,6 @@ public class DefaultHgEnvironmentBuilder implements HgEnvironmentBuilder {
     env.put(ENV_REPOSITORY_NAME, repository.getNamespace() + "/" + repository.getName());
     env.put(ENV_REPOSITORY_ID, repository.getId());
     env.put(ENV_REPOSITORY_PATH, directory.getAbsolutePath());
-
-    // enable experimental httppostargs protocol of mercurial
-    // Issue 970: https://goo.gl/poascp
-    env.put(ENV_HTTP_POST_ARGS, String.valueOf(config.isEnableHttpPostArgs()));
   }
 
   private void write(ImmutableMap.Builder<String, String> env) {

--- a/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/web/HgCGIServlet.java
+++ b/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/web/HgCGIServlet.java
@@ -143,14 +143,14 @@ public class HgCGIServlet extends HttpServlet implements ScmProviderHttpServlet 
 
     File directory = handler.getDirectory(repository.getId());
     executor.setWorkDirectory(directory);
-    executor.setArgs(createArgs());
 
     HgConfig config = handler.getConfig();
+    executor.setArgs(createArgs(config));
     executor.execute(config.getHgBinary());
   }
 
   @Nonnull
-  private List<String> createArgs() {
+  private List<String> createArgs(HgConfig config) {
     List<String> args = new ArrayList<>();
     config(args, "extensions.cgiserve", extension.getAbsolutePath());
 
@@ -161,6 +161,11 @@ public class HgCGIServlet extends HttpServlet implements ScmProviderHttpServlet 
     config(args, "web.push_ssl", "false");
     config(args, "web.allow_read", "*");
     config(args, "web.allow_push", "*");
+
+    // enable experimental httppostargs protocol of mercurial
+    // Issue 970: https://goo.gl/poascp
+    config(args, "experimental.httppostargs", String.valueOf(config.isEnableHttpPostArgs()));
+
     args.add("cgiserve");
     return args;
   }

--- a/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/DefaultHgEnvironmentBuilderTest.java
+++ b/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/DefaultHgEnvironmentBuilderTest.java
@@ -136,7 +136,6 @@ class DefaultHgEnvironmentBuilderTest {
     assertThat(env)
       .containsEntry(ENV_REPOSITORY_ID, repositoryId)
       .containsEntry(ENV_REPOSITORY_NAME, "hitchhiker/HeartOfGold")
-      .containsEntry(ENV_HTTP_POST_ARGS, "false")
       .containsEntry(ENV_REPOSITORY_PATH, directory.resolve("repo").toAbsolutePath().toString());
   }
 


### PR DESCRIPTION
## Proposed changes

Fixes a regression which was introduced with #1416. In #1416 we have reimplemented the way configuration is passed to the mercurial cgi handler. Before #1416 we used environment variables which are picked up by `hgweb.py`, after #1416 we pass mercurial configurations as command line parameters directly in the HgCGIServlet. But sadly the configuration option for httppostargs uses still an environment variable, which is not picked up by anyone.

See #1525 

### Your checklist for this pull request

- [X] PR is well described and the description can be used as commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [X] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [X] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
