### PR TITLE
Fix repository create route from namespace overview page

### DIFF
--- a/gradle/changelog/repo_create_route.yaml
+++ b/gradle/changelog/repo_create_route.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Fix repository creation route from repository namespace overview page ([#1602](https://github.com/scm-manager/scm-manager/pull/1602))

--- a/scm-ui/ui-components/src/OverviewPageActions.tsx
+++ b/scm-ui/ui-components/src/OverviewPageActions.tsx
@@ -32,6 +32,7 @@ type Props = {
   currentGroup: string;
   groups?: string[];
   link: string;
+  createLink?: string;
   groupSelected: (namespace: string) => void;
   label?: string;
   testId?: string;
@@ -47,6 +48,7 @@ const OverviewPageActions: FC<Props> = ({
   currentGroup,
   showCreateButton,
   link: inputLink,
+  createLink,
   groupSelected,
   label,
   testId,
@@ -72,7 +74,7 @@ const OverviewPageActions: FC<Props> = ({
     if (showCreateButton) {
       return (
         <div className={classNames("input-button", "control", "column")}>
-          <Button label={label} link={`${link}create`} color="primary" />
+          <Button label={label} link={createLink || `${link}create`} color="primary" />
         </div>
       );
     }

--- a/scm-ui/ui-webapp/src/repos/containers/Overview.tsx
+++ b/scm-ui/ui-webapp/src/repos/containers/Overview.tsx
@@ -145,6 +145,7 @@ const Overview: FC = () => {
             groups={namespacesToRender}
             groupSelected={namespaceSelected}
             link={namespace ? `repos/${namespace}` : "repos"}
+            createLink="/repos/create"
             label={t("overview.createButton")}
             testId="repository-overview"
             searchPlaceholder={t("overview.searchRepository")}


### PR DESCRIPTION
## Proposed changes

Fix repository create route from namespace overview page.

### Your checklist for this pull request

- [x] PR is well described and the description can be used as commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
