### PR TITLE
Add button to hg config ui to trigger automatic configuration

### DIFF
--- a/gradle/changelog/hg_auto_config_ui.yaml
+++ b/gradle/changelog/hg_auto_config_ui.yaml
@@ -1,0 +1,2 @@
+- type: Added
+  description: Trigger mercurial auto config via ui ([#1620](https://github.com/scm-manager/scm-manager/pull/1620))

--- a/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/api/v2/resources/HgConfigLinks.java
+++ b/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/api/v2/resources/HgConfigLinks.java
@@ -46,9 +46,9 @@ public class HgConfigLinks {
   }
 
 
-  public ConfigLinks global() {
+  public GlobalConfigLinks global() {
     LinkBuilder linkBuilder = new LinkBuilder(pathInfoStore.get().get(), HgConfigResource.class);
-    return new ConfigLinks() {
+    return new GlobalConfigLinks() {
       @Override
       public String get() {
         return linkBuilder.method("get").parameters().href();
@@ -57,6 +57,12 @@ public class HgConfigLinks {
       @Override
       public String update() {
         return linkBuilder.method("update").parameters().href();
+      }
+
+      @Override
+      public String autoConfigure() {
+        LinkBuilder linkBuilder = new LinkBuilder(pathInfoStore.get().get(), HgGlobalConfigAutoConfigurationResource.class);
+        return linkBuilder.method("autoConfiguration").parameters().href();
       }
     };
   }
@@ -86,5 +92,9 @@ public class HgConfigLinks {
   public interface ConfigLinks  {
     String get();
     String update();
+  }
+
+  public interface GlobalConfigLinks extends ConfigLinks  {
+    String autoConfigure();
   }
 }

--- a/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/api/v2/resources/HgGlobalConfigAutoConfigurationResource.java
+++ b/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/api/v2/resources/HgGlobalConfigAutoConfigurationResource.java
@@ -42,6 +42,9 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 
+import static sonia.scm.api.v2.resources.HgConfigResource.HG_CONFIG_PATH_V2;
+
+@Path(HG_CONFIG_PATH_V2 + "/auto-configuration")
 public class HgGlobalConfigAutoConfigurationResource {
 
   private final HgRepositoryHandler repositoryHandler;
@@ -73,7 +76,7 @@ public class HgGlobalConfigAutoConfigurationResource {
       mediaType = VndMediaType.ERROR_TYPE,
       schema = @Schema(implementation = ErrorDto.class)
     ))
-  public Response autoConfiguration() {
+  public Response autoConfigurationWithoutDto() {
     return autoConfiguration(null);
   }
 
@@ -127,6 +130,10 @@ public class HgGlobalConfigAutoConfigurationResource {
     ConfigurationPermissions.write(config).check();
 
     repositoryHandler.doAutoConfiguration(config);
+    HgGlobalConfig oldConfig = repositoryHandler.getConfig();
+    oldConfig.setHgBinary(config.getHgBinary());
+    repositoryHandler.setConfig(oldConfig);
+    repositoryHandler.storeConfig();
 
     return Response.noContent().build();
   }

--- a/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/api/v2/resources/HgGlobalConfigToHgGlobalConfigDtoMapper.java
+++ b/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/api/v2/resources/HgGlobalConfigToHgGlobalConfigDtoMapper.java
@@ -52,10 +52,11 @@ public abstract class HgGlobalConfigToHgGlobalConfigDtoMapper extends BaseMapper
 
   @AfterMapping
   void appendLinks(HgGlobalConfig config, @MappingTarget HgGlobalGlobalConfigDto target) {
-    HgConfigLinks.ConfigLinks configLinks = links.global();
+    HgConfigLinks.GlobalConfigLinks configLinks = links.global();
     Links.Builder linksBuilder = linkingTo().self(configLinks.get());
     if (ConfigurationPermissions.write(config).isPermitted()) {
       linksBuilder.single(link("update", configLinks.update()));
+      linksBuilder.single(link("autoConfiguration", configLinks.autoConfigure()));
     }
     target.add(linksBuilder.build());
   }

--- a/scm-plugins/scm-hg-plugin/src/main/js/HgConfigurationForm.tsx
+++ b/scm-plugins/scm-hg-plugin/src/main/js/HgConfigurationForm.tsx
@@ -147,12 +147,14 @@ class HgConfigurationForm extends React.Component<Props, State> {
         {this.inputField("encoding")}
         <div className="column is-half">{this.checkbox("showRevisionInId")}</div>
         <div className="column is-half">{this.checkbox("enableHttpPostArgs")}</div>
-        <Button
-          disabled={!this.props.initialConfiguration?._links?.autoConfiguration}
-          action={() => this.triggerAutoConfigure()}
-        >
-          {t("scm-hg-plugin.config.autoConfigure")}
-        </Button>
+        <div className="column is-full">
+          <Button
+            disabled={!this.props.initialConfiguration?._links?.autoConfiguration}
+            action={() => this.triggerAutoConfigure()}
+          >
+            {t("scm-hg-plugin.config.autoConfigure")}
+          </Button>
+        </div>
       </div>
     );
   }

--- a/scm-plugins/scm-hg-plugin/src/main/js/HgConfigurationForm.tsx
+++ b/scm-plugins/scm-hg-plugin/src/main/js/HgConfigurationForm.tsx
@@ -23,8 +23,8 @@
  */
 import React from "react";
 import { WithTranslation, withTranslation } from "react-i18next";
-import { Links } from "@scm-manager/ui-types";
-import { InputField, Checkbox } from "@scm-manager/ui-components";
+import { Link, Links } from "@scm-manager/ui-types";
+import { InputField, Checkbox, Button, apiClient } from "@scm-manager/ui-components";
 
 type Configuration = {
   hgBinary: string;
@@ -89,6 +89,22 @@ class HgConfigurationForm extends React.Component<Props, State> {
     );
   };
 
+  triggerAutoConfigure = () => {
+    apiClient
+      .put(
+        (this.props.initialConfiguration._links.autoConfiguration as Link).href,
+        { ...this.props.initialConfiguration, hgBinary: this.state.hgBinary },
+        "application/vnd.scmm-hgConfig+json;v=2"
+      )
+      .then(() =>
+        apiClient
+          .get((this.props.initialConfiguration._links.self as Link).href)
+          .then(r => r.json())
+          .then((config: Configuration) => this.setState({ hgBinary: config.hgBinary }))
+      )
+      .then(() => this.updateValidationStatus());
+  };
+
   inputField = (name: string) => {
     const { readOnly, t } = this.props;
     return (
@@ -124,16 +140,19 @@ class HgConfigurationForm extends React.Component<Props, State> {
   };
 
   render() {
+    const { t } = this.props;
     return (
       <div className="columns is-multiline">
         {this.inputField("hgBinary")}
         {this.inputField("encoding")}
-        <div className="column is-half">
-          {this.checkbox("showRevisionInId")}
-        </div>
-        <div className="column is-half">
-          {this.checkbox("enableHttpPostArgs")}
-        </div>
+        <div className="column is-half">{this.checkbox("showRevisionInId")}</div>
+        <div className="column is-half">{this.checkbox("enableHttpPostArgs")}</div>
+        <Button
+          disabled={!this.props.initialConfiguration?._links?.autoConfiguration}
+          action={() => this.triggerAutoConfigure()}
+        >
+          {t("scm-hg-plugin.config.autoConfigure")}
+        </Button>
       </div>
     );
   }

--- a/scm-plugins/scm-hg-plugin/src/main/resources/locales/de/plugins.json
+++ b/scm-plugins/scm-hg-plugin/src/main/resources/locales/de/plugins.json
@@ -23,7 +23,8 @@
       "disabledHelpText": "Aktiviert oder deaktiviert das Mercurial Plugin.",
       "required": "Dieser Konfigurationswert wird benötigt",
       "submit": "Speichern",
-      "success": "Einstellungen wurden erfolgreich geändert"
+      "success": "Einstellungen wurden erfolgreich geändert",
+      "autoConfigure": "Mercurial automatisch konfigurieren"
     }
   },
   "permissions" : {

--- a/scm-plugins/scm-hg-plugin/src/main/resources/locales/en/plugins.json
+++ b/scm-plugins/scm-hg-plugin/src/main/resources/locales/en/plugins.json
@@ -23,7 +23,8 @@
       "disabledHelpText": "Enable or disable the Mercurial plugin.",
       "required": "This configuration value is required",
       "submit": "Submit",
-      "success": "Configuration changed successfully"
+      "success": "Configuration changed successfully",
+      "autoConfigure": "Configure mercurial automatically"
     }
   },
   "permissions" : {

--- a/scm-plugins/scm-hg-plugin/src/main/resources/locales/en/plugins.json
+++ b/scm-plugins/scm-hg-plugin/src/main/resources/locales/en/plugins.json
@@ -24,7 +24,7 @@
       "required": "This configuration value is required",
       "submit": "Submit",
       "success": "Configuration changed successfully",
-      "autoConfigure": "Configure mercurial automatically"
+      "autoConfigure": "Configure Mercurial Automatically"
     }
   },
   "permissions" : {

--- a/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/api/v2/resources/HgGlobalConfigAutoConfigurationResourceTest.java
+++ b/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/api/v2/resources/HgGlobalConfigAutoConfigurationResourceTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;

--- a/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/api/v2/resources/HgGlobalConfigToHgGlobalConfigDtoMapperTest.java
+++ b/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/api/v2/resources/HgGlobalConfigToHgGlobalConfigDtoMapperTest.java
@@ -84,6 +84,9 @@ class HgGlobalConfigToHgGlobalConfigDtoMapperTest {
     assertThat(dto.getLinks().getLinkBy("update")).hasValueSatisfying(
       link -> assertThat(link.getHref()).isEqualTo(expectedBaseUri.toString())
     );
+    assertThat(dto.getLinks().getLinkBy("autoConfiguration")).hasValueSatisfying(
+      link -> assertThat(link.getHref()).isEqualTo(expectedBaseUri.toString() + "/auto-configuration")
+    );
   }
 
   @Test
@@ -97,5 +100,6 @@ class HgGlobalConfigToHgGlobalConfigDtoMapperTest {
       link -> assertThat(link.getHref()).isEqualTo(expectedBaseUri.toString())
     );
     assertThat(dto.getLinks().hasLink("update")).isFalse();
+    assertThat(dto.getLinks().hasLink("autoConfiguration")).isFalse();
   }
 }


### PR DESCRIPTION
## Proposed changes

Add button on global mercurial config to trigger automatic mercurial configuration for SCM-Manager instance.

### Your checklist for this pull request

- [x] PR is well described and the description can be used as commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
