### PR TITLE
Add more system metrics

### DIFF
--- a/gradle/changelog/system_metrics.yaml
+++ b/gradle/changelog/system_metrics.yaml
@@ -1,0 +1,2 @@
+- type: added
+  description: Metrics about logging, file descriptors, process threads and process memory ([#1609](https://github.com/scm-manager/scm-manager/pull/1609))

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -173,6 +173,7 @@ ext {
     jerseyClientRuntime: "com.sun.jersey.contribs:jersey-apache-client:${jerseyClientVersion}",
 
     // metrics
-    micrometerCore: "io.micrometer:micrometer-core:${micrometerVersion}"
+    micrometerCore: "io.micrometer:micrometer-core:${micrometerVersion}",
+    micrometerExtra: "io.github.mweirauch:micrometer-jvm-extras:0.2.2"
   ]
 }

--- a/scm-webapp/build.gradle
+++ b/scm-webapp/build.gradle
@@ -117,6 +117,9 @@ dependencies {
   implementation libraries.legmanShiro
   implementation libraries.legmanMicrometer
 
+  // metrics
+  implementation libraries.micrometerExtra
+
   // lombok
   compileOnly libraries.lombok
   testCompileOnly libraries.lombok

--- a/scm-webapp/src/main/java/sonia/scm/metrics/HttpMetricsFilter.java
+++ b/scm-webapp/src/main/java/sonia/scm/metrics/HttpMetricsFilter.java
@@ -47,7 +47,7 @@ import java.io.IOException;
 @Priority(Filters.PRIORITY_PRE_BASEURL)
 public class HttpMetricsFilter extends HttpFilter {
 
-  static final String METRIC_DURATION = "scm.http.requests";
+  static final String METRIC_DURATION = "http.server.requests";
 
   private final HttpServletRequestTagsProvider tagsProvider = new DefaultHttpServletRequestTagsProvider();
 

--- a/scm-webapp/src/main/java/sonia/scm/metrics/MeterRegistryProvider.java
+++ b/scm-webapp/src/main/java/sonia/scm/metrics/MeterRegistryProvider.java
@@ -26,13 +26,18 @@ package sonia.scm.metrics;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import io.github.mweirauch.micrometer.jvm.extras.ProcessMemoryMetrics;
+import io.github.mweirauch.micrometer.jvm.extras.ProcessThreadMetrics;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
+import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.core.instrument.binder.system.UptimeMetrics;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,12 +108,19 @@ public class MeterRegistryProvider implements Provider<MeterRegistry> {
     return staticRegistry;
   }
 
-  @SuppressWarnings("java:S2095") // we can't close JvmGcMetrics, but it should be ok
+  @SuppressWarnings("java:S2095") // we can't close, but it should be ok
   private void bindCommonMetrics(MeterRegistry registry) {
+    // bind all metrics for https://grafana.com/grafana/dashboards/4701
+    // expect those for tomcat
     new ClassLoaderMetrics().bindTo(registry);
     new JvmMemoryMetrics().bindTo(registry);
     new JvmGcMetrics().bindTo(registry);
     new ProcessorMetrics().bindTo(registry);
     new JvmThreadMetrics().bindTo(registry);
+    new UptimeMetrics().bindTo(registry);
+    new FileDescriptorMetrics().bindTo(registry);
+    new ProcessMemoryMetrics().bindTo(registry);
+    new ProcessThreadMetrics().bindTo(registry);
+    new LogbackMetrics().bindTo(registry);
   }
 }


### PR DESCRIPTION
## Proposed changes

Add metrics about logging, file descriptors, process threads and process memory.
Rename scm.http.requests to http.server.requests to match micrometer defaults.
With this change the exposed metrics are now compatible (except for the tomcat metrics) to the official micrometer grafana dashboard (https://grafana.com/grafana/dashboards/4701).

### Your checklist for this pull request

- [X] PR is well described and the description can be used as commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [X] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [X] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
