### PR TITLE
Mark configuration files in debian package

### DIFF
--- a/gradle/changelog/debian_conffiles.yaml
+++ b/gradle/changelog/debian_conffiles.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Mark configuration files in debian package ([#1574](https://github.com/scm-manager/scm-manager/issues/1574))

--- a/scm-packaging/deb/build.gradle
+++ b/scm-packaging/deb/build.gradle
@@ -24,7 +24,7 @@
 import org.gradle.util.VersionNumber
 
 plugins {
-  id 'nebula.ospackage' version '8.4.1'
+  id 'nebula.ospackage' version '8.5.6'
   id 'org.scm-manager.packaging'
   id 'com.github.hierynomus.license-base' version '0.15.0'
 }
@@ -94,6 +94,8 @@ task deb(type: Deb) {
     permissionGroup 'scm'
     fileMode 0640
   }
+  // https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/118
+  configurationFile('/etc/default/scm-server')
 
   from('src/main/fs/etc/scm') {
     fileType CONFIG | NOREPLACE
@@ -103,6 +105,9 @@ task deb(type: Deb) {
     fileMode 0640
     expand([version: version])
   }
+  // https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/118
+  configurationFile('/etc/scm/server-config.xml')
+  configurationFile('/etc/scm/logging.xml')
 
   from('src/main/fs/etc/systemd') {
     into '/etc/systemd'

--- a/scm-packaging/rpm/build.gradle
+++ b/scm-packaging/rpm/build.gradle
@@ -46,7 +46,7 @@ buildscript {
 }
 
 plugins {
-  id 'nebula.ospackage' version '8.4.1'
+  id 'nebula.ospackage' version '8.5.6'
   id 'org.scm-manager.packaging'
   id 'com.github.hierynomus.license-base' version '0.15.0'
 }


### PR DESCRIPTION
## Proposed changes

Mark server-config.xml, logging.xml and defaults explicit as
configuration files.
Due too a bug in gradle-ospackage-plugin it is not enough to mark them via fileType.

https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/118

The issue was reported via the mailing list: https://groups.google.com/g/scmmanager/c/VXULeu7yWFA/m/DPusceOXBgAJ

### Your checklist for this pull request

- [X] PR is well described and the description can be used as commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
