### PR TITLE
Clarify that FileUpload component does not upload directly

### DIFF
--- a/gradle/changelog/adjust_fileupload.yaml
+++ b/gradle/changelog/adjust_fileupload.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Clarify that FileUpload component does not upload directly ([#1566](https://github.com/scm-manager/scm-manager/pull/1566))

--- a/scm-ui/ui-components/src/forms/FileUpload.tsx
+++ b/scm-ui/ui-components/src/forms/FileUpload.tsx
@@ -51,7 +51,7 @@ const FileUpload: FC<Props> = ({ handleFile }) => {
         />
         <span className="file-cta">
           <span className="file-icon">
-            <i className="fas fa-upload" />
+            <i className="fas fa-arrow-circle-up" />
           </span>
           <span className="file-label">{t("fileUpload.label")}</span>
         </span>

--- a/scm-ui/ui-styles/public/index.html
+++ b/scm-ui/ui-styles/public/index.html
@@ -971,6 +971,28 @@
         <tr>
           <td>
             <a class="level-item">
+              <span class="tooltip has-tooltip-top" data-tooltip="fas fa-arrow-circle-up">
+                <i class="fas fa-lg fa-arrow-circle-up"></i>
+              </span>
+            </a>
+          </td>
+          <td><code>arrow-circle-up</code></td>
+          <td>Upload</td>
+        </tr>
+        <tr>
+          <td>
+            <a class="level-item">
+              <span class="tooltip has-tooltip-top" data-tooltip="fas fa-arrow-circle-down">
+                <i class="fas fa-lg fa-arrow-circle-down"></i>
+              </span>
+            </a>
+          </td>
+          <td><code>arrow-circle-down</code></td>
+          <td>Download</td>
+        </tr>
+        <tr>
+          <td>
+            <a class="level-item">
               <span class="tooltip has-tooltip-top" data-tooltip="fas fa-archive">
                 <i class="fas fa-lg fa-archive"></i>
               </span>
@@ -1709,8 +1731,8 @@
         <label class="file-label">
           <input class="file-input" name="resume" type="file">
           <span class="file-cta">
-              <span class="file-icon"><i class="fas fa-upload"></i></span>
-              <span class="file-label">Upload File</span>
+              <span class="file-icon"><i class="fas fa-arrow-circle-up"></i></span>
+              <span class="file-label">Select File</span>
             </span>
           <span class="file-name">2fRNLPdVq2.tar.gz</span>
         </label>

--- a/scm-ui/ui-webapp/public/locales/de/commons.json
+++ b/scm-ui/ui-webapp/public/locales/de/commons.json
@@ -120,7 +120,7 @@
     "lastDivider": "und"
   },
   "fileUpload": {
-    "label": "Datei hochladen"
+    "label": "Datei auswählen"
   },
   "importLog": {
     "title": "Importprotokoll"

--- a/scm-ui/ui-webapp/public/locales/en/commons.json
+++ b/scm-ui/ui-webapp/public/locales/en/commons.json
@@ -121,7 +121,7 @@
     "lastDivider": "and"
   },
   "fileUpload": {
-    "label": "Upload File"
+    "label": "Select File"
   },
   "importLog": {
     "title": "Import Log"


### PR DESCRIPTION
## Proposed changes

Clarify that FileUpload component does not upload directly:
Changed label from “Upload” to “Select File” and icon from _direct_ to _a kind of_ upload.

### Your checklist for this pull request

- [x] PR is well described and the description can be used as commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
