### PR TITLE
Add extension point for repository creators

### DIFF
--- a/gradle/changelog/extension_point_repository_creator.yaml
+++ b/gradle/changelog/extension_point_repository_creator.yaml
@@ -1,0 +1,2 @@
+- type: added
+  description: Extension Point for repository creators ([#1657](https://github.com/scm-manager/scm-manager/pull/1657))

--- a/scm-ui/ui-extensions/package.json
+++ b/scm-ui/ui-extensions/package.json
@@ -10,7 +10,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "react": "^17.0.1"
+    "react": "^17.0.1",
+    "@scm-manager/ui-types": "^2.18.1-SNAPSHOT"
   },
   "devDependencies": {
     "@scm-manager/babel-preset": "^2.12.0",

--- a/scm-ui/ui-extensions/src/binder.ts
+++ b/scm-ui/ui-extensions/src/binder.ts
@@ -30,7 +30,7 @@ type ExtensionRegistration<P, T> = {
   extensionName: string;
 };
 
-export type ExtensionPointDefinition<N extends string, T, P> = {
+export type ExtensionPointDefinition<N extends string, T, P = undefined> = {
   name: N;
   type: T;
   props: P;

--- a/scm-ui/ui-extensions/src/extensionPoints.ts
+++ b/scm-ui/ui-extensions/src/extensionPoints.ts
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-import React from "react";
+import { ExtensionPointDefinition } from "./binder";
 import {
   IndexResources,
   NamespaceStrategies,
@@ -30,26 +30,28 @@ import {
   RepositoryTypeCollection
 } from "@scm-manager/ui-types";
 
-export type SubFormProps = {
+type RepositoryCreatorSubFormProps = {
   repository: RepositoryCreation;
   onChange: (repository: RepositoryCreation) => void;
   setValid: (valid: boolean) => void;
   disabled?: boolean;
 };
 
-export type CreatorComponentProps = {
+export type RepositoryCreatorComponentProps = {
   namespaceStrategies: NamespaceStrategies;
   repositoryTypes: RepositoryTypeCollection;
   index: IndexResources;
 
-  nameForm: React.ComponentType<SubFormProps>;
-  informationForm: React.ComponentType<SubFormProps>;
+  nameForm: React.ComponentType<RepositoryCreatorSubFormProps>;
+  informationForm: React.ComponentType<RepositoryCreatorSubFormProps>;
 };
 
-export type Creator = {
+export type RepositoryCreatorExtension = {
   subtitle: string;
   path: string;
   icon: string;
   label: string;
-  component: React.ComponentType<CreatorComponentProps>;
+  component: React.ComponentType<RepositoryCreatorComponentProps>;
 };
+
+export type RepositoryCreator = ExtensionPointDefinition<"repos.creator", RepositoryCreatorExtension>;

--- a/scm-ui/ui-extensions/src/index.ts
+++ b/scm-ui/ui-extensions/src/index.ts
@@ -25,3 +25,8 @@
 export { default as binder, Binder, ExtensionPointDefinition } from "./binder";
 export * from "./useBinder";
 export { default as ExtensionPoint } from "./ExtensionPoint";
+
+// suppress eslint prettier warning,
+// because prettier does not understand "* as"
+// eslint-disable-next-line prettier/prettier
+export * as extensionPoints from "./extensionPoints";

--- a/scm-ui/ui-types/src/Repositories.ts
+++ b/scm-ui/ui-types/src/Repositories.ts
@@ -56,7 +56,7 @@ export type RepositoryCreation = RepositoryBase & {
   contextEntries: { [key: string]: any };
 };
 
-export type RepositoryUrlImport = Repository & {
+export type RepositoryUrlImport = RepositoryCreation & {
   importUrl: string;
   username?: string;
   password?: string;

--- a/scm-ui/ui-webapp/src/containers/Main.tsx
+++ b/scm-ui/ui-webapp/src/containers/Main.tsx
@@ -37,7 +37,6 @@ import { binder, ExtensionPoint } from "@scm-manager/ui-extensions";
 import CreateUser from "../users/containers/CreateUser";
 import SingleUser from "../users/containers/SingleUser";
 import RepositoryRoot from "../repos/containers/RepositoryRoot";
-import CreateRepository from "../repos/containers/CreateRepository";
 
 import Groups from "../groups/containers/Groups";
 import SingleGroup from "../groups/containers/SingleGroup";
@@ -47,8 +46,8 @@ import Admin from "../admin/containers/Admin";
 
 import Profile from "./Profile";
 import NamespaceRoot from "../repos/namespaces/containers/NamespaceRoot";
-import ImportRepository from "../repos/containers/ImportRepository";
 import ImportLog from "../repos/importlog/ImportLog";
+import CreateRepositoryRoot from "../repos/containers/CreateRepositoryRoot";
 
 type Props = {
   me: Me;
@@ -79,8 +78,8 @@ class Main extends React.Component<Props> {
             <Route path="/logout" component={Logout} />
             <Redirect exact strict from="/repos" to="/repos/" />
             <ProtectedRoute exact path="/repos/" component={Overview} authenticated={authenticated} />
-            <ProtectedRoute exact path="/repos/create" component={CreateRepository} authenticated={authenticated} />
-            <ProtectedRoute exact path="/repos/import" component={ImportRepository} authenticated={authenticated} />
+            <ProtectedRoute path="/repos/create" component={CreateRepositoryRoot} authenticated={authenticated} />
+            <Redirect exact strict from="/repos/import" to="/repos/create/import" />
             <ProtectedRoute exact path="/repos/:namespace" component={Overview} authenticated={authenticated} />
             <ProtectedRoute exact path="/repos/:namespace/:page" component={Overview} authenticated={authenticated} />
             <ProtectedRoute path="/repo/:namespace/:name" component={RepositoryRoot} authenticated={authenticated} />

--- a/scm-ui/ui-webapp/src/repos/components/ImportFullRepository.tsx
+++ b/scm-ui/ui-webapp/src/repos/components/ImportFullRepository.tsx
@@ -22,28 +22,35 @@
  * SOFTWARE.
  */
 import React, { FC, FormEvent, useState } from "react";
-import NamespaceAndNameFields from "./NamespaceAndNameFields";
-import { File, Repository } from "@scm-manager/ui-types";
-import RepositoryInformationForm from "./RepositoryInformationForm";
+import { File, RepositoryCreation } from "@scm-manager/ui-types";
 import { apiClient, ErrorNotification, Level, SubmitButton } from "@scm-manager/ui-components";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import ImportFullRepositoryForm from "./ImportFullRepositoryForm";
+import { SubFormProps } from "../types";
 
 type Props = {
   url: string;
   repositoryType: string;
   setImportPending: (pending: boolean) => void;
+  nameForm: React.ComponentType<SubFormProps>;
+  informationForm: React.ComponentType<SubFormProps>;
 };
 
-const ImportFullRepository: FC<Props> = ({ url, repositoryType, setImportPending }) => {
-  const [repo, setRepo] = useState<Repository>({
+const ImportFullRepository: FC<Props> = ({
+  url,
+  repositoryType,
+  setImportPending,
+  nameForm: NameForm,
+  informationForm: InformationForm
+}) => {
+  const [repo, setRepo] = useState<RepositoryCreation>({
     name: "",
     namespace: "",
     type: repositoryType,
     contact: "",
     description: "",
-    _links: {}
+    contextEntries: []
   });
   const [password, setPassword] = useState("");
   const [valid, setValid] = useState({ namespaceAndName: false, contact: true, file: false });
@@ -97,15 +104,15 @@ const ImportFullRepository: FC<Props> = ({ url, repositoryType, setImportPending
         setValid={(file: boolean) => setValid({ ...valid, file })}
       />
       <hr />
-      <NamespaceAndNameFields
+      <NameForm
         repository={repo}
-        onChange={setRepo as React.Dispatch<React.SetStateAction<Repository>>}
+        onChange={setRepo as React.Dispatch<React.SetStateAction<RepositoryCreation>>}
         setValid={(namespaceAndName: boolean) => setValid({ ...valid, namespaceAndName })}
         disabled={loading}
       />
-      <RepositoryInformationForm
+      <InformationForm
         repository={repo}
-        onChange={setRepo as React.Dispatch<React.SetStateAction<Repository>>}
+        onChange={setRepo as React.Dispatch<React.SetStateAction<RepositoryCreation>>}
         disabled={loading}
         setValid={(contact: boolean) => setValid({ ...valid, contact })}
       />

--- a/scm-ui/ui-webapp/src/repos/components/ImportRepositoryFromBundle.tsx
+++ b/scm-ui/ui-webapp/src/repos/components/ImportRepositoryFromBundle.tsx
@@ -22,28 +22,35 @@
  * SOFTWARE.
  */
 import React, { FC, FormEvent, useState } from "react";
-import NamespaceAndNameFields from "./NamespaceAndNameFields";
-import { File, Repository } from "@scm-manager/ui-types";
-import RepositoryInformationForm from "./RepositoryInformationForm";
+import { File, RepositoryCreation } from "@scm-manager/ui-types";
 import { apiClient, ErrorNotification, Level, SubmitButton } from "@scm-manager/ui-components";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import ImportFromBundleForm from "./ImportFromBundleForm";
+import { SubFormProps } from "../types";
 
 type Props = {
   url: string;
   repositoryType: string;
   setImportPending: (pending: boolean) => void;
+  nameForm: React.ComponentType<SubFormProps>;
+  informationForm: React.ComponentType<SubFormProps>;
 };
 
-const ImportRepositoryFromBundle: FC<Props> = ({ url, repositoryType, setImportPending }) => {
-  const [repo, setRepo] = useState<Repository>({
+const ImportRepositoryFromBundle: FC<Props> = ({
+  url,
+  repositoryType,
+  setImportPending,
+  nameForm: NameForm,
+  informationForm: InformationForm
+}) => {
+  const [repo, setRepo] = useState<RepositoryCreation>({
     name: "",
     namespace: "",
     type: repositoryType,
     contact: "",
     description: "",
-    _links: {}
+    contextEntries: []
   });
   const [password, setPassword] = useState("");
   const [valid, setValid] = useState({ namespaceAndName: false, contact: true, file: false });
@@ -101,15 +108,15 @@ const ImportRepositoryFromBundle: FC<Props> = ({ url, repositoryType, setImportP
         disabled={loading}
       />
       <hr />
-      <NamespaceAndNameFields
+      <NameForm
         repository={repo}
-        onChange={setRepo as React.Dispatch<React.SetStateAction<Repository>>}
+        onChange={setRepo as React.Dispatch<React.SetStateAction<RepositoryCreation>>}
         setValid={(namespaceAndName: boolean) => setValid({ ...valid, namespaceAndName })}
         disabled={loading}
       />
-      <RepositoryInformationForm
+      <InformationForm
         repository={repo}
-        onChange={setRepo as React.Dispatch<React.SetStateAction<Repository>>}
+        onChange={setRepo as React.Dispatch<React.SetStateAction<RepositoryCreation>>}
         disabled={loading}
         setValid={(contact: boolean) => setValid({ ...valid, contact })}
       />

--- a/scm-ui/ui-webapp/src/repos/components/ImportRepositoryFromUrl.tsx
+++ b/scm-ui/ui-webapp/src/repos/components/ImportRepositoryFromUrl.tsx
@@ -22,21 +22,28 @@
  * SOFTWARE.
  */
 import React, { FC, FormEvent, useState } from "react";
-import NamespaceAndNameFields from "./NamespaceAndNameFields";
-import { Repository, RepositoryUrlImport } from "@scm-manager/ui-types";
+import { RepositoryCreation, RepositoryUrlImport } from "@scm-manager/ui-types";
 import ImportFromUrlForm from "./ImportFromUrlForm";
-import RepositoryInformationForm from "./RepositoryInformationForm";
 import { apiClient, ErrorNotification, Level, SubmitButton } from "@scm-manager/ui-components";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
+import { SubFormProps } from "../types";
 
 type Props = {
   url: string;
   repositoryType: string;
   setImportPending: (pending: boolean) => void;
+  nameForm: React.ComponentType<SubFormProps>;
+  informationForm: React.ComponentType<SubFormProps>;
 };
 
-const ImportRepositoryFromUrl: FC<Props> = ({ url, repositoryType, setImportPending }) => {
+const ImportRepositoryFromUrl: FC<Props> = ({
+  url,
+  repositoryType,
+  setImportPending,
+  nameForm: NameForm,
+  informationForm: InformationForm
+}) => {
   const [repo, setRepo] = useState<RepositoryUrlImport>({
     name: "",
     namespace: "",
@@ -46,7 +53,7 @@ const ImportRepositoryFromUrl: FC<Props> = ({ url, repositoryType, setImportPend
     importUrl: "",
     username: "",
     password: "",
-    _links: {}
+    contextEntries: []
   });
 
   const [valid, setValid] = useState({ namespaceAndName: false, contact: true, importUrl: false });
@@ -96,15 +103,15 @@ const ImportRepositoryFromUrl: FC<Props> = ({ url, repositoryType, setImportPend
         disabled={loading}
       />
       <hr />
-      <NamespaceAndNameFields
+      <NameForm
         repository={repo}
-        onChange={setRepo as React.Dispatch<React.SetStateAction<Repository>>}
+        onChange={setRepo as React.Dispatch<React.SetStateAction<RepositoryCreation>>}
         setValid={(namespaceAndName: boolean) => setValid({ ...valid, namespaceAndName })}
         disabled={loading}
       />
-      <RepositoryInformationForm
+      <InformationForm
         repository={repo}
-        onChange={setRepo as React.Dispatch<React.SetStateAction<Repository>>}
+        onChange={setRepo as React.Dispatch<React.SetStateAction<RepositoryCreation>>}
         disabled={loading}
         setValid={(contact: boolean) => setValid({ ...valid, contact })}
       />

--- a/scm-ui/ui-webapp/src/repos/components/NamespaceAndNameFields.tsx
+++ b/scm-ui/ui-webapp/src/repos/components/NamespaceAndNameFields.tsx
@@ -23,7 +23,7 @@
  */
 
 import React, { FC, useEffect, useState } from "react";
-import { Repository, CUSTOM_NAMESPACE_STRATEGY } from "@scm-manager/ui-types";
+import { CUSTOM_NAMESPACE_STRATEGY, RepositoryCreation } from "@scm-manager/ui-types";
 import { useTranslation } from "react-i18next";
 import { InputField } from "@scm-manager/ui-components";
 import { ExtensionPoint } from "@scm-manager/ui-extensions";
@@ -31,8 +31,8 @@ import * as validator from "./form/repositoryValidation";
 import { useNamespaceStrategies } from "@scm-manager/ui-api";
 
 type Props = {
-  repository: Repository;
-  onChange: (repository: Repository) => void;
+  repository: RepositoryCreation;
+  onChange: (repository: RepositoryCreation) => void;
   setValid: (valid: boolean) => void;
   disabled?: boolean;
 };
@@ -83,10 +83,10 @@ const NamespaceAndNameFields: FC<Props> = ({ repository, onChange, setValid, dis
   };
 
   const renderNamespaceField = () => {
-      let informationMessage = undefined;
-      if (repository?.namespace?.indexOf(" ") > 0) {
-        informationMessage =  t("validation.namespaceSpaceWarningText");
-      }
+    let informationMessage = undefined;
+    if (repository?.namespace?.indexOf(" ") > 0) {
+      informationMessage = t("validation.namespaceSpaceWarningText");
+    }
 
     const props = {
       label: t("repository.namespace"),

--- a/scm-ui/ui-webapp/src/repos/components/RepositoryInformationForm.tsx
+++ b/scm-ui/ui-webapp/src/repos/components/RepositoryInformationForm.tsx
@@ -23,15 +23,15 @@
  */
 import React, { FC, useState } from "react";
 import { InputField, Textarea } from "@scm-manager/ui-components";
-import { Repository } from "@scm-manager/ui-types";
+import { RepositoryCreation } from "@scm-manager/ui-types";
 import { useTranslation } from "react-i18next";
 import * as validator from "./form/repositoryValidation";
 
 type Props = {
-  repository: Repository;
-  onChange: (repository: Repository) => void;
-  disabled: boolean;
+  repository: RepositoryCreation;
+  onChange: (repository: RepositoryCreation) => void;
   setValid: (valid: boolean) => void;
+  disabled?: boolean;
 };
 
 const RepositoryInformationForm: FC<Props> = ({ repository, onChange, disabled, setValid }) => {

--- a/scm-ui/ui-webapp/src/repos/components/form/RepositoryFormSwitcher.tsx
+++ b/scm-ui/ui-webapp/src/repos/components/form/RepositoryFormSwitcher.tsx
@@ -24,11 +24,8 @@
 
 import React, { FC } from "react";
 import styled from "styled-components";
-import { useTranslation } from "react-i18next";
-import { Button, ButtonAddons, Icon, Level } from "@scm-manager/ui-components";
+import { Button, ButtonAddons, Icon, Level, urls } from "@scm-manager/ui-components";
 import { useLocation } from "react-router-dom";
-import { useBinder } from "@scm-manager/ui-extensions";
-import { useRepositoryTypes } from "@scm-manager/ui-api";
 
 const MarginIcon = styled(Icon)`
   padding-right: 0.5rem;
@@ -52,13 +49,14 @@ const TopLevel = styled(Level)`
 `;
 
 type RepositoryForm = {
-  href: string;
+  path: string;
   icon: string;
   label: string;
 };
 
-const RepositoryFormButton: FC<RepositoryForm> = ({ href, icon, label }) => {
+const RepositoryFormButton: FC<RepositoryForm> = ({ path, icon, label }) => {
   const location = useLocation();
+  const href = urls.concat("/repos/create", path);
   const isSelected = href === location.pathname;
 
   return (
@@ -69,40 +67,20 @@ const RepositoryFormButton: FC<RepositoryForm> = ({ href, icon, label }) => {
   );
 };
 
-const RepositoryFormSwitcher: FC = () => {
-  const [t] = useTranslation("repos");
-  const { data } = useRepositoryTypes();
-  const binder = useBinder();
-
-  const forms = [
-    {
-      href: "/repos/create",
-      icon: "plus",
-      label: t("repositoryForm.createButton")
-    },
-    {
-      href: "/repos/import",
-      icon: "file-upload",
-      label: t("repositoryForm.importButton")
-    }
-  ];
-
-  if (data && binder.hasExtension("repo.add.form-switcher")) {
-    const extensionForms: RepositoryForm[] = binder.getExtensions("repo.add.form-switcher", { repositoryTypes: data });
-    forms.push(...extensionForms);
-  }
-
-  return (
-    <TopLevel
-      right={
-        <ButtonAddons>
-          {forms.map(form => (
-            <RepositoryFormButton key={form.href} {...form} />
-          ))}
-        </ButtonAddons>
-      }
-    />
-  );
+type Props = {
+  forms: RepositoryForm[];
 };
+
+const RepositoryFormSwitcher: FC<Props> = ({ forms }) => (
+  <TopLevel
+    right={
+      <ButtonAddons>
+        {(forms || []).map(form => (
+          <RepositoryFormButton key={form.path} {...form} />
+        ))}
+      </ButtonAddons>
+    }
+  />
+);
 
 export default RepositoryFormSwitcher;

--- a/scm-ui/ui-webapp/src/repos/containers/CreateRepository.tsx
+++ b/scm-ui/ui-webapp/src/repos/containers/CreateRepository.tsx
@@ -55,7 +55,7 @@ const CreateRepository: FC = () => {
     <Page
       title={t("create.title")}
       subtitle={t("create.subtitle")}
-      afterTitle={<RepositoryFormSwitcher creationMode={"CREATE"} />}
+      afterTitle={<RepositoryFormSwitcher />}
       loading={isPageLoading}
       error={pageLoadingError || error || undefined}
       showContentOnError={true}

--- a/scm-ui/ui-webapp/src/repos/containers/CreateRepositoryRoot.tsx
+++ b/scm-ui/ui-webapp/src/repos/containers/CreateRepositoryRoot.tsx
@@ -33,11 +33,11 @@ import RepositoryFormSwitcher from "../components/form/RepositoryFormSwitcher";
 import { useIndex, useNamespaceStrategies, useRepositoryTypes } from "@scm-manager/ui-api";
 import NamespaceAndNameFields from "../components/NamespaceAndNameFields";
 import RepositoryInformationForm from "../components/RepositoryInformationForm";
-import { Creator } from "../types";
+import { extensionPoints } from "@scm-manager/ui-extensions/";
 
 type CreatorRouteProps = {
-  creator: Creator;
-  creators: Creator[];
+  creator: extensionPoints.RepositoryCreatorExtension;
+  creators: extensionPoints.RepositoryCreatorExtension[];
 };
 
 const useCreateRepositoryData = () => {
@@ -84,7 +84,7 @@ const CreateRepositoryRoot: FC = () => {
   const [t] = useTranslation("repos");
   const binder = useBinder();
 
-  const creators: Creator[] = [
+  const creators: extensionPoints.RepositoryCreatorExtension[] = [
     {
       subtitle: t("create.subtitle"),
       path: "",
@@ -101,7 +101,7 @@ const CreateRepositoryRoot: FC = () => {
     }
   ];
 
-  const extCreators: Creator[] = binder.getExtensions("repos.creator");
+  const extCreators = binder.getExtensions<extensionPoints.RepositoryCreator>("repos.creator");
   if (extCreators) {
     creators.push(...extCreators);
   }

--- a/scm-ui/ui-webapp/src/repos/containers/CreateRepositoryRoot.tsx
+++ b/scm-ui/ui-webapp/src/repos/containers/CreateRepositoryRoot.tsx
@@ -1,0 +1,120 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import React, { FC } from "react";
+import { Route, Switch } from "react-router-dom";
+import CreateRepository from "./CreateRepository";
+import ImportRepository from "./ImportRepository";
+import { useBinder } from "@scm-manager/ui-extensions";
+import { useTranslation } from "react-i18next";
+import { Page, urls } from "@scm-manager/ui-components";
+import RepositoryFormSwitcher from "../components/form/RepositoryFormSwitcher";
+import { useIndex, useNamespaceStrategies, useRepositoryTypes } from "@scm-manager/ui-api";
+import NamespaceAndNameFields from "../components/NamespaceAndNameFields";
+import RepositoryInformationForm from "../components/RepositoryInformationForm";
+import { Creator } from "../types";
+
+type CreatorRouteProps = {
+  creator: Creator;
+  creators: Creator[];
+};
+
+const useCreateRepositoryData = () => {
+  const { isLoading: isLoadingNS, error: errorNS, data: namespaceStrategies } = useNamespaceStrategies();
+  const { isLoading: isLoadingRT, error: errorRT, data: repositoryTypes } = useRepositoryTypes();
+  const { isLoading: isLoadingIdx, error: errorIdx, data: index } = useIndex();
+  return {
+    isPageLoading: isLoadingNS || isLoadingRT || isLoadingIdx,
+    pageLoadingError: errorNS || errorRT || errorIdx || undefined,
+    namespaceStrategies,
+    repositoryTypes,
+    index
+  };
+};
+
+const CreatorRoute: FC<CreatorRouteProps> = ({ creator, creators }) => {
+  const { isPageLoading, pageLoadingError, namespaceStrategies, repositoryTypes, index } = useCreateRepositoryData();
+  const [t] = useTranslation(["repos", "plugins"]);
+
+  const Component = creator.component;
+
+  return (
+    <Page
+      title={t("repos:create.title")}
+      subtitle={t(`plugins:${creator.subtitle}`, creator.subtitle)}
+      afterTitle={<RepositoryFormSwitcher forms={creators} />}
+      loading={isPageLoading}
+      error={pageLoadingError}
+    >
+      {namespaceStrategies && repositoryTypes && index ? (
+        <Component
+          namespaceStrategies={namespaceStrategies}
+          repositoryTypes={repositoryTypes}
+          index={index}
+          nameForm={NamespaceAndNameFields}
+          informationForm={RepositoryInformationForm}
+        />
+      ) : null}
+    </Page>
+  );
+};
+
+const CreateRepositoryRoot: FC = () => {
+  const [t] = useTranslation("repos");
+  const binder = useBinder();
+
+  const creators: Creator[] = [
+    {
+      subtitle: t("create.subtitle"),
+      path: "",
+      icon: "plus",
+      label: t("repositoryForm.createButton"),
+      component: CreateRepository
+    },
+    {
+      subtitle: t("import.subtitle"),
+      path: "import",
+      icon: "file-upload",
+      label: t("repositoryForm.importButton"),
+      component: ImportRepository
+    }
+  ];
+
+  const extCreators: Creator[] = binder.getExtensions("repos.creator");
+  if (extCreators) {
+    creators.push(...extCreators);
+  }
+
+  return (
+    <Switch>
+      {creators.map(creator => (
+        <Route key={creator.path} exact path={urls.concat("/repos/create", creator.path)}>
+          <CreatorRoute creator={creator} creators={creators} />
+        </Route>
+      ))}
+    </Switch>
+  );
+};
+
+export default CreateRepositoryRoot;

--- a/scm-ui/ui-webapp/src/repos/containers/ImportRepository.tsx
+++ b/scm-ui/ui-webapp/src/repos/containers/ImportRepository.tsx
@@ -105,7 +105,7 @@ const ImportRepository: FC = () => {
     <Page
       title={t("create.title")}
       subtitle={t("import.subtitle")}
-      afterTitle={<RepositoryFormSwitcher creationMode={"IMPORT"} />}
+      afterTitle={<RepositoryFormSwitcher />}
       loading={isLoading}
       error={error || undefined}
       showContentOnError={true}

--- a/scm-ui/ui-webapp/src/repos/containers/ImportRepository.tsx
+++ b/scm-ui/ui-webapp/src/repos/containers/ImportRepository.tsx
@@ -29,13 +29,12 @@ import { useTranslation } from "react-i18next";
 import ImportRepositoryTypeSelect from "../components/ImportRepositoryTypeSelect";
 import ImportTypeSelect from "../components/ImportTypeSelect";
 import ImportRepositoryFromUrl from "../components/ImportRepositoryFromUrl";
-import { Loading, Notification, Page, useNavigationLock } from "@scm-manager/ui-components";
-import RepositoryFormSwitcher from "../components/form/RepositoryFormSwitcher";
+import { Loading, Notification, useNavigationLock } from "@scm-manager/ui-components";
 
 import ImportRepositoryFromBundle from "../components/ImportRepositoryFromBundle";
 import ImportFullRepository from "../components/ImportFullRepository";
-import { useRepositoryTypes } from "@scm-manager/ui-api";
 import { Prompt } from "react-router-dom";
+import { CreatorComponentProps } from "../types";
 
 const ImportPendingLoading = ({ importPending }: { importPending: boolean }) => {
   const [t] = useTranslation("repos");
@@ -51,8 +50,7 @@ const ImportPendingLoading = ({ importPending }: { importPending: boolean }) => 
   );
 };
 
-const ImportRepository: FC = () => {
-  const { data: repositoryTypes, error, isLoading } = useRepositoryTypes();
+const ImportRepository: FC<CreatorComponentProps> = ({ repositoryTypes, nameForm, informationForm }) => {
   const [importPending, setImportPending] = useState(false);
   const [repositoryType, setRepositoryType] = useState<RepositoryType | undefined>();
   const [importType, setImportType] = useState("");
@@ -72,6 +70,8 @@ const ImportRepository: FC = () => {
           url={((repositoryType!._links.import as Link[])!.find((link: Link) => link.name === "url") as Link).href}
           repositoryType={repositoryType!.name}
           setImportPending={setImportPending}
+          nameForm={nameForm}
+          informationForm={informationForm}
         />
       );
     }
@@ -82,6 +82,8 @@ const ImportRepository: FC = () => {
           url={((repositoryType!._links.import as Link[])!.find((link: Link) => link.name === "bundle") as Link).href}
           repositoryType={repositoryType!.name}
           setImportPending={setImportPending}
+          nameForm={nameForm}
+          informationForm={informationForm}
         />
       );
     }
@@ -94,6 +96,8 @@ const ImportRepository: FC = () => {
           }
           repositoryType={repositoryType!.name}
           setImportPending={setImportPending}
+          nameForm={nameForm}
+          informationForm={informationForm}
         />
       );
     }
@@ -102,14 +106,7 @@ const ImportRepository: FC = () => {
   };
 
   return (
-    <Page
-      title={t("create.title")}
-      subtitle={t("import.subtitle")}
-      afterTitle={<RepositoryFormSwitcher />}
-      loading={isLoading}
-      error={error || undefined}
-      showContentOnError={true}
-    >
+    <>
       <Prompt when={importPending} message={t("import.navigationWarning")} />
       <ImportPendingLoading importPending={importPending} />
       <ImportRepositoryTypeSelect
@@ -131,7 +128,7 @@ const ImportRepository: FC = () => {
         </>
       )}
       {importType && renderImportComponent()}
-    </Page>
+    </>
   );
 };
 

--- a/scm-ui/ui-webapp/src/repos/types/index.ts
+++ b/scm-ui/ui-webapp/src/repos/types/index.ts
@@ -21,32 +21,35 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import React, { FC } from "react";
-import { ErrorNotification } from "@scm-manager/ui-components";
-import RepositoryForm from "../components/form";
-import { Redirect } from "react-router-dom";
-import { useCreateRepository } from "@scm-manager/ui-api";
-import { CreatorComponentProps } from "../types";
 
-const CreateRepository: FC<CreatorComponentProps> = ({ repositoryTypes, namespaceStrategies, index }) => {
-  const { isLoading, error, repository, create } = useCreateRepository();
+import React from "react";
+import {
+  IndexResources,
+  NamespaceStrategies,
+  RepositoryCreation,
+  RepositoryTypeCollection
+} from "@scm-manager/ui-types";
 
-  if (repository) {
-    return <Redirect to={`/repo/${repository.namespace}/${repository.name}`} />;
-  }
-
-  return (
-    <>
-      <ErrorNotification error={error} />
-      <RepositoryForm
-        repositoryTypes={repositoryTypes._embedded.repositoryTypes}
-        loading={isLoading}
-        namespaceStrategy={namespaceStrategies.current}
-        createRepository={create}
-        indexResources={index}
-      />
-    </>
-  );
+export type SubFormProps = {
+  repository: RepositoryCreation;
+  onChange: (repository: RepositoryCreation) => void;
+  setValid: (valid: boolean) => void;
+  disabled?: boolean;
 };
 
-export default CreateRepository;
+export type CreatorComponentProps = {
+  namespaceStrategies: NamespaceStrategies;
+  repositoryTypes: RepositoryTypeCollection;
+  index: IndexResources;
+
+  nameForm: React.ComponentType<SubFormProps>;
+  informationForm: React.ComponentType<SubFormProps>;
+};
+
+export type Creator = {
+  subtitle: string;
+  path: string;
+  icon: string;
+  label: string;
+  component: React.ComponentType<CreatorComponentProps>;
+};

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/RepositoryTypeDto.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/RepositoryTypeDto.java
@@ -21,26 +21,28 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.api.v2.resources;
 
+import de.otto.edison.hal.Embedded;
 import de.otto.edison.hal.HalRepresentation;
 import de.otto.edison.hal.Links;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@NoArgsConstructor
 @Getter
 @Setter
+@NoArgsConstructor
+@SuppressWarnings("java:S2160") // we need no equals for dtos
 public class RepositoryTypeDto extends HalRepresentation {
 
   private String name;
   private String displayName;
 
-  @Override
-  @SuppressWarnings("squid:S1185") // We want to have this method available in this package
-  protected HalRepresentation add(Links links) {
-    return super.add(links);
+  public RepositoryTypeDto(Links links, Embedded embedded) {
+    super(links, embedded);
   }
 }
+
+


### PR DESCRIPTION
## Proposed changes

Adds an extension point for repository creator such as repository create, repository import or repository mirror.

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests
- [X] New ui components are tested inside the storybook (module ui-components only) 
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [X] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
