### PR TITLE
Bugfix for long filenames in tar

### DIFF
--- a/scm-core/build.gradle
+++ b/scm-core/build.gradle
@@ -98,6 +98,9 @@ dependencies {
   annotationProcessor libraries.sspProcessor
   testImplementation libraries.shiroUnit
 
+  // compression
+  implementation libraries.commonsCompress
+
   // tests
   testImplementation libraries.junitJupiterApi
   testImplementation libraries.junitJupiterParams

--- a/scm-core/src/main/java/sonia/scm/util/Archives.java
+++ b/scm-core/src/main/java/sonia/scm/util/Archives.java
@@ -27,8 +27,6 @@ package sonia.scm.util;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
-import sonia.scm.ContextEntry;
-import sonia.scm.repository.api.ExportFailedException;
 
 import java.io.BufferedOutputStream;
 import java.io.IOException;
@@ -121,9 +119,8 @@ public final class Archives {
           createArchiveEntryForFile(filePath, fileOrDir, taos);
         }
       } catch (IOException e) {
-        throw new ExportFailedException(
-          ContextEntry.ContextBuilder.noContext(),
-          "Could not export repository. Error on bundling files.",
+        throw new ArchiveException(
+          "Could not add file '" + fileOrDir + "' to tar archive as '" + path + "'",
           e
         );
       }
@@ -163,6 +160,12 @@ public final class Archives {
       if (!Files.exists(directory)) {
         Files.createDirectories(directory);
       }
+    }
+  }
+
+  public static final class ArchiveException extends RuntimeException {
+    public ArchiveException(String message, Throwable cause) {
+      super(message, cause);
     }
   }
 }

--- a/scm-core/src/main/java/sonia/scm/util/Archives.java
+++ b/scm-core/src/main/java/sonia/scm/util/Archives.java
@@ -1,0 +1,58 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.util;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+
+import java.io.BufferedOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public final class Archives {
+
+  private Archives() {
+  }
+
+  /**
+   * Creates a tar output stream that is backed by the given output stream.
+   * @param dest The stream the tar should be written to.
+   */
+  public static TarArchiveOutputStream writeTarStream(OutputStream dest) {
+    BufferedOutputStream bos = new BufferedOutputStream(dest);
+    TarArchiveOutputStream tarArchiveOutputStream = new TarArchiveOutputStream(bos);
+    tarArchiveOutputStream.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+    tarArchiveOutputStream.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
+    return tarArchiveOutputStream;
+  }
+
+  /**
+   * Creates a tar input stream that takes its bytes from the given input stream.
+   * @param source The stream the tar should be extracted from.
+   */
+  public static TarArchiveInputStream readTarStream(InputStream source) {
+    return new TarArchiveInputStream(source);
+  }
+}

--- a/scm-core/src/test/java/sonia/scm/util/ArchivesTest.java
+++ b/scm-core/src/test/java/sonia/scm/util/ArchivesTest.java
@@ -1,0 +1,67 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package sonia.scm.util;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.util.Collections.singleton;
+import static org.assertj.core.api.Assertions.assertThat;
+import static sonia.scm.util.Archives.addPathToTar;
+import static sonia.scm.util.Archives.extractTar;
+import static sonia.scm.util.Archives.createTarOutputStream;
+
+class ArchivesTest {
+
+  @Test
+  void writeAndReadTar(@TempDir Path temp) throws IOException {
+    Path source = temp.resolve("source");
+    Files.createDirectories(source);
+
+    Path file = source.resolve("file");
+    Path fileInDirectory = source.resolve("some").resolve("very").resolve("deep").resolve("nested").resolve("directory").resolve("with").resolve("file");
+    Files.createDirectories(fileInDirectory.getParent());
+
+    Files.write(file, singleton("content"));
+    Files.write(fileInDirectory, singleton("content in directory"));
+
+    Path tarFile = temp.resolve("test.tar");
+    try (OutputStream outputStream = Files.newOutputStream(tarFile)) {
+      addPathToTar(source, outputStream).run();
+    }
+
+    Path target = temp.resolve("target");
+    Files.createDirectories(target);
+    extractTar(Files.newInputStream(tarFile), target).run();
+
+    assertThat(target.resolve("file")).hasContent("content");
+    assertThat(target.resolve("some").resolve("very").resolve("deep").resolve("nested").resolve("directory").resolve("with").resolve("file")).hasContent("content in directory");
+  }
+}

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitBundleCommand.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitBundleCommand.java
@@ -28,8 +28,8 @@ import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import sonia.scm.ContextEntry;
 import sonia.scm.repository.api.BundleResponse;
 import sonia.scm.repository.api.ExportFailedException;
