### PR TITLE
Fix filter redirect on paginated overview page

### DIFF
--- a/gradle/changelog/filter_on_pagination.yaml
+++ b/gradle/changelog/filter_on_pagination.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Wrong redirect on paginated overviews  ([#1535](https://github.com/scm-manager/scm-manager/pull/1535))

--- a/scm-ui/ui-components/src/OverviewPageActions.tsx
+++ b/scm-ui/ui-components/src/OverviewPageActions.tsx
@@ -80,7 +80,7 @@ const OverviewPageActions: FC<Props> = ({
           placeholder={searchPlaceholder}
           value={urls.getQueryStringFromLocation(location)}
           filter={filter => {
-            history.push(`/${link}/?q=${filter}`);
+            history.push(`${location.pathname}?q=${filter}`);
           }}
           testId={testId + "-filter"}
         />

--- a/scm-ui/ui-components/src/OverviewPageActions.tsx
+++ b/scm-ui/ui-components/src/OverviewPageActions.tsx
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import React, { FC } from "react";
+import React, { FC, useState } from "react";
 import { useHistory, useLocation } from "react-router-dom";
 import classNames from "classnames";
 import { Button, DropDown, urls } from "./index";
@@ -50,6 +50,7 @@ const OverviewPageActions: FC<Props> = ({
 }) => {
   const history = useHistory();
   const location = useLocation();
+  const [filterValue, setFilterValue] = useState(urls.getQueryStringFromLocation(location));
   const groupSelector = groups && (
     <div className={"column is-flex"}>
       <DropDown
@@ -72,6 +73,15 @@ const OverviewPageActions: FC<Props> = ({
     return null;
   };
 
+  const filter = (filter: string) => {
+    if ((filter && filter !== filterValue) || (!filter && filterValue)) {
+      history.push(`/${link}/?q=${filter}`);
+    } else {
+      history.push(`${location.pathname}?q=${filter}`);
+    }
+    setFilterValue(filter);
+  };
+
   return (
     <div className={"columns is-tablet"}>
       {groupSelector}
@@ -79,9 +89,7 @@ const OverviewPageActions: FC<Props> = ({
         <FilterInput
           placeholder={searchPlaceholder}
           value={urls.getQueryStringFromLocation(location)}
-          filter={filter => {
-            history.push(`${location.pathname}?q=${filter}`);
-          }}
+          filter={filter}
           testId={testId + "-filter"}
         />
       </div>


### PR DESCRIPTION
## Proposed changes
Fix unnecessary redirect on paginated overview pages which cuts the page number from url.

### Your checklist for this pull request

- [x] PR is well described and the description can be used as commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
