### PR TITLE
Fix wrapping of title and actions in source view

### DIFF
--- a/gradle/changelog/sources_wrapping.yaml
+++ b/gradle/changelog/sources_wrapping.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Fix wrapping of title and actions in source view ([#1569](https://github.com/scm-manager/scm-manager/issues/1569))

--- a/scm-ui/ui-components/src/repos/DiffFile.tsx
+++ b/scm-ui/ui-components/src/repos/DiffFile.tsx
@@ -64,12 +64,6 @@ const DiffFilePanel = styled.div`
   ${(props: Collapsible) => (props.collapsed ? "border-bottom: none;" : "")};
 `;
 
-const FlexWrapLevel = styled.div`
-  /* breaks into a second row
-     when buttons and title become too long */
-  flex-wrap: wrap;
-`;
-
 const FullWidthTitleHeader = styled.div`
   max-width: 100%;
 `;
@@ -78,8 +72,7 @@ const TitleWrapper = styled.span`
   margin-left: 0.25rem;
 `;
 
-const ButtonWrapper = styled.div`
-  /* align child to right */
+const AlignRight = styled.div`
   margin-left: auto;
 `;
 
@@ -460,13 +453,13 @@ class DiffFile extends React.Component<Props, State> {
       </MenuContext.Consumer>
     );
     const headerButtons = (
-      <ButtonWrapper className={classNames("level-right", "is-flex")}>
+      <AlignRight className={classNames("level-right", "is-flex")}>
         <ButtonGroup>
           {sideBySideToggle}
           {openInFullscreen}
           {fileControls}
         </ButtonGroup>
-      </ButtonWrapper>
+      </AlignRight>
     );
 
     let errorModal;
@@ -489,7 +482,7 @@ class DiffFile extends React.Component<Props, State> {
       >
         {errorModal}
         <div className="panel-heading">
-          <FlexWrapLevel className="level">
+          <div className={classNames("level", "is-flex-wrap-wrap")}>
             <FullWidthTitleHeader
               className={classNames("level-left", "is-flex", "has-cursor-pointer")}
               onClick={this.toggleCollapse}
@@ -502,7 +495,7 @@ class DiffFile extends React.Component<Props, State> {
               {this.renderChangeTag(file)}
             </FullWidthTitleHeader>
             {headerButtons}
-          </FlexWrapLevel>
+          </div>
         </div>
         {body}
       </DiffFilePanel>

--- a/scm-ui/ui-webapp/src/repos/sources/containers/Content.tsx
+++ b/scm-ui/ui-webapp/src/repos/sources/containers/Content.tsx
@@ -55,24 +55,24 @@ const Header = styled.div`
   padding: 0.5em 0.75em;
 `;
 
-const RightMarginIcon = styled(Icon)`
-  margin-right: 0.5em;
-`;
-
-const RightMarginFileButtonAddons = styled(FileButtonAddons)`
-  margin-right: 0.5em;
-`;
-
-const BorderBottom = styled.div`
-  border-bottom: solid 1px #dbdbdb;
-`;
-
 const LighterGreyBackgroundPanelBlock = styled.div`
   background-color: #fbfbfb;
 `;
 
 const LighterGreyBackgroundTable = styled.table`
   background-color: #fbfbfb;
+`;
+
+const BorderBottom = styled.div`
+  border-bottom: solid 1px #dbdbdb;
+`;
+
+const FullWidthTitleHeader = styled.div`
+  max-width: 100%;
+`;
+
+const AlignRight = styled.div`
+  margin-left: auto;
 `;
 
 const BorderLessDiv = styled.div`
@@ -111,7 +111,8 @@ class Content extends React.Component<Props, State> {
     const icon = collapsed ? "angle-right" : "angle-down";
 
     const selector = file._links.history ? (
-      <RightMarginFileButtonAddons
+      <FileButtonAddons
+        className="mr-2"
         selected={selected}
         showSources={() => this.setState({ selected: "source" })}
         showHistory={() => this.setState({ selected: "history" })}
@@ -120,34 +121,33 @@ class Content extends React.Component<Props, State> {
     ) : null;
 
     return (
-      <span className="has-cursor-pointer">
-        <div className={classNames("media", "is-flex", "is-align-items-center")}>
-          <div className={classNames("media-content", "mr-3")} onClick={this.toggleCollapse}>
-            <div className="is-word-break">
-              <RightMarginIcon className="is-inline" name={`${icon} fa-fw`} color="inherit" />
-              {file.name}
-            </div>
-          </div>
-          <div className="buttons is-grouped">
-            {selector}
-            <OpenInFullscreenButton
-              modalTitle={file?.name}
-              modalBody={<BorderLessDiv className="panel">{content}</BorderLessDiv>}
-              tooltipStyle="htmlTitle"
-            />
-            <ExtensionPoint
-              name="repos.sources.content.actionbar"
-              props={{
-                repository,
-                file,
-                revision,
-                handleExtensionError: this.handleExtensionError
-              }}
-              renderAll={true}
-            />
-          </div>
-        </div>
-      </span>
+      <div className={classNames("level", "is-flex-wrap-wrap")}>
+        <FullWidthTitleHeader
+          className={classNames("level-left", "is-flex", "has-cursor-pointer", "is-word-break", "mr-2")}
+          onClick={this.toggleCollapse}
+        >
+          <Icon className={classNames("is-inline", "mr-2")} name={`${icon} fa-fw`} color="inherit" />
+          {file.name}
+        </FullWidthTitleHeader>
+        <AlignRight className={classNames("level-right", "buttons")}>
+          {selector}
+          <OpenInFullscreenButton
+            modalTitle={file?.name}
+            modalBody={<BorderLessDiv className="panel">{content}</BorderLessDiv>}
+            tooltipStyle="htmlTitle"
+          />
+          <ExtensionPoint
+            name="repos.sources.content.actionbar"
+            props={{
+              repository,
+              file,
+              revision,
+              handleExtensionError: this.handleExtensionError
+            }}
+            renderAll={true}
+          />
+        </AlignRight>
+      </div>
     );
   }
 


### PR DESCRIPTION
## Proposed changes

The title of a file and the action buttons had to share the space. Now the title takes it needs and the actions move down if necessary. This behavior is similar to the list of files in changeset view (content component).

### Your checklist for this pull request

- [x] PR is well described and the description can be used as commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
