### PR TITLE
ReadOnlyCheck ExtensionPoint

### DIFF
--- a/scm-core/src/main/java/sonia/scm/repository/DefaultRepositoryExportingCheck.java
+++ b/scm-core/src/main/java/sonia/scm/repository/DefaultRepositoryExportingCheck.java
@@ -26,6 +26,7 @@ package sonia.scm.repository;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import sonia.scm.plugin.Extension;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -36,6 +37,7 @@ import java.util.function.Supplier;
 /**
  * Default implementation of {@link RepositoryExportingCheck}. This tracks the exporting status of repositories.
  */
+@Extension
 public final class DefaultRepositoryExportingCheck implements RepositoryExportingCheck {
 
   private static final Logger LOG = LoggerFactory.getLogger(DefaultRepositoryExportingCheck.class);

--- a/scm-core/src/main/java/sonia/scm/repository/EventDrivenRepositoryArchiveCheck.java
+++ b/scm-core/src/main/java/sonia/scm/repository/EventDrivenRepositoryArchiveCheck.java
@@ -25,6 +25,7 @@
 package sonia.scm.repository;
 
 import com.github.legman.Subscribe;
+import sonia.scm.plugin.Extension;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -35,6 +36,7 @@ import java.util.HashSet;
  * {@link RepositoryModificationEvent}s. The initial set of archived repositories is read by
  * {@link EventDrivenRepositoryArchiveCheckInitializer} on startup.
  */
+@Extension
 public final class EventDrivenRepositoryArchiveCheck implements RepositoryArchivedCheck {
 
   private static final Collection<String> ARCHIVED_REPOSITORIES = Collections.synchronizedSet(new HashSet<>());

--- a/scm-core/src/main/java/sonia/scm/repository/ReadOnlyCheckInitializer.java
+++ b/scm-core/src/main/java/sonia/scm/repository/ReadOnlyCheckInitializer.java
@@ -33,17 +33,17 @@ import javax.inject.Inject;
 import java.util.Set;
 
 /**
- * Initializes read only permissions for {@link RepositoryPermissionGuard} at startup.
+ * Initializes read only permissions and their checks at startup.
  */
 @Extension
 @EagerSingleton
-final class RepositoryPermissionGuardInitializer implements Initable {
+final class ReadOnlyCheckInitializer implements Initable {
 
   private final PermissionProvider permissionProvider;
   private final Set<ReadOnlyCheck> readOnlyChecks;
 
   @Inject
-  RepositoryPermissionGuardInitializer(PermissionProvider permissionProvider, Set<ReadOnlyCheck> readOnlyChecks) {
+  ReadOnlyCheckInitializer(PermissionProvider permissionProvider, Set<ReadOnlyCheck> readOnlyChecks) {
     this.permissionProvider = permissionProvider;
     this.readOnlyChecks = readOnlyChecks;
   }

--- a/scm-core/src/main/java/sonia/scm/repository/ReadOnlyException.java
+++ b/scm-core/src/main/java/sonia/scm/repository/ReadOnlyException.java
@@ -24,27 +24,25 @@
 
 package sonia.scm.repository;
 
-import static java.lang.String.format;
-import static sonia.scm.ContextEntry.ContextBuilder.entity;
+import sonia.scm.ContextEntry;
+import sonia.scm.ExceptionWithContext;
 
-@SuppressWarnings("java:S110") // large history is ok for exceptions
-public class RepositoryArchivedException extends ReadOnlyException {
+import java.util.List;
 
-  public static final String CODE = "3hSIlptme1";
+/**
+ * Read only exception is thrown if someone tries to execute a write command on a read only repository.
+ *
+ * @since 2.19.0
+ */
+public class ReadOnlyException extends ExceptionWithContext {
 
-  public RepositoryArchivedException(Repository repository) {
-    super(entity(repository).build(), format("Repository %s is marked as archived and must not be modified", repository));
-  }
-
-  public RepositoryArchivedException(String repositoryId) {
-    super(
-      entity(Repository.class, repositoryId).build(),
-      format("Repository with id %s is marked as archived and must not be modified", repositoryId)
-    );
+  public ReadOnlyException(List<ContextEntry> context, String message) {
+    super(context, message);
   }
 
   @Override
   public String getCode() {
-    return CODE;
+    return "BaSXkAztI1";
   }
+
 }

--- a/scm-core/src/main/java/sonia/scm/repository/RepositoryExportingCheck.java
+++ b/scm-core/src/main/java/sonia/scm/repository/RepositoryExportingCheck.java
@@ -31,7 +31,7 @@ import java.util.function.Supplier;
  *
  * @since 2.14.0
  */
-public interface RepositoryExportingCheck {
+public interface RepositoryExportingCheck extends ReadOnlyCheck {
 
   /**
    * Checks whether the repository with the given id is currently (that is, at this moment) being exported or not.
@@ -59,4 +59,21 @@ public interface RepositoryExportingCheck {
    * @return The result of the callback.
    */
   <T> T withExportingLock(Repository repository, Supplier<T> callback);
+
+  @Override
+  default boolean isReadOnly(String repositoryId) {
+    return isExporting(repositoryId);
+  }
+
+  @Override
+  default String getReason() {
+    return "repository is exporting";
+  }
+
+  @Override
+  default void check(String repositoryId) {
+    if (isExporting(repositoryId)) {
+      throw new RepositoryExportingException(repositoryId);
+    }
+  }
 }

--- a/scm-core/src/main/java/sonia/scm/repository/RepositoryExportingException.java
+++ b/scm-core/src/main/java/sonia/scm/repository/RepositoryExportingException.java
@@ -24,17 +24,23 @@
 
 package sonia.scm.repository;
 
-import sonia.scm.ExceptionWithContext;
-
 import static java.lang.String.format;
 import static sonia.scm.ContextEntry.ContextBuilder.entity;
 
-public class RepositoryExportingException extends ExceptionWithContext {
+@SuppressWarnings("java:S110") // large history is ok for exceptions
+public class RepositoryExportingException extends ReadOnlyException {
 
   public static final String CODE = "1mSNlpe1V1";
 
   public RepositoryExportingException(Repository repository) {
     super(entity(repository).build(), format("Repository %s is currently being exported and must not be modified", repository));
+  }
+
+  public RepositoryExportingException(String repositoryId) {
+    super(
+      entity(Repository.class, repositoryId).build(),
+      format("Repository with id %s is currently being exported and must not be modified", repositoryId)
+    );
   }
 
   @Override

--- a/scm-core/src/main/java/sonia/scm/repository/RepositoryPermissionGuard.java
+++ b/scm-core/src/main/java/sonia/scm/repository/RepositoryPermissionGuard.java
@@ -37,7 +37,7 @@ import java.util.function.BooleanSupplier;
 
 /**
  * This intercepts permission checks for repositories and blocks write permissions for archived repositories.
- * Read only permissions are set at startup by {@link RepositoryPermissionGuardInitializer}.
+ * Read only permissions are set at startup by {@link ReadOnlyCheckInitializer}.
  */
 public class RepositoryPermissionGuard implements PermissionGuard<Repository> {
 

--- a/scm-core/src/main/java/sonia/scm/repository/RepositoryPermissionGuard.java
+++ b/scm-core/src/main/java/sonia/scm/repository/RepositoryPermissionGuard.java
@@ -26,6 +26,7 @@ package sonia.scm.repository;
 
 import com.github.sdorra.ssp.PermissionActionCheckInterceptor;
 import com.github.sdorra.ssp.PermissionGuard;
+import com.google.common.collect.ImmutableSet;
 import org.apache.shiro.authz.AuthorizationException;
 import org.apache.shiro.subject.Subject;
 
@@ -34,9 +35,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.function.BooleanSupplier;
 
-import static sonia.scm.repository.DefaultRepositoryExportingCheck.isRepositoryExporting;
-import static sonia.scm.repository.EventDrivenRepositoryArchiveCheck.isRepositoryArchived;
-
 /**
  * This intercepts permission checks for repositories and blocks write permissions for archived repositories.
  * Read only permissions are set at startup by {@link RepositoryPermissionGuardInitializer}.
@@ -44,9 +42,19 @@ import static sonia.scm.repository.EventDrivenRepositoryArchiveCheck.isRepositor
 public class RepositoryPermissionGuard implements PermissionGuard<Repository> {
 
   private static final Collection<String> READ_ONLY_VERBS = Collections.synchronizedSet(new HashSet<>());
+  private static Collection<ReadOnlyCheck> readOnlyChecks = Collections.emptySet();
 
   static void setReadOnlyVerbs(Collection<String> readOnlyVerbs) {
     READ_ONLY_VERBS.addAll(readOnlyVerbs);
+  }
+
+  /**
+   * Sets static read only checks.
+   * @param readOnlyChecks read only checks
+   * @since 2.19.0
+   */
+  static void setReadOnlyChecks(Collection<ReadOnlyCheck> readOnlyChecks) {
+    RepositoryPermissionGuard.readOnlyChecks = ImmutableSet.copyOf(readOnlyChecks);
   }
 
   @Override
@@ -62,17 +70,20 @@ public class RepositoryPermissionGuard implements PermissionGuard<Repository> {
     @Override
     public void check(Subject subject, String id, Runnable delegate) {
       delegate.run();
-      if (isRepositoryArchived(id)) {
-        throw new AuthorizationException("repository is archived");
-      }
-      if (isRepositoryExporting(id)) {
-        throw new AuthorizationException("repository is exporting");
+      for (ReadOnlyCheck check : readOnlyChecks) {
+        if (check.isReadOnly(id)) {
+          throw new AuthorizationException(check.getReason());
+        }
       }
     }
 
     @Override
     public boolean isPermitted(Subject subject, String id, BooleanSupplier delegate) {
-      return !isRepositoryArchived(id) && !isRepositoryExporting(id) && delegate.getAsBoolean();
+      return isWritable(id) && delegate.getAsBoolean();
+    }
+
+    private boolean isWritable(String id) {
+      return readOnlyChecks.stream().noneMatch(c -> c.isReadOnly(id));
     }
   }
 }

--- a/scm-core/src/main/java/sonia/scm/repository/RepositoryPermissionGuardInitializer.java
+++ b/scm-core/src/main/java/sonia/scm/repository/RepositoryPermissionGuardInitializer.java
@@ -30,6 +30,7 @@ import sonia.scm.SCMContextProvider;
 import sonia.scm.plugin.Extension;
 
 import javax.inject.Inject;
+import java.util.Set;
 
 /**
  * Initializes read only permissions for {@link RepositoryPermissionGuard} at startup.
@@ -39,14 +40,18 @@ import javax.inject.Inject;
 final class RepositoryPermissionGuardInitializer implements Initable {
 
   private final PermissionProvider permissionProvider;
+  private final Set<ReadOnlyCheck> readOnlyChecks;
 
   @Inject
-  RepositoryPermissionGuardInitializer(PermissionProvider permissionProvider) {
+  RepositoryPermissionGuardInitializer(PermissionProvider permissionProvider, Set<ReadOnlyCheck> readOnlyChecks) {
     this.permissionProvider = permissionProvider;
+    this.readOnlyChecks = readOnlyChecks;
   }
 
   @Override
   public void init(SCMContextProvider context) {
     RepositoryPermissionGuard.setReadOnlyVerbs(permissionProvider.readOnlyVerbs());
+    RepositoryPermissionGuard.setReadOnlyChecks(readOnlyChecks);
+    RepositoryReadOnlyChecker.setReadOnlyChecks(readOnlyChecks);
   }
 }

--- a/scm-core/src/test/java/sonia/scm/repository/DefaultRepositoryExportingCheckTest.java
+++ b/scm-core/src/test/java/sonia/scm/repository/DefaultRepositoryExportingCheckTest.java
@@ -26,7 +26,10 @@ package sonia.scm.repository;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.function.Supplier;
+
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class DefaultRepositoryExportingCheckTest {
 
@@ -61,5 +64,33 @@ class DefaultRepositoryExportingCheckTest {
   void shouldNotBeReadOnlyIfNotBeingExported() {
     boolean readOnly = check.isExporting(EXPORTING_REPOSITORY);
     assertThat(readOnly).isFalse();
+  }
+
+  @Test
+  void shouldThrowExportingException() {
+    RepositoryExportingCheck check = new TestingRepositoryExportingCheck();
+
+    assertThrows(RepositoryExportingException.class, () -> check.check(EXPORTING_REPOSITORY));
+  }
+
+  @Test
+  void shouldThrowExportingExceptionWithId() {
+    RepositoryExportingCheck check = new TestingRepositoryExportingCheck();
+
+    assertThrows(RepositoryExportingException.class, () -> check.check("exporting_hog"));
+  }
+
+  private static class TestingRepositoryExportingCheck implements RepositoryExportingCheck {
+
+
+    @Override
+    public boolean isExporting(String repositoryId) {
+      return "exporting_hog".equals(repositoryId);
+    }
+
+    @Override
+    public <T> T withExportingLock(Repository repository, Supplier<T> callback) {
+      return null;
+    }
   }
 }

--- a/scm-core/src/test/java/sonia/scm/repository/ReadOnlyCheckTest.java
+++ b/scm-core/src/test/java/sonia/scm/repository/ReadOnlyCheckTest.java
@@ -1,0 +1,71 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.repository;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ReadOnlyCheckTest {
+
+  private final ReadOnlyCheck check = new TesingReadOnlyCheck();
+
+  private final Repository repository = new Repository("42", "git", "hitchhiker", "hog");
+
+  @Test
+  void shouldDelegateToMethodWithRepositoryId() {
+    assertThat(check.isReadOnly(repository)).isTrue();
+  }
+
+  @Test
+  void shouldThrowReadOnlyException() {
+    assertThrows(ReadOnlyException.class, () -> check.check(repository));
+  }
+
+  @Test
+  void shouldThrowReadOnlyExceptionForId() {
+    assertThrows(ReadOnlyException.class, () -> check.check("42"));
+  }
+
+  @Test
+  void shouldNotThrowException() {
+    assertDoesNotThrow(() -> check.check("21"));
+  }
+
+  private class TesingReadOnlyCheck implements ReadOnlyCheck {
+
+    @Override
+    public String getReason() {
+      return "Testing";
+    }
+
+    @Override
+    public boolean isReadOnly(String repositoryId) {
+      return repositoryId.equals("42");
+    }
+  }
+
+}

--- a/scm-core/src/test/java/sonia/scm/repository/RepositoryArchivedCheckTest.java
+++ b/scm-core/src/test/java/sonia/scm/repository/RepositoryArchivedCheckTest.java
@@ -1,0 +1,62 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.repository;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RepositoryArchivedCheckTest {
+
+  private final RepositoryArchivedCheck check = new TestingRepositoryArchivedCheck();
+
+  private final Repository repository = new Repository("42", "git", "hitchhiker", "hog");
+
+  @Test
+  void shouldThrowForRepositoryMarkedAsArchived() {
+    assertThrows(RepositoryArchivedException.class, () -> check.check(repository));
+  }
+
+  @Test
+  void shouldThrowForRepositoryMarkedAsArchivedWithId() {
+    assertThrows(RepositoryArchivedException.class, () -> check.check("42"));
+  }
+
+  @Test
+  void shouldThrowForArchivedRepository() {
+    Repository repository = new Repository("21", "hg", "hitchhiker", "puzzle42");
+    repository.setArchived(true);
+    assertThrows(RepositoryArchivedException.class, () -> check.check(repository));
+  }
+
+  private static class TestingRepositoryArchivedCheck implements RepositoryArchivedCheck {
+    @Override
+    public boolean isArchived(String repositoryId) {
+      return "42".equals(repositoryId);
+    }
+  }
+
+}

--- a/scm-core/src/test/java/sonia/scm/repository/RepositoryReadOnlyCheckerHack.java
+++ b/scm-core/src/test/java/sonia/scm/repository/RepositoryReadOnlyCheckerHack.java
@@ -24,27 +24,23 @@
 
 package sonia.scm.repository;
 
-import static java.lang.String.format;
-import static sonia.scm.ContextEntry.ContextBuilder.entity;
+import java.util.Collection;
 
-@SuppressWarnings("java:S110") // large history is ok for exceptions
-public class RepositoryArchivedException extends ReadOnlyException {
+/**
+ * This class exists to bypass the visibility of the {@link RepositoryReadOnlyChecker} methods.
+ * This is necessary to use those methods from test which are located in other packages.
+ */
+public class RepositoryReadOnlyCheckerHack {
 
-  public static final String CODE = "3hSIlptme1";
-
-  public RepositoryArchivedException(Repository repository) {
-    super(entity(repository).build(), format("Repository %s is marked as archived and must not be modified", repository));
+  private RepositoryReadOnlyCheckerHack() {
   }
 
-  public RepositoryArchivedException(String repositoryId) {
-    super(
-      entity(Repository.class, repositoryId).build(),
-      format("Repository with id %s is marked as archived and must not be modified", repositoryId)
-    );
-  }
-
-  @Override
-  public String getCode() {
-    return CODE;
+  /**
+   * Bypass the visibility of the {@link RepositoryReadOnlyChecker#setReadOnlyChecks(Collection)} method.
+   *
+   * @param readOnlyChecks checks to register
+   */
+  public static void setReadOnlyChecks(Collection<ReadOnlyCheck> readOnlyChecks) {
+    RepositoryReadOnlyChecker.setReadOnlyChecks(readOnlyChecks);
   }
 }

--- a/scm-ui/ui-webapp/src/repos/components/form/RepositoryFormSwitcher.tsx
+++ b/scm-ui/ui-webapp/src/repos/components/form/RepositoryFormSwitcher.tsx
@@ -26,6 +26,7 @@ import React, { FC } from "react";
 import styled from "styled-components";
 import { Button, ButtonAddons, Icon, Level, urls } from "@scm-manager/ui-components";
 import { useLocation } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 
 const MarginIcon = styled(Icon)`
   padding-right: 0.5rem;
@@ -58,11 +59,12 @@ const RepositoryFormButton: FC<RepositoryForm> = ({ path, icon, label }) => {
   const location = useLocation();
   const href = urls.concat("/repos/create", path);
   const isSelected = href === location.pathname;
+  const [t] = useTranslation(["repos", "plugins"]);
 
   return (
     <SmallButton color={isSelected ? "link is-selected" : undefined} link={!isSelected ? href : undefined}>
       <MarginIcon name={icon} color={isSelected ? "white" : "default"} />
-      <p className="is-hidden-mobile is-hidden-tablet-only">{label}</p>
+      <p className="is-hidden-mobile is-hidden-tablet-only">{t(`plugins:${label}`, label)}</p>
     </SmallButton>
   );
 };
@@ -75,7 +77,7 @@ const RepositoryFormSwitcher: FC<Props> = ({ forms }) => (
   <TopLevel
     right={
       <ButtonAddons>
-        {(forms || []).map(form => (
+        {(forms || []).map((form) => (
           <RepositoryFormButton key={form.path} {...form} />
         ))}
       </ButtonAddons>

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/RepositoryExportResource.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/RepositoryExportResource.java
@@ -39,7 +39,6 @@ import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import sonia.scm.BadRequestException;
 import sonia.scm.ConcurrentModificationException;
 import sonia.scm.NotFoundException;
-import sonia.scm.Type;
 import sonia.scm.importexport.ExportFileExtensionResolver;
 import sonia.scm.importexport.ExportNotificationHandler;
 import sonia.scm.importexport.ExportService;
@@ -50,6 +49,7 @@ import sonia.scm.repository.NamespaceAndName;
 import sonia.scm.repository.Repository;
 import sonia.scm.repository.RepositoryManager;
 import sonia.scm.repository.RepositoryPermissions;
+import sonia.scm.repository.RepositoryType;
 import sonia.scm.repository.api.BundleCommandBuilder;
 import sonia.scm.repository.api.Command;
 import sonia.scm.repository.api.ExportFailedException;
@@ -442,7 +442,7 @@ public class RepositoryExportResource {
     if (!type.equals(repository.getType())) {
       throw new WrongTypeException(repository);
     }
-    Type repositoryType = type(manager, type);
+    RepositoryType repositoryType = type(manager, type);
     checkSupport(repositoryType, Command.BUNDLE);
     return repository;
   }

--- a/scm-webapp/src/main/java/sonia/scm/importexport/FromBundleImporter.java
+++ b/scm-webapp/src/main/java/sonia/scm/importexport/FromBundleImporter.java
@@ -28,7 +28,6 @@ import com.google.common.io.Files;
 import org.apache.shiro.SecurityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sonia.scm.Type;
 import sonia.scm.event.ScmEventBus;
 import sonia.scm.repository.ImportRepositoryHookEvent;
 import sonia.scm.repository.InternalRepositoryException;
@@ -38,6 +37,7 @@ import sonia.scm.repository.RepositoryImportEvent;
 import sonia.scm.repository.RepositoryManager;
 import sonia.scm.repository.RepositoryPermission;
 import sonia.scm.repository.RepositoryPermissions;
+import sonia.scm.repository.RepositoryType;
 import sonia.scm.repository.api.Command;
 import sonia.scm.repository.api.RepositoryService;
 import sonia.scm.repository.api.RepositoryServiceFactory;
@@ -78,7 +78,7 @@ public class FromBundleImporter {
   public Repository importFromBundle(boolean compressed, InputStream inputStream, Repository repository) {
     RepositoryPermissions.create().check();
 
-    Type t = type(manager, repository.getType());
+    RepositoryType t = type(manager, repository.getType());
     checkSupport(t, Command.UNBUNDLE);
 
     repository.setPermissions(singletonList(

--- a/scm-webapp/src/main/java/sonia/scm/importexport/FromUrlImporter.java
+++ b/scm-webapp/src/main/java/sonia/scm/importexport/FromUrlImporter.java
@@ -31,7 +31,6 @@ import org.apache.shiro.SecurityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sonia.scm.AlreadyExistsException;
-import sonia.scm.Type;
 import sonia.scm.event.ScmEventBus;
 import sonia.scm.repository.InternalRepositoryException;
 import sonia.scm.repository.Repository;
@@ -39,6 +38,7 @@ import sonia.scm.repository.RepositoryImportEvent;
 import sonia.scm.repository.RepositoryManager;
 import sonia.scm.repository.RepositoryPermission;
 import sonia.scm.repository.RepositoryPermissions;
+import sonia.scm.repository.RepositoryType;
 import sonia.scm.repository.api.Command;
 import sonia.scm.repository.api.ImportFailedException;
 import sonia.scm.repository.api.PullCommandBuilder;
@@ -73,7 +73,7 @@ public class FromUrlImporter {
   }
 
   public Repository importFromUrl(RepositoryImportParameters parameters, Repository repository) {
-    Type t = type(manager, repository.getType());
+    RepositoryType t = type(manager, repository.getType());
     RepositoryPermissions.create().check();
     checkSupport(t, Command.PULL);
 

--- a/scm-webapp/src/main/java/sonia/scm/importexport/RepositoryTypeSupportChecker.java
+++ b/scm-webapp/src/main/java/sonia/scm/importexport/RepositoryTypeSupportChecker.java
@@ -27,14 +27,11 @@ package sonia.scm.importexport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sonia.scm.BadRequestException;
-import sonia.scm.Type;
 import sonia.scm.repository.RepositoryHandler;
 import sonia.scm.repository.RepositoryManager;
 import sonia.scm.repository.RepositoryType;
 import sonia.scm.repository.api.Command;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
 import java.util.Set;
 
 import static sonia.scm.ContextEntry.ContextBuilder.noContext;
@@ -44,7 +41,7 @@ public class RepositoryTypeSupportChecker {
   private RepositoryTypeSupportChecker() {
   }
 
-  private static final Logger logger = LoggerFactory.getLogger(RepositoryTypeSupportChecker.class);
+  private static final Logger LOG = LoggerFactory.getLogger(RepositoryTypeSupportChecker.class);
 
   /**
    * Check repository type for support for the given command.
@@ -52,31 +49,28 @@ public class RepositoryTypeSupportChecker {
    * @param type repository type
    * @param cmd  command
    */
-  public static void checkSupport(Type type, Command cmd) {
-    if (!(type instanceof RepositoryType)) {
-      logger.warn("type {} is not a repository type", type.getName());
-      throw new WebApplicationException(Response.Status.BAD_REQUEST);
-    }
-
-    Set<Command> cmds = ((RepositoryType) type).getSupportedCommands();
+  public static void checkSupport(RepositoryType type, Command cmd) {
+    Set<Command> cmds = type.getSupportedCommands();
     if (!cmds.contains(cmd)) {
-      logger.warn("type {} does not support this command {}",
+      LOG.debug("type {} does not support this command {}",
         type.getName(),
-        cmd.name());
+        cmd);
       throw new IllegalTypeForImportException("type does not support command");
     }
   }
 
-  @SuppressWarnings("javasecurity:S5145") // the type parameter is validated in the resource to only contain valid characters (\w)
-  public static Type type(RepositoryManager manager, String type) {
+  @SuppressWarnings("javasecurity:S5145")
+  // the type parameter is validated in the resource to only contain valid characters (\w)
+  public static RepositoryType type(RepositoryManager manager, String type) {
     RepositoryHandler handler = manager.getHandler(type);
     if (handler == null) {
-      logger.warn("no handler for type {} found", type);
+      LOG.debug("no handler for type {} found", type);
       throw new IllegalTypeForImportException("unsupported repository type: " + type);
     }
     return handler.getType();
   }
 
+  @SuppressWarnings("java:S110") // this is fine for exceptions
   private static class IllegalTypeForImportException extends BadRequestException {
     public IllegalTypeForImportException(String message) {
       super(noContext(), message);


### PR DESCRIPTION
## Proposed changes

The ReadOnlyCheck extension point can be used by plugins to protect a repository from write access.

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
