### PR TITLE
Fix repository overview for not existing namespace

### DIFF
--- a/gradle/changelog/namespace_not_existing.yaml
+++ b/gradle/changelog/namespace_not_existing.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Do not show repositories on overview for not existing namespace ([#1608](https://github.com/scm-manager/scm-manager/pull/1608))

--- a/scm-ui/ui-webapp/public/locales/de/repos.json
+++ b/scm-ui/ui-webapp/public/locales/de/repos.json
@@ -56,6 +56,7 @@
     "title": "Repositories",
     "subtitle": "Übersicht aller verfügbaren Repositories",
     "noRepositories": "Keine Repositories gefunden.",
+    "invalidNamespace": "Keine Repositories gefunden. Möglicherweise existiert der ausgewählte Namespace nicht.",
     "createButton": "Repository hinzufügen",
     "searchRepository": "Repository suchen",
     "allNamespaces": "Alle Namespaces"

--- a/scm-ui/ui-webapp/public/locales/en/repos.json
+++ b/scm-ui/ui-webapp/public/locales/en/repos.json
@@ -56,6 +56,7 @@
     "title": "Repositories",
     "subtitle": "Overview of available repositories",
     "noRepositories": "No repositories found.",
+    "invalidNamespace": "No repositories found. It's likely that the selected namespace does not exist.",
     "createButton": "Add Repository",
     "searchRepository": "Search repository",
     "allNamespaces": "All namespaces"

--- a/scm-ui/ui-webapp/src/repos/containers/Overview.tsx
+++ b/scm-ui/ui-webapp/src/repos/containers/Overview.tsx
@@ -56,7 +56,10 @@ const useOverviewData = () => {
     search,
     // if a namespaces is selected we have to wait
     // until the list of namespaces are loaded from the server
-    disabled: !!namespace && !namespaces
+    // also do not fetch repositories if an invalid namespace is selected
+    disabled:
+      (!!namespace && !namespaces) ||
+      (!!namespace && !namespaces?._embedded.namespaces.some(n => n.namespace === namespace))
   };
   const { isLoading: isLoadingRepositories, error: errorRepositories, data: repositories } = useRepositories(request);
 
@@ -92,7 +95,7 @@ const Repositories: FC<RepositoriesProps> = ({ namespaces, repositories, search,
       return <Notification type="info">{t("overview.noRepositories")}</Notification>;
     }
   } else {
-    return null;
+    return <Notification type="info">{t("overview.invalidNamespace")}</Notification>;
   }
 };
 
@@ -141,7 +144,9 @@ const Overview: FC = () => {
         {showActions ? (
           <OverviewPageActions
             showCreateButton={showCreateButton}
-            currentGroup={namespace || ""}
+            currentGroup={
+              namespace && namespaces?._embedded.namespaces.some(n => n.namespace === namespace) ? namespace : ""
+            }
             groups={namespacesToRender}
             groupSelected={namespaceSelected}
             link={namespace ? `repos/${namespace}` : "repos"}


### PR DESCRIPTION
## Proposed changes

Do not show repositories on the overview if a not existing namespace is selected.

### Your checklist for this pull request

- [x] PR is well described and the description can be used as commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
