### PR TITLE
Custom permission roles

### DIFF
--- a/gradle/changelog/custom_permission_role.yaml
+++ b/gradle/changelog/custom_permission_role.yaml
@@ -1,0 +1,2 @@
+- type: changed
+  description: Show "CUSTOM" name instead empty entry for permission roles ([#1597](https://github.com/scm-manager/scm-manager/pull/1597))

--- a/scm-ui/ui-webapp/src/repos/permissions/components/RoleSelector.tsx
+++ b/scm-ui/ui-webapp/src/repos/permissions/components/RoleSelector.tsx
@@ -31,11 +31,7 @@ type Props = {
   label?: string;
   helpText?: string;
   loading?: boolean;
-};
-
-const emptyOption = {
-  label: "",
-  value: ""
+  emptyLabel?: string;
 };
 
 const createSelectOptions = (roles: string[]) => {
@@ -47,11 +43,13 @@ const createSelectOptions = (roles: string[]) => {
   });
 };
 
-const RoleSelector: FC<Props> = ({ availableRoles, role, handleRoleChange, loading, label, helpText }) => {
+const RoleSelector: FC<Props> = ({ availableRoles, role, handleRoleChange, loading, label, helpText, emptyLabel }) => {
   if (!availableRoles) {
     return null;
   }
-  const options = role ? createSelectOptions(availableRoles) : [emptyOption, ...createSelectOptions(availableRoles)];
+  const options = role
+    ? createSelectOptions(availableRoles)
+    : [{ label: emptyLabel || "", value: "" }, ...createSelectOptions(availableRoles)];
 
   return (
     <Select

--- a/scm-ui/ui-webapp/src/repos/permissions/containers/CreatePermissionForm.tsx
+++ b/scm-ui/ui-webapp/src/repos/permissions/containers/CreatePermissionForm.tsx
@@ -164,6 +164,7 @@ const CreatePermissionForm: FC<Props> = ({
           selectedVerbs={selectedVerbs || []}
           onClose={() => setShowAdvancedDialog(false)}
           onSubmit={submitAdvancedPermissionsDialog}
+          readOnly={!create}
         />
       ) : null}
       <ErrorNotification error={error} />
@@ -212,6 +213,7 @@ const CreatePermissionForm: FC<Props> = ({
                   helpText={t("permission.help.roleHelpText")}
                   handleRoleChange={handleRoleChange}
                   role={permission.role || ""}
+                  emptyLabel={t("permission.custom")}
                 />
               </div>
               <div className="column">

--- a/scm-ui/ui-webapp/src/repos/permissions/containers/SinglePermission.tsx
+++ b/scm-ui/ui-webapp/src/repos/permissions/containers/SinglePermission.tsx
@@ -111,6 +111,7 @@ const SinglePermission: FC<Props> = ({
             availableRoles={availableRoleNames}
             role={permission.role || ""}
             loading={isLoading}
+            emptyLabel={t("permission.custom")}
           />
         </td>
       )}


### PR DESCRIPTION
## Proposed changes

Show "CUSTOM" as name on permission roles instead an empty entry. Before it could seem that an permission roles has no permissions at all.

### Your checklist for this pull request

- [x] PR is well described and the description can be used as commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
