### PR TITLE
Fix stacktrace in response for invalid url

### DIFF
--- a/gradle/changelog/url_exception.yaml
+++ b/gradle/changelog/url_exception.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Response with exception stack trace for invalid urls ([#1605](https://github.com/scm-manager/scm-manager/pull/1605))

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/JsonMarshallingResponseFilter.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/JsonMarshallingResponseFilter.java
@@ -35,6 +35,7 @@ import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.ext.Provider;
 import java.util.Set;
 
@@ -45,6 +46,8 @@ import java.util.Set;
 @Provider
 @Priority(ResponseFilterPriorities.JSON_MARSHALLING)
 public class JsonMarshallingResponseFilter implements ContainerResponseFilter {
+
+  private static final MediaType ERROR_MEDIA_TYPE = MediaType.valueOf(VndMediaType.ERROR_TYPE);
 
   private final ObjectMapper objectMapper;
   private final Set<JsonEnricher> enrichers;
@@ -57,17 +60,18 @@ public class JsonMarshallingResponseFilter implements ContainerResponseFilter {
 
   @Override
   public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+    if (isError(responseContext)) {
+      return;
+    }
     if (hasVndEntity(responseContext)) {
       JsonNode node = getJsonEntity(responseContext);
-      if (!isErrorNode(node)) {
-        callEnrichers(requestContext, responseContext, node);
-      }
+      callEnrichers(requestContext, responseContext, node);
       responseContext.setEntity(node);
     }
   }
 
-  private boolean isErrorNode(JsonNode node) {
-    return node.has("transactionId") && node.has("errorCode") && node.has("message");
+  private boolean isError(ContainerResponseContext responseContext) {
+    return ERROR_MEDIA_TYPE.equals(responseContext.getMediaType());
   }
 
   private void callEnrichers(ContainerRequestContext requestContext, ContainerResponseContext responseContext, JsonNode node) {

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/JsonMarshallingResponseFilter.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/JsonMarshallingResponseFilter.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.api.v2;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -59,9 +59,15 @@ public class JsonMarshallingResponseFilter implements ContainerResponseFilter {
   public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
     if (hasVndEntity(responseContext)) {
       JsonNode node = getJsonEntity(responseContext);
-      callEnrichers(requestContext, responseContext, node);
+      if (!isErrorNode(node)) {
+        callEnrichers(requestContext, responseContext, node);
+      }
       responseContext.setEntity(node);
     }
+  }
+
+  private boolean isErrorNode(JsonNode node) {
+    return node.has("transactionId") && node.has("errorCode") && node.has("message");
   }
 
   private void callEnrichers(ContainerRequestContext requestContext, ContainerResponseContext responseContext, JsonNode node) {


### PR DESCRIPTION
## Proposed changes

This fixes responses with complete stack traces for
requests with invalid urls, for example such containing
backslash ('\') in the query parameter part (eg. q\=search).
In this case the response contains an error object due to
this error, and requesting the uri info would trigger the
same error a second time, only that now the exception mapper
would not catch the error again. So we check whether we have
an error object before trying to create an enricher context.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described and the description can be used as commit message on squash
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
