### PR TITLE
Add API for metrics based on Micrometer

### DIFF
--- a/gradle/changelog/metrics_api.yaml
+++ b/gradle/changelog/metrics_api.yaml
@@ -1,0 +1,2 @@
+- type: added
+  description: API for metrics ([#1576](https://github.com/scm-manager/scm-manager/issues/1576))

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -18,6 +18,7 @@ ext {
   hamcrestVersion = '2.1'
   mockitoVersion = '3.6.28'
   jerseyClientVersion = '1.19.4'
+  micrometerVersion = '1.6.4'
 
   nodeVersion = '14.15.1'
   yarnVersion = '1.22.5'
@@ -165,6 +166,9 @@ ext {
 
     // rest api client for testing
     jerseyClientApi: "com.sun.jersey:jersey-client:${jerseyClientVersion}",
-    jerseyClientRuntime: "com.sun.jersey.contribs:jersey-apache-client:${jerseyClientVersion}"
+    jerseyClientRuntime: "com.sun.jersey.contribs:jersey-apache-client:${jerseyClientVersion}",
+
+    // metrics
+    micrometerCore: "io.micrometer:micrometer-core:${micrometerVersion}"
   ]
 }

--- a/scm-core/build.gradle
+++ b/scm-core/build.gradle
@@ -101,6 +101,9 @@ dependencies {
   // compression
   implementation libraries.commonsCompress
 
+  // metrics
+  api libraries.micrometerCore
+
   // tests
   testImplementation libraries.junitJupiterApi
   testImplementation libraries.junitJupiterParams

--- a/scm-core/src/main/java/sonia/scm/metrics/MonitoringSystem.java
+++ b/scm-core/src/main/java/sonia/scm/metrics/MonitoringSystem.java
@@ -1,0 +1,64 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import sonia.scm.plugin.ExtensionPoint;
+
+import java.util.Optional;
+
+/**
+ * Extension point to pass SCM-Manager metrics to a monitoring system.
+ *
+ * @since 2.15.0
+ */
+@ExtensionPoint
+public interface MonitoringSystem {
+
+  /**
+   * Returns type of provider.
+   *
+   * @return type
+   */
+  String getType();
+
+  /**
+   * Returns registry of metrics provider.
+   *
+   * @return metrics registry
+   */
+  MeterRegistry getRegistry();
+
+  /**
+   * Returns an optional scrape target.
+   * A scrape target is only needed if the monitoring system pulls the metrics over http.
+   * If the monitoring system uses a push based model, this method returns an empty optional.
+   *
+   * @return optional scrape target
+   */
+  default Optional<ScrapeTarget> getScrapeTarget() {
+    return Optional.empty();
+  }
+}

--- a/scm-core/src/main/java/sonia/scm/metrics/MonitoringSystem.java
+++ b/scm-core/src/main/java/sonia/scm/metrics/MonitoringSystem.java
@@ -38,11 +38,11 @@ import java.util.Optional;
 public interface MonitoringSystem {
 
   /**
-   * Returns type of provider.
+   * Returns name of monitoring system.
    *
-   * @return type
+   * @return name of monitoring system
    */
-  String getType();
+  String getName();
 
   /**
    * Returns registry of metrics provider.

--- a/scm-core/src/main/java/sonia/scm/metrics/ScrapeTarget.java
+++ b/scm-core/src/main/java/sonia/scm/metrics/ScrapeTarget.java
@@ -45,7 +45,7 @@ public interface ScrapeTarget {
   /**
    * Writes received metrics to given output stream.
    *
-   * @param outputStream output stream
+   * @param outputStream Output stream the metrics will be written to.
    * @throws IOException if an IO error is encountered
    */
   void write(OutputStream outputStream) throws IOException;

--- a/scm-core/src/main/java/sonia/scm/metrics/ScrapeTarget.java
+++ b/scm-core/src/main/java/sonia/scm/metrics/ScrapeTarget.java
@@ -1,0 +1,52 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.metrics;
+
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Target for monitoring systems which scrape metrics from an http endpoint.
+ *
+ * @since 2.15.0
+ */
+public interface ScrapeTarget {
+
+  /**
+   * Returns content type of output format.
+   *
+   * @return content type
+   */
+  String getContentType();
+
+  /**
+   * Writes received metrics to given output stream.
+   *
+   * @param outputStream output stream
+   * @throws IOException if an IO error is encountered
+   */
+  void write(OutputStream outputStream) throws IOException;
+}

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/MetricsIndexEnricher.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/MetricsIndexEnricher.java
@@ -50,7 +50,7 @@ public class MetricsIndexEnricher implements HalEnricher {
   private List<String> scrapeTargets(Set<MonitoringSystem> monitoringSystems) {
     return monitoringSystems.stream()
       .filter(sys -> sys.getScrapeTarget().isPresent())
-      .map(MonitoringSystem::getType)
+      .map(MonitoringSystem::getName)
       .collect(Collectors.toList());
   }
 

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/MetricsIndexEnricher.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/MetricsIndexEnricher.java
@@ -1,0 +1,72 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.api.v2.resources;
+
+import org.apache.shiro.SecurityUtils;
+import sonia.scm.metrics.MonitoringSystem;
+import sonia.scm.plugin.Extension;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Extension
+@Enrich(Index.class)
+public class MetricsIndexEnricher implements HalEnricher {
+
+  private final Provider<ResourceLinks> resourceLinks;
+  private final List<String> scrapeTargets;
+
+  @Inject
+  public MetricsIndexEnricher(Provider<ResourceLinks> resourceLinks, Set<MonitoringSystem> monitoringSystems) {
+    this.resourceLinks = resourceLinks;
+    this.scrapeTargets = scrapeTargets(monitoringSystems);
+  }
+
+  private List<String> scrapeTargets(Set<MonitoringSystem> monitoringSystems) {
+    return monitoringSystems.stream()
+      .filter(sys -> sys.getScrapeTarget().isPresent())
+      .map(MonitoringSystem::getType)
+      .collect(Collectors.toList());
+  }
+
+  @Override
+  public void enrich(HalEnricherContext context, HalAppender appender) {
+    if (!isPermitted() || scrapeTargets.isEmpty()) {
+      return;
+    }
+    HalAppender.LinkArrayBuilder links = appender.linkArrayBuilder("metrics");
+    for (String type : scrapeTargets) {
+      links.append(type, resourceLinks.get().metrics().forType(type));
+    }
+    links.build();
+  }
+
+  private boolean isPermitted() {
+    return SecurityUtils.getSubject().isPermitted("metrics:read");
+  }
+}

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/MetricsResource.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/MetricsResource.java
@@ -1,0 +1,99 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.api.v2.resources;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.apache.shiro.SecurityUtils;
+import sonia.scm.NotFoundException;
+import sonia.scm.metrics.MonitoringSystem;
+import sonia.scm.metrics.ScrapeTarget;
+import sonia.scm.web.VndMediaType;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static sonia.scm.ContextEntry.ContextBuilder.entity;
+
+/**
+ * Endpoint for pull based monitoring systems, which scrape for metrics.
+ * @since 2.15.0
+ */
+@OpenAPIDefinition(tags = {
+  @Tag(name = "Metrics", description = "Scrape targets for monitoring systems")
+})
+@Path("v2/metrics")
+public class MetricsResource {
+
+  private final Map<String, MonitoringSystem> providers = new HashMap<>();
+
+  @Inject
+  public MetricsResource(Set<MonitoringSystem> monitoringSystems) {
+    for (MonitoringSystem system : monitoringSystems) {
+      providers.put(system.getType(), system);
+    }
+  }
+
+  @GET
+  @Path("{type}")
+  @Operation(summary = "Scrape target", description = "Scrape target for a monitoring system", tags = "Metrics")
+  @ApiResponse(
+    responseCode = "200",
+    description = "success"
+  )
+  @ApiResponse(responseCode = "401", description = "not authenticated / invalid credentials")
+  @ApiResponse(responseCode = "404", description = "unknown monitoring system or system without scrape target")
+  @ApiResponse(
+    responseCode = "500",
+    description = "internal server error",
+    content = @Content(
+      mediaType = VndMediaType.ERROR_TYPE,
+      schema = @Schema(implementation = ErrorDto.class)
+    ))
+  public Response metrics(@PathParam("type") String type) {
+    SecurityUtils.getSubject().checkPermission("metrics:read");
+
+    MonitoringSystem system = providers.get(type);
+    if (system == null) {
+      throw new NotFoundException(MonitoringSystem.class, type);
+    }
+    ScrapeTarget scrapeTarget = system.getScrapeTarget()
+      .orElseThrow(() -> NotFoundException.notFound(entity(ScrapeTarget.class, type).in(MonitoringSystem.class, type)));
+    StreamingOutput output = scrapeTarget::write;
+    return Response.ok(output, scrapeTarget.getContentType()).build();
+  }
+
+}

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/ResourceLinks.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/ResourceLinks.java
@@ -1085,4 +1085,21 @@ class ResourceLinks {
       return permissionLinkBuilder.method("getNamespaceResource").parameters(namespace).method("permissions").parameters().method(methodName).parameters(permissionName).href();
     }
   }
+
+  public MetricsLinks metrics() {
+    return new MetricsLinks(new LinkBuilder(scmPathInfoStore.get(), MetricsResource.class));
+  }
+
+  public static class MetricsLinks {
+
+    private final LinkBuilder metricsLinkBuilder;
+
+    private MetricsLinks(LinkBuilder metricsLinkBuilder) {
+      this.metricsLinkBuilder = metricsLinkBuilder;
+    }
+
+    public String forType(String type) {
+      return metricsLinkBuilder.method("metrics").parameters(type).href();
+    }
+  }
 }

--- a/scm-webapp/src/main/java/sonia/scm/lifecycle/modules/ScmServletModule.java
+++ b/scm-webapp/src/main/java/sonia/scm/lifecycle/modules/ScmServletModule.java
@@ -30,6 +30,7 @@ import com.google.inject.multibindings.Multibinder;
 import com.google.inject.servlet.RequestScoped;
 import com.google.inject.servlet.ServletModule;
 import com.google.inject.throwingproviders.ThrowingProviderBinder;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sonia.scm.Default;
@@ -54,6 +55,7 @@ import sonia.scm.group.GroupDisplayManager;
 import sonia.scm.group.GroupManager;
 import sonia.scm.group.GroupManagerProvider;
 import sonia.scm.group.xml.XmlGroupDAO;
+import sonia.scm.metrics.MeterRegistryProvider;
 import sonia.scm.migration.MigrationDAO;
 import sonia.scm.net.SSLContextProvider;
 import sonia.scm.net.ahc.AdvancedHttpClient;
@@ -169,6 +171,9 @@ class ScmServletModule extends ServletModule {
 
     // bind extensions
     pluginLoader.getExtensionProcessor().processAutoBindExtensions(binder());
+
+    // bind metrics
+    bind(MeterRegistry.class).toProvider(MeterRegistryProvider.class).asEagerSingleton();
 
     // bind security stuff
     bind(LoginAttemptHandler.class).to(ConfigurableLoginAttemptHandler.class);

--- a/scm-webapp/src/main/java/sonia/scm/metrics/MeterRegistryProvider.java
+++ b/scm-webapp/src/main/java/sonia/scm/metrics/MeterRegistryProvider.java
@@ -1,0 +1,75 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import java.util.Set;
+
+@Singleton
+public class MeterRegistryProvider implements Provider<MeterRegistry> {
+
+  private final Set<MonitoringSystem> providerSet;
+
+  @Inject
+  public MeterRegistryProvider(Set<MonitoringSystem> providerSet) {
+    this.providerSet = providerSet;
+  }
+
+  @Override
+  public MeterRegistry get() {
+    CompositeMeterRegistry registry = createRegistry();
+    if (!providerSet.isEmpty()) {
+      bindCommonMetrics(registry);
+    }
+    return registry;
+  }
+
+  private CompositeMeterRegistry createRegistry() {
+    CompositeMeterRegistry registry = new CompositeMeterRegistry();
+    for (MonitoringSystem provider : providerSet) {
+      registry.add(provider.getRegistry());
+    }
+    return registry;
+  }
+
+  @SuppressWarnings("java:S2095") // we can't close JvmGcMetrics, but it should be ok
+  private void bindCommonMetrics(MeterRegistry registry) {
+    new ClassLoaderMetrics().bindTo(registry);
+    new JvmMemoryMetrics().bindTo(registry);
+    new JvmGcMetrics().bindTo(registry);
+    new ProcessorMetrics().bindTo(registry);
+    new JvmThreadMetrics().bindTo(registry);
+  }
+}

--- a/scm-webapp/src/main/java/sonia/scm/metrics/MeterRegistryProvider.java
+++ b/scm-webapp/src/main/java/sonia/scm/metrics/MeterRegistryProvider.java
@@ -49,14 +49,21 @@ public class MeterRegistryProvider implements Provider<MeterRegistry> {
 
   @Override
   public MeterRegistry get() {
-    CompositeMeterRegistry registry = createRegistry();
+    MeterRegistry registry = createRegistry();
     if (!providerSet.isEmpty()) {
       bindCommonMetrics(registry);
     }
     return registry;
   }
 
-  private CompositeMeterRegistry createRegistry() {
+  private MeterRegistry createRegistry() {
+    if (providerSet.size() == 1) {
+      return providerSet.iterator().next().getRegistry();
+    }
+    return createCompositeRegistry();
+  }
+
+  private CompositeMeterRegistry createCompositeRegistry() {
     CompositeMeterRegistry registry = new CompositeMeterRegistry();
     for (MonitoringSystem provider : providerSet) {
       registry.add(provider.getRegistry());

--- a/scm-webapp/src/main/resources/META-INF/scm/permissions.xml
+++ b/scm-webapp/src/main/resources/META-INF/scm/permissions.xml
@@ -83,5 +83,8 @@
   <permission>
     <value>plugin:read,write</value>
   </permission>
+  <permission>
+    <value>metrics:read</value>
+  </permission>
 </permissions>
 

--- a/scm-webapp/src/main/resources/locales/de/plugins.json
+++ b/scm-webapp/src/main/resources/locales/de/plugins.json
@@ -115,6 +115,12 @@
         "description": "Darf die Berechtigungen auf Namespace-Ebene lesen und bearbeiten"
       }
     },
+    "metrics": {
+      "read": {
+        "displayName": "Metriken lesen",
+        "description": "Darf Metriken über die zur Verfügung gestellten Endpunkte lesen"
+      }
+    },
     "unknown": "Unbekannte Berechtigung"
   },
   "verbs": {

--- a/scm-webapp/src/main/resources/locales/en/plugins.json
+++ b/scm-webapp/src/main/resources/locales/en/plugins.json
@@ -115,6 +115,12 @@
         "description": "May read and modify the permissions set for namespaces"
       }
     },
+    "metrics": {
+      "read": {
+        "displayName": "Read all metrics",
+        "description": "May read metrics over the exported scrape endpoints"
+      }
+    },
     "unknown": "Unknown permission"
   },
   "verbs": {

--- a/scm-webapp/src/test/java/sonia/scm/api/v2/resources/MetricsIndexEnricherTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/api/v2/resources/MetricsIndexEnricherTest.java
@@ -1,0 +1,226 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.api.v2.resources;
+
+import com.google.common.collect.ImmutableSet;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.shiro.subject.Subject;
+import org.apache.shiro.util.ThreadContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sonia.scm.metrics.MonitoringSystem;
+import sonia.scm.metrics.ScrapeTarget;
+
+import javax.inject.Provider;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MetricsIndexEnricherTest {
+
+  @Mock
+  private HalEnricherContext context;
+
+  @Mock
+  private HalAppender appender;
+
+  @Mock
+  private Subject subject;
+
+  private Provider<ResourceLinks> resourceLinks;
+
+  @BeforeEach
+  void setUpResourceLinks() {
+    ScmPathInfoStore scmPathInfoStore = new ScmPathInfoStore();
+    scmPathInfoStore.set(() -> URI.create("/"));
+    resourceLinks = () -> new ResourceLinks(scmPathInfoStore);
+  }
+
+  @BeforeEach
+  void setUpSubject() {
+    ThreadContext.bind(subject);
+  }
+
+  @AfterEach
+  void tearDownSubject() {
+    ThreadContext.unbindSubject();
+  }
+
+  @Nested
+  class WithPermission {
+
+    @BeforeEach
+    void prepareSubject() {
+      when(subject.isPermitted("metrics:read")).thenReturn(true);
+    }
+
+    @Test
+    void shouldNotEnrichWithoutMonitoringSystems() {
+      MetricsIndexEnricher enricher = new MetricsIndexEnricher(
+        resourceLinks,
+        Collections.emptySet()
+      );
+      enricher.enrich(context, appender);
+
+      verify(appender, never()).linkArrayBuilder("metrics");
+    }
+
+    @Test
+    void shouldNotEnrichWithMonitoringSystemsWithScrapeTarget() {
+      MetricsIndexEnricher enricher = new MetricsIndexEnricher(
+        resourceLinks,
+        Collections.singleton(new NoScrapeMonitoringSystem())
+      );
+      enricher.enrich(context, appender);
+
+      verify(appender, never()).linkArrayBuilder("metrics");
+    }
+
+    @Test
+    void shouldEnrichIndex() {
+      CapturingLinkArrayBuilder linkBuilder = new CapturingLinkArrayBuilder();
+      when(appender.linkArrayBuilder("metrics")).thenReturn(linkBuilder);
+
+      MetricsIndexEnricher enricher = new MetricsIndexEnricher(
+        resourceLinks,
+        ImmutableSet.of(
+          new NoScrapeMonitoringSystem(),
+          new ScrapeMonitoringSystem("one"),
+          new ScrapeMonitoringSystem("two"))
+      );
+      enricher.enrich(context, appender);
+
+      assertThat(linkBuilder.buildWasCalled).isTrue();
+      assertThat(linkBuilder.links)
+        .containsEntry("one", "/v2/metrics/one")
+        .containsEntry("two", "/v2/metrics/two")
+        .hasSize(2);
+    }
+  }
+
+  @Nested
+  class WithoutPermission {
+
+    @BeforeEach
+    void prepareSubject() {
+      when(subject.isPermitted("metrics:read")).thenReturn(false);
+    }
+
+    @Test
+    void shouldNotEnrichWithoutPermission() {
+      MetricsIndexEnricher enricher = new MetricsIndexEnricher(
+        resourceLinks,
+        ImmutableSet.of(
+          new ScrapeMonitoringSystem("one")
+        )
+      );
+      enricher.enrich(context, appender);
+
+      verify(appender, never()).linkArrayBuilder("metrics");
+    }
+
+  }
+
+  private static class NoScrapeMonitoringSystem implements MonitoringSystem {
+
+    @Override
+    public String getType() {
+      return "noscrap";
+    }
+
+    @Override
+    public MeterRegistry getRegistry() {
+      return new SimpleMeterRegistry();
+    }
+  }
+
+  private static class ScrapeMonitoringSystem implements MonitoringSystem {
+
+    private final String type;
+
+    private ScrapeMonitoringSystem(String type) {
+      this.type = type;
+    }
+
+    @Override
+    public String getType() {
+      return type;
+    }
+
+    @Override
+    public MeterRegistry getRegistry() {
+      return new SimpleMeterRegistry();
+    }
+
+    @Override
+    public Optional<ScrapeTarget> getScrapeTarget() {
+      return Optional.of(new NoopScrapeTarget());
+    }
+  }
+
+  private static class NoopScrapeTarget implements ScrapeTarget {
+
+    @Override
+    public String getContentType() {
+      return null;
+    }
+
+    @Override
+    public void write(OutputStream outputStream) throws IOException {
+
+    }
+  }
+
+  private static class CapturingLinkArrayBuilder implements HalAppender.LinkArrayBuilder {
+
+    private final Map<String, String> links = new HashMap<>();
+    private boolean buildWasCalled = false;
+
+    @Override
+    public HalAppender.LinkArrayBuilder append(String name, String href) {
+      links.put(name, href);
+      return this;
+    }
+
+    @Override
+    public void build() {
+      buildWasCalled = true;
+    }
+  }
+}

--- a/scm-webapp/src/test/java/sonia/scm/api/v2/resources/MetricsIndexEnricherTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/api/v2/resources/MetricsIndexEnricherTest.java
@@ -160,7 +160,7 @@ class MetricsIndexEnricherTest {
   private static class NoScrapeMonitoringSystem implements MonitoringSystem {
 
     @Override
-    public String getType() {
+    public String getName() {
       return "noscrap";
     }
 
@@ -179,7 +179,7 @@ class MetricsIndexEnricherTest {
     }
 
     @Override
-    public String getType() {
+    public String getName() {
       return type;
     }
 

--- a/scm-webapp/src/test/java/sonia/scm/api/v2/resources/MetricsResourceTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/api/v2/resources/MetricsResourceTest.java
@@ -118,7 +118,7 @@ class MetricsResourceTest {
   private static class NoScrapeMonitoringSystem implements MonitoringSystem {
 
     @Override
-    public String getType() {
+    public String getName() {
       return "noscrape";
     }
 
@@ -131,7 +131,7 @@ class MetricsResourceTest {
   private static class ScrapeMonitoringSystem implements MonitoringSystem {
 
     @Override
-    public String getType() {
+    public String getName() {
       return "scrape";
     }
 

--- a/scm-webapp/src/test/java/sonia/scm/api/v2/resources/MetricsResourceTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/api/v2/resources/MetricsResourceTest.java
@@ -1,0 +1,162 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.api.v2.resources;
+
+import com.google.common.collect.ImmutableSet;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.shiro.authz.AuthorizationException;
+import org.apache.shiro.subject.Subject;
+import org.apache.shiro.util.ThreadContext;
+import org.jboss.resteasy.mock.MockHttpRequest;
+import org.jboss.resteasy.mock.MockHttpResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sonia.scm.metrics.MonitoringSystem;
+import sonia.scm.metrics.ScrapeTarget;
+import sonia.scm.web.RestDispatcher;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+
+@ExtendWith(MockitoExtension.class)
+class MetricsResourceTest {
+
+  private RestDispatcher dispatcher;
+
+  @Mock
+  private Subject subject;
+
+  @BeforeEach
+  void setUpDispatcher() {
+    dispatcher = new RestDispatcher();
+    dispatcher.addSingletonResource(new MetricsResource(ImmutableSet.of(
+      new NoScrapeMonitoringSystem(),
+      new ScrapeMonitoringSystem()
+    )));
+  }
+
+  @BeforeEach
+  void setUpSubject() {
+    ThreadContext.bind(subject);
+  }
+
+  @AfterEach
+  void tearDownSubject() {
+    ThreadContext.unbindSubject();
+  }
+
+  @Test
+  void shouldReturn404ForUnknownMonitoringSystem() throws URISyntaxException {
+    MockHttpRequest request = MockHttpRequest.get("/v2/metrics/unknown");
+    MockHttpResponse response = new MockHttpResponse();
+    dispatcher.invoke(request, response);
+    assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_NOT_FOUND);
+  }
+
+  @Test
+  void shouldReturn404ForMonitoringSystemWithoutScrapeTarget() throws URISyntaxException {
+    MockHttpRequest request = MockHttpRequest.get("/v2/metrics/noscrape");
+    MockHttpResponse response = new MockHttpResponse();
+    dispatcher.invoke(request, response);
+    assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_NOT_FOUND);
+  }
+
+  @Test
+  void shouldReturn403WithoutPermission() throws URISyntaxException {
+    doThrow(new AuthorizationException("not permitted")).when(subject).checkPermission("metrics:read");
+    MockHttpRequest request = MockHttpRequest.get("/v2/metrics/scrape");
+    MockHttpResponse response = new MockHttpResponse();
+    dispatcher.invoke(request, response);
+    assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
+  }
+
+  @Test
+  void shouldReturnMetrics() throws URISyntaxException, UnsupportedEncodingException {
+    MockHttpRequest request = MockHttpRequest.get("/v2/metrics/scrape");
+    MockHttpResponse response = new MockHttpResponse();
+    dispatcher.invoke(request, response);
+    assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+    assertThat(response.getOutputHeaders().getFirst("Content-Type").toString()).hasToString("text/plain;charset=UTF-8");
+    assertThat(response.getContentAsString()).isEqualTo("hello");
+  }
+
+  private static class NoScrapeMonitoringSystem implements MonitoringSystem {
+
+    @Override
+    public String getType() {
+      return "noscrape";
+    }
+
+    @Override
+    public MeterRegistry getRegistry() {
+      return new SimpleMeterRegistry();
+    }
+  }
+
+  private static class ScrapeMonitoringSystem implements MonitoringSystem {
+
+    @Override
+    public String getType() {
+      return "scrape";
+    }
+
+    @Override
+    public MeterRegistry getRegistry() {
+      return new SimpleMeterRegistry();
+    }
+
+    @Override
+    public Optional<ScrapeTarget> getScrapeTarget() {
+      return Optional.of(new HelloScrapeTarget());
+    }
+  }
+
+  private static class HelloScrapeTarget implements ScrapeTarget {
+
+    @Override
+    public String getContentType() {
+      return "text/plain";
+    }
+
+    @Override
+    public void write(OutputStream outputStream) throws IOException {
+      outputStream.write("hello".getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+}

--- a/scm-webapp/src/test/java/sonia/scm/metrics/MeterRegistryProviderTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/metrics/MeterRegistryProviderTest.java
@@ -24,7 +24,9 @@
 
 package sonia.scm.metrics;
 
+import com.google.common.collect.ImmutableSet;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 
@@ -62,6 +64,20 @@ class MeterRegistryProviderTest {
     MeterRegistryProvider provider = new MeterRegistryProvider(Collections.singleton(new SimpleMonitoringSystem()));
     MeterRegistry registry = provider.get();
     assertThat(registry.getMeters()).isNotEmpty();
+  }
+
+  @Test
+  void shouldCreateCompositeMeterRegistry() {
+    MeterRegistryProvider provider = new MeterRegistryProvider(
+      ImmutableSet.of(new SimpleMonitoringSystem(), new SimpleMonitoringSystem())
+    );
+    assertThat(provider.get()).isInstanceOf(CompositeMeterRegistry.class);
+  }
+
+  @Test
+  void shouldReturnSingleRegistryUnwrapped() {
+    MeterRegistryProvider provider = new MeterRegistryProvider(Collections.singleton(new SimpleMonitoringSystem()));
+    assertThat(provider.get()).isInstanceOf(SimpleMeterRegistry.class);
   }
 
   private static class SimpleMonitoringSystem implements MonitoringSystem {

--- a/scm-webapp/src/test/java/sonia/scm/metrics/MeterRegistryProviderTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/metrics/MeterRegistryProviderTest.java
@@ -1,0 +1,80 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class MeterRegistryProviderTest {
+
+  @Test
+  void shouldReturnNoopRegistry() {
+    MeterRegistryProvider provider = new MeterRegistryProvider(Collections.emptySet());
+    MeterRegistry registry = provider.get();
+    registry.counter("sample").increment();
+    assertThat(registry.get("sample").counter().count()).isEqualTo(0.0);
+  }
+
+  @Test
+  void shouldNotRegisterCommonMetricsForDefaultRegistry() {
+    MeterRegistryProvider provider = new MeterRegistryProvider(Collections.emptySet());
+    assertThat(provider.get().getMeters()).withFailMessage("no common metrics should be registered").isEmpty();
+  }
+
+  @Test
+  void shouldStoreMetrics() {
+    MeterRegistryProvider provider = new MeterRegistryProvider(Collections.singleton(new SimpleMonitoringSystem()));
+    MeterRegistry registry = provider.get();
+    registry.counter("sample").increment();
+    assertThat(registry.get("sample").counter().count()).isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldRegisterCommonMetrics() {
+    MeterRegistryProvider provider = new MeterRegistryProvider(Collections.singleton(new SimpleMonitoringSystem()));
+    MeterRegistry registry = provider.get();
+    assertThat(registry.getMeters()).isNotEmpty();
+  }
+
+  private static class SimpleMonitoringSystem implements MonitoringSystem {
+
+    @Override
+    public String getType() {
+      return "simple";
+    }
+
+    @Override
+    public MeterRegistry getRegistry() {
+      return new SimpleMeterRegistry();
+    }
+  }
+
+}

--- a/scm-webapp/src/test/java/sonia/scm/metrics/MeterRegistryProviderTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/metrics/MeterRegistryProviderTest.java
@@ -67,7 +67,7 @@ class MeterRegistryProviderTest {
   private static class SimpleMonitoringSystem implements MonitoringSystem {
 
     @Override
-    public String getType() {
+    public String getName() {
       return "simple";
     }
 


### PR DESCRIPTION
## Proposed changes

Adds an API for collecting metrics. The default implementation provides only an api, it does not store or expose the metrics. To store and access the collected metrics an plugin which implements the MonitoringInterface is required. The implementation provides an API to collection custom metrics and it collects common JVM metrics if an implementation of the MonitoringInterface is bound.

### Your checklist for this pull request

- [X] PR is well described and the description can be used as commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [X] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [x] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
