### PR TITLE
Prevent breadcrumb overflow and shrink large elements

### DIFF
--- a/gradle/changelog/long_breadcrumb.yaml
+++ b/gradle/changelog/long_breadcrumb.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Prevent breadcrumb overflow and shrink large elements ([#1563](https://github.com/scm-manager/scm-manager/pull/1563))

--- a/scm-ui/ui-components/src/Breadcrumb.stories.tsx
+++ b/scm-ui/ui-components/src/Breadcrumb.stories.tsx
@@ -38,6 +38,8 @@ const Wrapper = styled.div`
 
 const master = { name: "master", revision: "1", defaultBranch: true, _links: {} };
 const path = "src/main/java/com/cloudogu";
+const longPath =
+  "dream-path/src/main/scm-plugins/javaUtilityHomeHousingLinkReferrer/sonia/scm/repositoryUndergroundSupportManager/spi/SvnRepositoryServiceResolver.java";
 const baseUrl = "scm-manager.org/scm/repo/hitchhiker/heartOfGold/sources";
 const sources = Git;
 
@@ -54,5 +56,17 @@ storiesOf("BreadCrumb", module)
       sources={sources}
       revision={"1"}
       permalink={"/" + path}
+    />
+  ))
+  .add("Long path", () => (
+    <Breadcrumb
+      repository={repository}
+      defaultBranch={master}
+      branch={master}
+      path={longPath}
+      baseUrl={baseUrl}
+      sources={sources}
+      revision={"1"}
+      permalink={"/" + longPath}
     />
   ));

--- a/scm-ui/ui-components/src/Breadcrumb.tsx
+++ b/scm-ui/ui-components/src/Breadcrumb.tsx
@@ -78,7 +78,7 @@ const BreadcrumbNav = styled.nav`
 
   /* sizing of each item */
   li {
-    max-width: calc(33.333% - 0.5rem);
+    max-width: 375px;
     a {
       display: initial;
     }

--- a/scm-ui/ui-components/src/Breadcrumb.tsx
+++ b/scm-ui/ui-components/src/Breadcrumb.tsx
@@ -62,7 +62,27 @@ const PermaLinkWrapper = styled.div`
 
 const BreadcrumbNav = styled.nav`
   flex: 1;
-  margin: 1rem 0.5rem !important;
+  width: 100%;
+
+  /* move slash to end */
+  li + li::before {
+    content: none;
+  }
+  li:not(:last-child)::after {
+    color: #b5b5b5; //$breadcrumb-item-separator-color
+    content: "\\0002f";
+  }
+  li:first-child {
+    margin-left: 0.75rem;
+  }
+
+  /* sizing of each item */
+  li {
+    max-width: calc(33.333% - 0.5rem);
+    a {
+      display: initial;
+    }
+  }
 `;
 
 const HomeIcon = styled(Icon)`
@@ -101,7 +121,7 @@ const Breadcrumb: FC<Props> = ({ repository, branch, defaultBranch, revision, pa
         if (paths.length - 1 === index) {
           return (
             <li className="is-active" key={index}>
-              <Link to="#" aria-current="page">
+              <Link className="is-ellipsis-overflow" to="#" aria-current="page">
                 {pathFragment}
               </Link>
             </li>
@@ -109,7 +129,13 @@ const Breadcrumb: FC<Props> = ({ repository, branch, defaultBranch, revision, pa
         }
         return (
           <li key={index}>
-            <Link to={baseUrl + "/" + encodeURIComponent(revision) + "/" + currPath}>{pathFragment}</Link>
+            <Link
+              className="is-ellipsis-overflow"
+              title={pathFragment}
+              to={baseUrl + "/" + encodeURIComponent(revision) + "/" + currPath}
+            >
+              {pathFragment}
+            </Link>
           </li>
         );
       });
@@ -132,8 +158,8 @@ const Breadcrumb: FC<Props> = ({ repository, branch, defaultBranch, revision, pa
 
   return (
     <>
-      <div className="is-flex is-align-items-center">
-        <PermaLinkWrapper>
+      <div className="is-flex is-align-items-center ml-5 my-4 mr-3">
+        <PermaLinkWrapper className="ml-1">
           {copying ? (
             <Icon name="spinner fa-spin" />
           ) : (
@@ -142,7 +168,10 @@ const Breadcrumb: FC<Props> = ({ repository, branch, defaultBranch, revision, pa
             </Tooltip>
           )}
         </PermaLinkWrapper>
-        <BreadcrumbNav className={classNames("breadcrumb", "sources-breadcrumb")} aria-label="breadcrumbs">
+        <BreadcrumbNav
+          className={classNames("breadcrumb", "sources-breadcrumb", "ml-1", "mb-0")}
+          aria-label="breadcrumbs"
+        >
           <ul>
             <li>
               <Link to={homeUrl}>

--- a/scm-ui/ui-webapp/src/repos/sources/containers/Content.tsx
+++ b/scm-ui/ui-webapp/src/repos/sources/containers/Content.tsx
@@ -122,9 +122,11 @@ class Content extends React.Component<Props, State> {
     return (
       <span className="has-cursor-pointer">
         <div className={classNames("media", "is-flex", "is-align-items-center")}>
-          <div className="media-content" onClick={this.toggleCollapse}>
-            <RightMarginIcon name={icon} color="inherit" />
-            <span className="is-word-break">{file.name}</span>
+          <div className={classNames("media-content", "mr-3")} onClick={this.toggleCollapse}>
+            <div className="is-word-break">
+              <RightMarginIcon className="is-inline" name={`${icon} fa-fw`} color="inherit" />
+              {file.name}
+            </div>
           </div>
           <div className="buttons is-grouped">
             {selector}


### PR DESCRIPTION
## Proposed changes

- Restore left margin on copy permalink
- Move slash to the right to make it resemble the console
- Shrink large elements
- Add new storyshot
- Fix separation of toggle icon and file title

### Your checklist for this pull request

- [x] PR is well described and the description can be used as commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
