### PR TITLE
Enable refetch on focus

### DIFF
--- a/scm-ui/ui-api/src/ApiProvider.tsx
+++ b/scm-ui/ui-api/src/ApiProvider.tsx
@@ -31,9 +31,7 @@ import { reset } from "./reset";
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      retry: false,
-      // refetch on focus can reset form inputs
-      refetchOnWindowFocus: false
+      retry: false
     }
   }
 });

--- a/scm-ui/ui-webapp/src/repos/containers/RepositoryRoot.tsx
+++ b/scm-ui/ui-webapp/src/repos/containers/RepositoryRoot.tsx
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 import React from "react";
-import { Redirect, Route, Link as RouteLink, Switch, useRouteMatch, match } from "react-router-dom";
+import { Redirect, Route, Link as RouteLink, Switch, useRouteMatch } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { binder, ExtensionPoint } from "@scm-manager/ui-extensions";
 import { Changeset, Link } from "@scm-manager/ui-types";
@@ -245,7 +245,9 @@ const RepositoryRoot = () => {
               <Redirect exact from={`${url}/changesets`} to={`${url}/code/changesets`} />
               <Redirect from={`${url}/branch/:branch/changesets`} to={`${url}/code/branch/:branch/changesets/`} />
 
-              <Route path={`${url}/info`} exact component={() => <RepositoryDetails repository={repository} />} />
+              <Route path={`${url}/info`} exact>
+                <RepositoryDetails repository={repository} />
+              </Route>
               <Route path={`${url}/settings/general`}>
                 <EditRepo repository={repository} />
               </Route>


### PR DESCRIPTION
## Proposed changes

During the integration of react-query we had to disable the refetch on focus option, because it has cleared our input fields on refocusing the browser tab. This problem comes mostly from a wrong use of routes. Often routes were used with the component prop and a anonymous function e.g.:

```jsx
<Route path="/my/route" component={() => <AwesomeComponent />} />
```

This triggers not only rerendering but remounting of the route component every time the parent is rerendered. With the ongoing work on the migration from redux to react-query, we have removed the usage of routes with component functions. So we can now safely enable the option refetch on mount of react-query.

### Your checklist for this pull request

- [X] PR is well described and the description can be used as commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