+import sonia.scm.util.Archives;
 
-import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -49,8 +49,7 @@ public class GitBundleCommand extends AbstractGitCommand implements BundleComman
     Path repoDir = context.getDirectory().toPath();
     if (Files.exists(repoDir)) {
       try (OutputStream os = request.getArchive().openStream();
-           BufferedOutputStream bos = new BufferedOutputStream(os);
-           TarArchiveOutputStream taos = new TarArchiveOutputStream(bos)) {
+           TarArchiveOutputStream taos = Archives.writeTarStream(os)) {
 
         createTarEntryForFiles("", repoDir, taos);
         taos.finish();

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitBundleCommand.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitBundleCommand.java
@@ -23,11 +23,9 @@
  */
 package sonia.scm.repository.spi;
 
-import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import sonia.scm.ContextEntry;
 import sonia.scm.repository.api.BundleResponse;
 import sonia.scm.repository.api.ExportFailedException;
-import sonia.scm.util.Archives;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -48,11 +46,8 @@ public class GitBundleCommand extends AbstractGitCommand implements BundleComman
   public BundleResponse bundle(BundleCommandRequest request) throws IOException {
     Path repoDir = context.getDirectory().toPath();
     if (Files.exists(repoDir)) {
-      try (OutputStream os = request.getArchive().openStream();
-           TarArchiveOutputStream taos = Archives.writeTarStream(os)) {
-
-        addPathToTar(repoDir, taos).withFilter(this::shouldIncludeFile).run();
-        taos.finish();
+      try (OutputStream os = request.getArchive().openStream()) {
+        addPathToTar(repoDir, os).withFilter(this::shouldIncludeFile).run();
       }
     } else {
       throw new ExportFailedException(

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitUnbundleCommand.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitUnbundleCommand.java
@@ -33,10 +33,10 @@ import sonia.scm.repository.api.UnbundleResponse;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static sonia.scm.util.Archives.readTarStream;
 
 public class GitUnbundleCommand extends AbstractGitCommand implements UnbundleCommand {
 
@@ -61,7 +61,7 @@ public class GitUnbundleCommand extends AbstractGitCommand implements UnbundleCo
   }
 
   private void unbundleRepositoryFromRequest(UnbundleCommandRequest request, Path repositoryDir) throws IOException {
-    try (TarArchiveInputStream tais = new TarArchiveInputStream(request.getArchive().openBufferedStream())) {
+    try (TarArchiveInputStream tais = readTarStream(request.getArchive().openBufferedStream())) {
       TarArchiveEntry entry;
       while ((entry = tais.getNextTarEntry()) != null) {
         Path filePath = repositoryDir.resolve(entry.getName());

--- a/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/GitBundleCommandTest.java
+++ b/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/GitBundleCommandTest.java
@@ -42,6 +42,7 @@ import java.nio.file.StandardCopyOption;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static sonia.scm.util.Archives.readTarStream;
 
 class GitBundleCommandTest {
 
@@ -94,7 +95,7 @@ class GitBundleCommandTest {
   }
 
   private void assertStreamContainsContent(ByteArrayOutputStream baos, String content) throws IOException {
-    TarArchiveInputStream tais = new TarArchiveInputStream(new BufferedInputStream(new ByteArrayInputStream(baos.toByteArray())));
+    TarArchiveInputStream tais = readTarStream(new BufferedInputStream(new ByteArrayInputStream(baos.toByteArray())));
     tais.getNextEntry();
 
     byte[] result = IOUtils.toByteArray(tais);

--- a/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/GitBundleCommandTest.java
+++ b/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/GitBundleCommandTest.java
@@ -42,7 +42,7 @@ import java.nio.file.StandardCopyOption;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static sonia.scm.util.Archives.readTarStream;
+import static sonia.scm.util.Archives.createTarInputStream;
 
 class GitBundleCommandTest {
 
@@ -95,7 +95,7 @@ class GitBundleCommandTest {
   }
 
   private void assertStreamContainsContent(ByteArrayOutputStream baos, String content) throws IOException {
-    TarArchiveInputStream tais = readTarStream(new BufferedInputStream(new ByteArrayInputStream(baos.toByteArray())));
+    TarArchiveInputStream tais = createTarInputStream(new BufferedInputStream(new ByteArrayInputStream(baos.toByteArray())));
     tais.getNextEntry();
 
     byte[] result = IOUtils.toByteArray(tais);

--- a/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/GitUnbundleCommandTest.java
+++ b/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/GitUnbundleCommandTest.java
@@ -30,8 +30,8 @@ import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import sonia.scm.util.Archives;
 
-import javax.annotation.Nonnull;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -82,9 +82,10 @@ class GitUnbundleCommandTest extends AbstractGitCommandTestBase {
 
   private UnbundleCommandRequest createUnbundleCommandRequestForFile(Path temp, String filePath, String fileContent) throws IOException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    TarArchiveOutputStream taos = new TarArchiveOutputStream(baos);
+    TarArchiveOutputStream taos = Archives.writeTarStream(baos);
     addEntry(taos, filePath, fileContent);
     taos.finish();
+    taos.close();
 
     when(gitContext.getDirectory()).thenReturn(temp.toFile());
     ByteSource byteSource = ByteSource.wrap(baos.toByteArray());

--- a/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/GitUnbundleCommandTest.java
+++ b/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/GitUnbundleCommandTest.java
@@ -82,7 +82,7 @@ class GitUnbundleCommandTest extends AbstractGitCommandTestBase {
 
   private UnbundleCommandRequest createUnbundleCommandRequestForFile(Path temp, String filePath, String fileContent) throws IOException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    TarArchiveOutputStream taos = Archives.writeTarStream(baos);
+    TarArchiveOutputStream taos = Archives.createTarOutputStream(baos);
     addEntry(taos, filePath, fileContent);
     taos.finish();
     taos.close();

--- a/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/spi/HgBundleCommand.java
+++ b/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/spi/HgBundleCommand.java
@@ -29,8 +29,8 @@ import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import sonia.scm.ContextEntry;
 import sonia.scm.repository.api.BundleResponse;
 import sonia.scm.repository.api.ExportFailedException;
+import sonia.scm.util.Archives;
 
-import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -52,8 +52,7 @@ public class HgBundleCommand implements BundleCommand {
     Path repoDir = context.getDirectory().toPath();
     if (Files.exists(repoDir)) {
       try (OutputStream os = request.getArchive().openStream();
-           BufferedOutputStream bos = new BufferedOutputStream(os);
-           TarArchiveOutputStream taos = new TarArchiveOutputStream(bos)) {
+           TarArchiveOutputStream taos = Archives.writeTarStream(os)) {
 
         createTarEntryForFiles("", repoDir, taos);
         taos.finish();

--- a/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/spi/HgBundleCommand.java
+++ b/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/spi/HgBundleCommand.java
@@ -24,7 +24,6 @@
 
 package sonia.scm.repository.spi;
 
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import sonia.scm.ContextEntry;
 import sonia.scm.repository.api.BundleResponse;
@@ -35,7 +34,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.stream.Stream;
+
+import static sonia.scm.util.Archives.addPathToTar;
 
 public class HgBundleCommand implements BundleCommand {
 
@@ -54,7 +54,7 @@ public class HgBundleCommand implements BundleCommand {
       try (OutputStream os = request.getArchive().openStream();
            TarArchiveOutputStream taos = Archives.writeTarStream(os)) {
 
-        createTarEntryForFiles("", repoDir, taos);
+        addPathToTar(repoDir, taos).run();
         taos.finish();
       }
     } else {
@@ -69,38 +69,5 @@ public class HgBundleCommand implements BundleCommand {
   @Override
   public String getFileExtension() {
     return TAR_ARCHIVE;
-  }
-
-  private void createTarEntryForFiles(String path, Path fileOrDir, TarArchiveOutputStream taos) throws IOException {
-    try (Stream<Path> files = Files.list(fileOrDir)) {
-      if (files != null) {
-        files.forEach(f -> bundleFileOrDir(path, f, taos));
-      }
-    }
-  }
-
-  private void bundleFileOrDir(String path, Path fileOrDir, TarArchiveOutputStream taos) {
-    try {
-      String filePath = path + "/" + fileOrDir.getFileName().toString();
-      if (Files.isDirectory(fileOrDir)) {
-        createTarEntryForFiles(filePath, fileOrDir, taos);
-      } else {
-        createArchiveEntryForFile(filePath, fileOrDir, taos);
-      }
-    } catch (IOException e) {
-      throw new ExportFailedException(
-        ContextEntry.ContextBuilder.noContext(),
-        "Could not export repository. Error on bundling files.",
-        e
-      );
-    }
-  }
-
-  private void createArchiveEntryForFile(String filePath, Path path, TarArchiveOutputStream taos) throws IOException {
-    TarArchiveEntry entry = new TarArchiveEntry(filePath);
-    entry.setSize(path.toFile().length());
-    taos.putArchiveEntry(entry);
-    Files.copy(path, taos);
-    taos.closeArchiveEntry();
   }
 }

--- a/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/spi/HgBundleCommand.java
+++ b/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/spi/HgBundleCommand.java
@@ -24,11 +24,9 @@
 
 package sonia.scm.repository.spi;
 
-import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import sonia.scm.ContextEntry;
 import sonia.scm.repository.api.BundleResponse;
 import sonia.scm.repository.api.ExportFailedException;
-import sonia.scm.util.Archives;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -51,11 +49,8 @@ public class HgBundleCommand implements BundleCommand {
   public BundleResponse bundle(BundleCommandRequest request) throws IOException {
     Path repoDir = context.getDirectory().toPath();
     if (Files.exists(repoDir)) {
-      try (OutputStream os = request.getArchive().openStream();
-           TarArchiveOutputStream taos = Archives.writeTarStream(os)) {
-
-        addPathToTar(repoDir, taos).run();
-        taos.finish();
+      try (OutputStream os = request.getArchive().openStream()) {
+        addPathToTar(repoDir, os).run();
       }
     } else {
       throw new ExportFailedException(

--- a/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/spi/HgUnbundleCommand.java
+++ b/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/spi/HgUnbundleCommand.java
@@ -25,8 +25,6 @@
 package sonia.scm.repository.spi;
 
 import com.google.common.io.ByteSource;
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sonia.scm.repository.api.UnbundleResponse;
@@ -34,10 +32,9 @@ import sonia.scm.repository.api.UnbundleResponse;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static sonia.scm.util.Archives.readTarStream;
+import static sonia.scm.util.Archives.extractTar;
 
 
 public class HgUnbundleCommand  implements UnbundleCommand {
@@ -64,20 +61,6 @@ public class HgUnbundleCommand  implements UnbundleCommand {
   }
 
   private void unbundleRepositoryFromRequest(UnbundleCommandRequest request, Path repositoryDir) throws IOException {
-    try (TarArchiveInputStream tais = readTarStream(request.getArchive().openBufferedStream())) {
-      TarArchiveEntry entry;
-      while ((entry = tais.getNextTarEntry()) != null) {
-        Path filePath = repositoryDir.resolve(entry.getName());
-        createDirectoriesIfNestedFile(filePath);
-        Files.copy(tais, filePath, StandardCopyOption.REPLACE_EXISTING);
-      }
-    }
-  }
-
-  private void createDirectoriesIfNestedFile(Path filePath) throws IOException {
-    Path directory = filePath.getParent();
-    if (!Files.exists(directory)) {
-      Files.createDirectories(directory);
-    }
+    extractTar(request.getArchive().openBufferedStream(), repositoryDir).run();
   }
 }

--- a/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/spi/HgUnbundleCommand.java
+++ b/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/spi/HgUnbundleCommand.java
@@ -37,6 +37,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static sonia.scm.util.Archives.readTarStream;
 
 
 public class HgUnbundleCommand  implements UnbundleCommand {
@@ -63,7 +64,7 @@ public class HgUnbundleCommand  implements UnbundleCommand {
   }
 
   private void unbundleRepositoryFromRequest(UnbundleCommandRequest request, Path repositoryDir) throws IOException {
-    try (TarArchiveInputStream tais = new TarArchiveInputStream(request.getArchive().openBufferedStream())) {
+    try (TarArchiveInputStream tais = readTarStream(request.getArchive().openBufferedStream())) {
       TarArchiveEntry entry;
       while ((entry = tais.getNextTarEntry()) != null) {
         Path filePath = repositoryDir.resolve(entry.getName());

--- a/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/spi/HgBundleCommandTest.java
+++ b/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/spi/HgBundleCommandTest.java
@@ -43,6 +43,7 @@ import java.nio.file.StandardCopyOption;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static sonia.scm.util.Archives.readTarStream;
 
 class HgBundleCommandTest {
 
@@ -95,7 +96,7 @@ class HgBundleCommandTest {
   }
 
   private void assertStreamContainsContent(ByteArrayOutputStream baos, String content) throws IOException {
-    TarArchiveInputStream tais = new TarArchiveInputStream(new BufferedInputStream(new ByteArrayInputStream(baos.toByteArray())));
+    TarArchiveInputStream tais = readTarStream(new BufferedInputStream(new ByteArrayInputStream(baos.toByteArray())));
     tais.getNextEntry();
 
     byte[] result = IOUtils.toByteArray(tais);

--- a/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/spi/HgBundleCommandTest.java
+++ b/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/spi/HgBundleCommandTest.java
@@ -43,7 +43,7 @@ import java.nio.file.StandardCopyOption;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static sonia.scm.util.Archives.readTarStream;
+import static sonia.scm.util.Archives.createTarInputStream;
 
 class HgBundleCommandTest {
 
@@ -96,7 +96,7 @@ class HgBundleCommandTest {
   }
 
   private void assertStreamContainsContent(ByteArrayOutputStream baos, String content) throws IOException {
-    TarArchiveInputStream tais = readTarStream(new BufferedInputStream(new ByteArrayInputStream(baos.toByteArray())));
+    TarArchiveInputStream tais = createTarInputStream(new BufferedInputStream(new ByteArrayInputStream(baos.toByteArray())));
     tais.getNextEntry();
 
     byte[] result = IOUtils.toByteArray(tais);

--- a/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/spi/HgUnbundleCommandTest.java
+++ b/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/spi/HgUnbundleCommandTest.java
@@ -31,6 +31,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import sonia.scm.util.Archives;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -82,9 +83,10 @@ class HgUnbundleCommandTest {
 
   private UnbundleCommandRequest createUnbundleCommandRequestForFile(Path temp, String filePath, String fileContent) throws IOException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    TarArchiveOutputStream taos = new TarArchiveOutputStream(baos);
+    TarArchiveOutputStream taos = Archives.writeTarStream(baos);
     addEntry(taos, filePath, fileContent);
     taos.finish();
+    taos.close();
 
     when(hgContext.getDirectory()).thenReturn(temp.toFile());
     ByteSource byteSource = ByteSource.wrap(baos.toByteArray());

--- a/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/spi/HgUnbundleCommandTest.java
+++ b/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/spi/HgUnbundleCommandTest.java
@@ -83,7 +83,7 @@ class HgUnbundleCommandTest {
 
   private UnbundleCommandRequest createUnbundleCommandRequestForFile(Path temp, String filePath, String fileContent) throws IOException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    TarArchiveOutputStream taos = Archives.writeTarStream(baos);
+    TarArchiveOutputStream taos = Archives.createTarOutputStream(baos);
     addEntry(taos, filePath, fileContent);
     taos.finish();
     taos.close();

--- a/scm-webapp/src/main/java/sonia/scm/importexport/FullScmRepositoryExporter.java
+++ b/scm-webapp/src/main/java/sonia/scm/importexport/FullScmRepositoryExporter.java
@@ -85,7 +85,7 @@ public class FullScmRepositoryExporter {
       RepositoryService service = serviceFactory.create(repository);
       BufferedOutputStream bos = new BufferedOutputStream(outputStream);
       GzipCompressorOutputStream gzos = new GzipCompressorOutputStream(bos);
-      TarArchiveOutputStream taos = Archives.writeTarStream(gzos)
+      TarArchiveOutputStream taos = Archives.createTarOutputStream(gzos)
     ) {
       writeEnvironmentData(taos);
       writeMetadata(repository, taos);

--- a/scm-webapp/src/main/java/sonia/scm/importexport/FullScmRepositoryExporter.java
+++ b/scm-webapp/src/main/java/sonia/scm/importexport/FullScmRepositoryExporter.java
@@ -34,6 +34,7 @@ import sonia.scm.repository.api.ExportFailedException;
 import sonia.scm.repository.api.RepositoryService;
 import sonia.scm.repository.api.RepositoryServiceFactory;
 import sonia.scm.repository.work.WorkdirProvider;
+import sonia.scm.util.Archives;
 import sonia.scm.util.IOUtil;
 
 import javax.inject.Inject;
@@ -84,7 +85,7 @@ public class FullScmRepositoryExporter {
       RepositoryService service = serviceFactory.create(repository);
       BufferedOutputStream bos = new BufferedOutputStream(outputStream);
       GzipCompressorOutputStream gzos = new GzipCompressorOutputStream(bos);
-      TarArchiveOutputStream taos = new TarArchiveOutputStream(gzos)
+      TarArchiveOutputStream taos = Archives.writeTarStream(gzos)
     ) {
       writeEnvironmentData(taos);
       writeMetadata(repository, taos);

--- a/scm-webapp/src/main/java/sonia/scm/importexport/FullScmRepositoryImporter.java
+++ b/scm-webapp/src/main/java/sonia/scm/importexport/FullScmRepositoryImporter.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import static java.util.Arrays.stream;
+import static sonia.scm.util.Archives.readTarStream;
 
 public class FullScmRepositoryImporter {
 
@@ -65,7 +66,7 @@ public class FullScmRepositoryImporter {
         try (
           BufferedInputStream bif = new BufferedInputStream(inputStream);
           GzipCompressorInputStream gcis = new GzipCompressorInputStream(bif);
-          TarArchiveInputStream tais = new TarArchiveInputStream(gcis)
+          TarArchiveInputStream tais = readTarStream(gcis)
         ) {
           return run(repository, tais);
         }

--- a/scm-webapp/src/main/java/sonia/scm/importexport/FullScmRepositoryImporter.java
+++ b/scm-webapp/src/main/java/sonia/scm/importexport/FullScmRepositoryImporter.java
@@ -40,7 +40,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import static java.util.Arrays.stream;
-import static sonia.scm.util.Archives.readTarStream;
+import static sonia.scm.util.Archives.createTarInputStream;
 
 public class FullScmRepositoryImporter {
 
@@ -66,7 +66,7 @@ public class FullScmRepositoryImporter {
         try (
           BufferedInputStream bif = new BufferedInputStream(inputStream);
           GzipCompressorInputStream gcis = new GzipCompressorInputStream(bif);
-          TarArchiveInputStream tais = readTarStream(gcis)
+          TarArchiveInputStream tais = createTarInputStream(gcis)
         ) {
           return run(repository, tais);
         }

--- a/scm-webapp/src/main/java/sonia/scm/importexport/TarArchiveRepositoryStoreExporter.java
+++ b/scm-webapp/src/main/java/sonia/scm/importexport/TarArchiveRepositoryStoreExporter.java
@@ -35,9 +35,9 @@ import sonia.scm.store.ExportableStore;
 import sonia.scm.store.StoreEntryMetaData;
 import sonia.scm.store.StoreExporter;
 import sonia.scm.store.StoreType;
+import sonia.scm.util.Archives;
 
 import javax.inject.Inject;
-import java.io.BufferedOutputStream;
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -58,8 +58,7 @@ public class TarArchiveRepositoryStoreExporter {
 
   public void export(Repository repository, OutputStream output) {
     try (
-      BufferedOutputStream bos = new BufferedOutputStream(output);
-      final TarArchiveOutputStream taos = new TarArchiveOutputStream(bos)
+      final TarArchiveOutputStream taos = Archives.writeTarStream(output)
     ) {
       List<ExportableStore> exportableStores = storeExporter.listExportableStores(repository);
       for (ExportableStore store : exportableStores) {

--- a/scm-webapp/src/main/java/sonia/scm/importexport/TarArchiveRepositoryStoreExporter.java
+++ b/scm-webapp/src/main/java/sonia/scm/importexport/TarArchiveRepositoryStoreExporter.java
@@ -58,7 +58,7 @@ public class TarArchiveRepositoryStoreExporter {
 
   public void export(Repository repository, OutputStream output) {
     try (
-      final TarArchiveOutputStream taos = Archives.writeTarStream(output)
+      final TarArchiveOutputStream taos = Archives.createTarOutputStream(output)
     ) {
       List<ExportableStore> exportableStores = storeExporter.listExportableStores(repository);
       for (ExportableStore store : exportableStores) {


### PR DESCRIPTION
## Proposed changes

Fixes errors with long file names in tar archives. This may arise with hg repositories with deep directories.

This has no changelog because this is a fix for an unreleased feature.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described and the description can be used as commit message on squash
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
