### PR TITLE
Fix endless loading spinner for sources of empty repositories

### DIFF
--- a/gradle/changelog/fix_loading_source_of_empty_repo.yaml
+++ b/gradle/changelog/fix_loading_source_of_empty_repo.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Fix endless loading spinner for sources of empty repositories ([#1565](https://github.com/scm-manager/scm-manager/issues/1565))

--- a/scm-ui/ui-api/src/sources.test.ts
+++ b/scm-ui/ui-api/src/sources.test.ts
@@ -120,7 +120,7 @@ describe("Test sources hooks", () => {
   });
 
   const firstChild = (directory?: File) => {
-    if (directory?._embedded.children && directory._embedded.children.length > 0) {
+    if (directory?._embedded?.children && directory._embedded.children.length > 0) {
       return directory._embedded.children[0];
     }
   };

--- a/scm-ui/ui-webapp/public/locales/de/repos.json
+++ b/scm-ui/ui-webapp/public/locales/de/repos.json
@@ -195,7 +195,8 @@
   "code": {
     "sources": "Sources",
     "commits": "Commits",
-    "branchSelector": "Branches"
+    "branchSelector": "Branches",
+    "noBranches": "Keine Sources für das Repository gefunden."
   },
   "changesets": {
     "errorTitle": "Fehler",

--- a/scm-ui/ui-webapp/public/locales/en/repos.json
+++ b/scm-ui/ui-webapp/public/locales/en/repos.json
@@ -195,7 +195,8 @@
   "code": {
     "sources": "Sources",
     "commits": "Commits",
-    "branchSelector": "Branches"
+    "branchSelector": "Branches",
+    "noBranches": "No sources found for this repository."
   },
   "changesets": {
     "errorTitle": "Error",

--- a/scm-ui/ui-webapp/src/repos/codeSection/containers/CodeOverview.tsx
+++ b/scm-ui/ui-webapp/src/repos/codeSection/containers/CodeOverview.tsx
@@ -26,7 +26,7 @@ import { Route, useLocation } from "react-router-dom";
 import Sources from "../../sources/containers/Sources";
 import ChangesetsRoot from "../../containers/ChangesetsRoot";
 import { Branch, Repository } from "@scm-manager/ui-types";
-import { ErrorPage, Loading } from "@scm-manager/ui-components";
+import { ErrorPage, Loading, Notification } from "@scm-manager/ui-components";
 import { useTranslation } from "react-i18next";
 import { useBranches } from "@scm-manager/ui-api";
 
@@ -57,7 +57,7 @@ const CodeOverviewWithBranches: FC<Props> = ({ repository, baseUrl }) => {
   const { isLoading, error, data } = useBranches(repository);
   const selectedBranch = useSelectedBranch();
   const [t] = useTranslation("repos");
-  const branches = data?._embedded.branches;
+  const branches = data?._embedded.branches || [];
 
   if (isLoading) {
     return <Loading />;
@@ -67,6 +67,10 @@ const CodeOverviewWithBranches: FC<Props> = ({ repository, baseUrl }) => {
     return (
       <ErrorPage title={t("repositoryRoot.errorTitle")} subtitle={t("repositoryRoot.errorSubtitle")} error={error} />
     );
+  }
+
+  if (branches.length === 0) {
+    return <Notification type="info">{t("code.noBranches")}</Notification>;
   }
 
   return <CodeRouting repository={repository} baseUrl={baseUrl} branches={branches} selectedBranch={selectedBranch} />;

--- a/scm-ui/ui-webapp/src/repos/sources/components/FileTree.tsx
+++ b/scm-ui/ui-webapp/src/repos/sources/components/FileTree.tsx
@@ -30,6 +30,7 @@ import { File } from "@scm-manager/ui-types";
 import { Notification } from "@scm-manager/ui-components";
 import FileTreeLeaf from "./FileTreeLeaf";
 import TruncatedNotification from "./TruncatedNotification";
+import {isRootPath} from "../utils/files";
 
 type Props = {
   directory: File;
@@ -60,7 +61,7 @@ const FileTree: FC<Props> = ({ directory, baseUrl, revision, fetchNextPage, isFe
   const { path } = directory;
   const files: File[] = [];
 
-  if (path) {
+  if (!isRootPath(path)) {
     files.push({
       name: "..",
       path: findParent(path),
@@ -73,13 +74,9 @@ const FileTree: FC<Props> = ({ directory, baseUrl, revision, fetchNextPage, isFe
     });
   }
 
-  files.push(...(directory._embedded.children || []));
+  files.push(...(directory._embedded?.children || []));
 
   const baseUrlWithRevision = baseUrl + "/" + encodeURIComponent(revision);
-
-  if (!files || files.length === 0) {
-    return <Notification type="info">{t("sources.noSources")}</Notification>;
-  }
 
   return (
     <div className="panel-block">

--- a/scm-ui/ui-webapp/src/repos/sources/utils/files.test.ts
+++ b/scm-ui/ui-webapp/src/repos/sources/utils/files.test.ts
@@ -1,0 +1,111 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+import { File } from "@scm-manager/ui-types";
+import { isEmptyDirectory, isRootFile, isRootPath } from "./files";
+
+describe("files tests", () => {
+  const createRootDirectory = (): File => {
+    return {
+      name: "",
+      path: "/",
+      revision: "42",
+      directory: true,
+      _links: {},
+      _embedded: {
+        children: []
+      }
+    };
+  };
+
+  const readme: File = {
+    name: "README.md",
+    path: "README.md",
+    revision: "42",
+    directory: false,
+    _links: {}
+  };
+
+  describe("isRootPath tests", () => {
+    it("should return false", () => {
+      const paths = ["a", "b/c", "/a"];
+      for (const p of paths) {
+        expect(isRootPath(p)).toBe(false);
+      }
+    });
+
+    it("should return true", () => {
+      const paths = ["", "/"];
+      for (const p of paths) {
+        expect(isRootPath(p)).toBe(true);
+      }
+    });
+  });
+
+  describe("isRootFile tests", () => {
+    it("should return false, if it is not a directory", () => {
+      const file = createRootDirectory();
+      file.directory = false;
+      expect(isRootFile(file)).toBe(false);
+    });
+
+    it("should return true", () => {
+      const directory = createRootDirectory();
+      expect(isRootFile(directory)).toBe(true);
+    });
+  });
+
+  describe("isEmptyDirectory tests", () => {
+    it("should return false, if it is not a directory", () => {
+      const directory = createRootDirectory();
+      directory.directory = false;
+      directory._embedded.children = [readme];
+      expect(isEmptyDirectory(directory)).toBe(false);
+    });
+
+    it("should return false, if it is not empty", () => {
+      const directory = createRootDirectory();
+      directory._embedded.children = [readme];
+      expect(isEmptyDirectory(directory)).toBe(false);
+    });
+
+    it("should return true, if children is empty", () => {
+      const directory = createRootDirectory();
+      expect(isEmptyDirectory(directory)).toBe(true);
+    });
+
+    it("should return true, if children is undefined", () => {
+      const directory = createRootDirectory();
+      directory._embedded.children = undefined;
+      expect(isEmptyDirectory(directory)).toBe(true);
+    });
+
+    it("should return true, if _embedded is undefined", () => {
+      const directory = createRootDirectory();
+      directory._embedded = undefined;
+      expect(isEmptyDirectory(directory)).toBe(true);
+    });
+  });
+});

--- a/scm-ui/ui-webapp/src/repos/sources/utils/files.ts
+++ b/scm-ui/ui-webapp/src/repos/sources/utils/files.ts
@@ -20,30 +20,25 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
+ *
  */
 
-import { Links } from "./hal";
+import { File } from "@scm-manager/ui-types";
 
-export type SubRepository = {
-  repositoryUrl: string;
-  browserUrl: string;
-  revision: string;
+export const isRootPath = (path: string) => {
+  return path === "" || path === "/";
 };
 
-export type File = {
-  name: string;
-  path: string;
-  directory: boolean;
-  description?: string;
-  revision: string;
-  length?: number;
-  commitDate?: string;
-  subRepository?: SubRepository;
-  partialResult?: boolean;
-  computationAborted?: boolean;
-  truncated?: boolean;
-  _links: Links;
-  _embedded?: {
-    children?: File[] | null;
-  };
+export const isRootFile = (file: File) => {
+  if (!file.directory) {
+    return false;
+  }
+  return isRootPath(file.path);
+};
+
+export const isEmptyDirectory = (file: File) => {
+  if (!file.directory) {
+    return false;
+  }
+  return (file._embedded?.children?.length || 0) === 0;
 };


### PR DESCRIPTION
## Proposed changes

Fixes endless loading spinner when clicking on "code" of an empty repository. A notification, that the repository is empty, is shown if the list of branches is empty. If the repository type does not support branches, the message is shown if the root directory is empty or the list of commits is empty.

### Your checklist for this pull request

- [X] PR is well described and the description can be used as commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [X] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
