### PR TITLE
Fix navigate to detail after search

### DIFF
--- a/gradle/changelog/navigate_after_search.yaml
+++ b/gradle/changelog/navigate_after_search.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Navigate after search ([#1589](https://github.com/scm-manager/scm-manager/pull/1589))

--- a/scm-ui/ui-api/src/urls.ts
+++ b/scm-ui/ui-api/src/urls.ts
@@ -38,6 +38,13 @@ export function withEndingSlash(url: string) {
   return url + "/";
 }
 
+export function withStartingSlash(url: string) {
+  if (url.startsWith("/")) {
+    return url;
+  }
+  return "/" + url;
+}
+
 export function concat(base: string, ...parts: string[]) {
   let url = base;
   for (const p of parts) {

--- a/scm-ui/ui-components/src/OverviewPageActions.tsx
+++ b/scm-ui/ui-components/src/OverviewPageActions.tsx
@@ -77,7 +77,7 @@ const OverviewPageActions: FC<Props> = ({
   const filter = (q: string) => {
     if (q !== filterValue) {
       setFilterValue(q);
-      history.push(`${location.pathname}?q=${q}`);
+      history.push(`${link}?q=${q}`);
     }
   };
 

--- a/scm-ui/ui-components/src/OverviewPageActions.tsx
+++ b/scm-ui/ui-components/src/OverviewPageActions.tsx
@@ -77,7 +77,7 @@ const OverviewPageActions: FC<Props> = ({
   const filter = (q: string) => {
     if (q !== filterValue) {
       setFilterValue(q);
-      history.push(`${link}?q=${q}`);
+      history.push(`${link}/?q=${q}`);
     }
   };
 

--- a/scm-ui/ui-components/src/OverviewPageActions.tsx
+++ b/scm-ui/ui-components/src/OverviewPageActions.tsx
@@ -38,11 +38,15 @@ type Props = {
   searchPlaceholder?: string;
 };
 
+const createAbsoluteLink = (url: string) => {
+  return urls.withStartingSlash(urls.withEndingSlash(url));
+};
+
 const OverviewPageActions: FC<Props> = ({
   groups,
   currentGroup,
   showCreateButton,
-  link,
+  link: inputLink,
   groupSelected,
   label,
   testId,
@@ -50,7 +54,8 @@ const OverviewPageActions: FC<Props> = ({
 }) => {
   const history = useHistory();
   const location = useLocation();
-  const [filterValue, setFilterValue] = useState(urls.getQueryStringFromLocation(location));
+  const [filterValue, setFilterValue] = useState(urls.getQueryStringFromLocation(location) || "");
+  const link = createAbsoluteLink(inputLink);
 
   const groupSelector = groups && (
     <div className={"column is-flex"}>
@@ -67,7 +72,7 @@ const OverviewPageActions: FC<Props> = ({
     if (showCreateButton) {
       return (
         <div className={classNames("input-button", "control", "column")}>
-          <Button label={label} link={`/${link}/create`} color="primary" />
+          <Button label={label} link={`${link}create`} color="primary" />
         </div>
       );
     }
@@ -77,7 +82,7 @@ const OverviewPageActions: FC<Props> = ({
   const filter = (q: string) => {
     if (q !== filterValue) {
       setFilterValue(q);
-      history.push(`${link}/?q=${q}`);
+      history.push(`${link}?q=${q}`);
     }
   };
 

--- a/scm-ui/ui-components/src/OverviewPageActions.tsx
+++ b/scm-ui/ui-components/src/OverviewPageActions.tsx
@@ -51,7 +51,7 @@ const OverviewPageActions: FC<Props> = ({
   const history = useHistory();
   const location = useLocation();
   const [filterValue, setFilterValue] = useState(urls.getQueryStringFromLocation(location));
-  
+
   const groupSelector = groups && (
     <div className={"column is-flex"}>
       <DropDown
@@ -74,13 +74,11 @@ const OverviewPageActions: FC<Props> = ({
     return null;
   };
 
-  const filter = (filter: string) => {
-    if ((filter && filter !== filterValue) || (!filter && filterValue)) {
-      history.push(`/${link}/?q=${filter}`);
-    } else {
-      history.push(`${location.pathname}?q=${filter}`);
+  const filter = (q: string) => {
+    if (q !== filterValue) {
+      setFilterValue(q);
+      history.push(`${location.pathname}?q=${q}`);
     }
-    setFilterValue(filter);
   };
 
   return (


### PR DESCRIPTION
## Proposed changes

Sometimes fails the navigation to a detail page after search.
This happens because of the OverviewPageActions which pushes the value of the filter to history.
This happens on change and on render, which could lead to a navigation back to the overview even after a click on an item in the overview.

### Your checklist for this pull request

- [X] PR is well described and the description can be used as commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [X] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
