### PR TITLE
Fix compatibility with old redux api

### DIFF
--- a/gradle/changelog/restore_redux_compatibility.yaml
+++ b/gradle/changelog/restore_redux_compatibility.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Fix compatibility with old redux api ([#1618](https://github.com/scm-manager/scm-manager/pull/1618))

--- a/scm-ui/ui-webapp/src/LegacyReduxProvider.tsx
+++ b/scm-ui/ui-webapp/src/LegacyReduxProvider.tsx
@@ -53,7 +53,9 @@ type State = {
     version: string;
     links: Links;
   };
-  me?: Me;
+  auth?: {
+    me?: Me;
+  };
 };
 
 const initialState: State = {};
@@ -72,7 +74,9 @@ const reducer = (state: State = initialState, action: ActionTypes = { type: ACTI
     case "scm/me_success": {
       return {
         ...state,
-        me: action.payload
+        auth: {
+          me: action.payload
+        }
       };
     }
     default: {


### PR DESCRIPTION
## Proposed changes

Fix compatibility with old redux api. The "me" data model had changed and broke some old plugins.

### Your checklist for this pull request

- [x] PR is well described and the description can be used as commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
 
### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
