### PR TITLE
Add header to toplevel error boundary

### DIFF
--- a/gradle/changelog/missing_header.yaml
+++ b/gradle/changelog/missing_header.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Add header to toplevel error boundary ([#1613](https://github.com/scm-manager/scm-manager/pull/1613))

--- a/scm-ui/ui-webapp/src/containers/Index.tsx
+++ b/scm-ui/ui-webapp/src/containers/Index.tsx
@@ -23,7 +23,7 @@
  */
 import React, { FC, useState } from "react";
 import App from "./App";
-import { ErrorBoundary, Loading } from "@scm-manager/ui-components";
+import { ErrorBoundary, Loading, Header } from "@scm-manager/ui-components";
 import PluginLoader from "./PluginLoader";
 import ScrollToTop from "./ScrollToTop";
 import IndexErrorPage from "./IndexErrorPage";
@@ -37,7 +37,12 @@ const Index: FC = () => {
   // TODO check componentDidUpdate method for anonymous user stuff
 
   if (error) {
-    return <IndexErrorPage error={error} />;
+    return (
+      <>
+        <Header />
+        <IndexErrorPage error={error} />
+      </>
+    );
   }
   if (isLoading || !data) {
     return <Loading />;


### PR DESCRIPTION
## Proposed changes

In the event of a reload due to a change of focus, possible error boundaries were displayed without the SCM-Manager header. This change complements the appropriate header.

### Your checklist for this pull request

- [x] PR is well described and the description can be used as commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
