### PR TITLE
Repository flag extension point

### DIFF
--- a/scm-ui/ui-components/src/Tag.stories.tsx
+++ b/scm-ui/ui-components/src/Tag.stories.tsx
@@ -24,10 +24,10 @@
 
 import styled from "styled-components";
 import { storiesOf } from "@storybook/react";
-import * as React from "react";
+import React, { ReactNode } from "react";
 import Tag from "./Tag";
-import { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
+import { colors, sizes } from "./styleConstants";
 
 const Wrapper = styled.div`
   margin: 2rem;
@@ -38,23 +38,30 @@ const Spacing = styled.div`
   padding: 1em;
 `;
 
-const colors = ["primary", "link", "info", "success", "warning", "danger"];
-
 const RoutingDecorator = (story: () => ReactNode) => <MemoryRouter initialEntries={["/"]}>{story()}</MemoryRouter>;
 
 storiesOf("Tag", module)
   .addDecorator(RoutingDecorator)
-  .addDecorator(storyFn => <Wrapper>{storyFn()}</Wrapper>)
+  .addDecorator((storyFn) => <Wrapper>{storyFn()}</Wrapper>)
   .add("Default", () => <Tag label="Default tag" />)
   .add("With Icon", () => <Tag label="System" icon="bolt" />)
   .add("Colors", () => (
     <div>
-      {colors.map(color => (
-        <Spacing>
+      {colors.map((color) => (
+        <Spacing key={color}>
           <Tag color={color} label={color} />
         </Spacing>
       ))}
     </div>
   ))
-  .add("With title", () => <Tag label="hover me" title="good job"/>)
-  .add("Clickable", () => <Tag label="Click here" onClick={() => alert("Not so fast")}/>);
+  .add("With title", () => <Tag label="hover me" title="good job" />)
+  .add("Clickable", () => <Tag label="Click here" onClick={() => alert("Not so fast")} />)
+  .add("Sizes", () => (
+    <div>
+      {sizes.map((size) => (
+        <Spacing key={size}>
+          <Tag size={size} label={size} />
+        </Spacing>
+      ))}
+    </div>
+  ));

--- a/scm-ui/ui-components/src/Tag.stories.tsx
+++ b/scm-ui/ui-components/src/Tag.stories.tsx
@@ -27,7 +27,7 @@ import { storiesOf } from "@storybook/react";
 import React, { ReactNode } from "react";
 import Tag from "./Tag";
 import { MemoryRouter } from "react-router-dom";
-import { colors, sizes } from "./styleConstants";
+import { Color, colors, sizes } from "./styleConstants";
 
 const Wrapper = styled.div`
   margin: 2rem;
@@ -35,7 +35,7 @@ const Wrapper = styled.div`
 `;
 
 const Spacing = styled.div`
-  padding: 1em;
+  padding: 0.5rem;
 `;
 
 const RoutingDecorator = (story: () => ReactNode) => <MemoryRouter initialEntries={["/"]}>{story()}</MemoryRouter>;
@@ -44,12 +44,22 @@ storiesOf("Tag", module)
   .addDecorator(RoutingDecorator)
   .addDecorator((storyFn) => <Wrapper>{storyFn()}</Wrapper>)
   .add("Default", () => <Tag label="Default tag" />)
+  .add("Rounded", () => <Tag label="Rounded tag" color="dark" rounded={true} />)
   .add("With Icon", () => <Tag label="System" icon="bolt" />)
   .add("Colors", () => (
     <div>
       {colors.map((color) => (
         <Spacing key={color}>
           <Tag color={color} label={color} />
+        </Spacing>
+      ))}
+    </div>
+  ))
+  .add("Outlined", () => (
+    <div>
+      {(["success", "black", "danger"] as Color[]).map((color) => (
+        <Spacing key={color}>
+          <Tag color={color} label={color} outlined={true} />
         </Spacing>
       ))}
     </div>

--- a/scm-ui/ui-components/src/Tag.tsx
+++ b/scm-ui/ui-components/src/Tag.tsx
@@ -21,50 +21,76 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from "react";
+import React, { FC, HTMLAttributes } from "react";
 import classNames from "classnames";
+import { Color, Size } from "./styleConstants";
+import styled, { css } from "styled-components";
 
 type Props = {
   className?: string;
-  color: string;
+  color?: Color;
   icon?: string;
-  label: string;
+  label?: string;
   title?: string;
+  size?: Size;
   onClick?: () => void;
   onRemove?: () => void;
 };
 
-class Tag extends React.Component<Props> {
-  static defaultProps = {
-    color: "light"
-  };
+type InnerTagProps = HTMLAttributes<HTMLSpanElement> & {
+  small: boolean;
+};
 
-  render() {
-    const { className, color, icon, label, title, onClick, onRemove } = this.props;
-    let showIcon = null;
-    if (icon) {
-      showIcon = (
-        <>
-          <i className={classNames("fas", `fa-${icon}`)} />
-          &nbsp;
-        </>
-      );
-    }
-    let showDelete = null;
-    if (onRemove) {
-      showDelete = <a className="tag is-delete" onClick={onRemove} />;
-    }
+const smallMixin = css`
+  font-size: 0.7rem !important;
+  padding: 0.25rem !important;
+  font-weight: bold;
+`;
 
-    return (
+const InnerTag = styled.span<InnerTagProps>`
+  ${(props) => props.small && smallMixin};
+`;
+
+const Tag: FC<Props> = ({
+  className,
+  color = "light",
+  size = "normal",
+  icon,
+  label,
+  title,
+  onClick,
+  onRemove,
+  children,
+}) => {
+  let showIcon = null;
+  if (icon) {
+    showIcon = (
       <>
-        <span className={classNames("tag", `is-${color}`, className)} title={title} onClick={onClick}>
-          {showIcon}
-          {label}
-        </span>
-        {showDelete}
+        <i className={classNames("fas", `fa-${icon}`)} />
+        &nbsp;
       </>
     );
   }
-}
+  let showDelete = null;
+  if (onRemove) {
+    showDelete = <a className="tag is-delete" onClick={onRemove} />;
+  }
+
+  return (
+    <>
+      <InnerTag
+        className={classNames("tag", `is-${color}`, `is-${size}`, className)}
+        title={title}
+        onClick={onClick}
+        small={size === "small"}
+      >
+        {showIcon}
+        {label}
+        {children}
+      </InnerTag>
+      {showDelete}
+    </>
+  );
+};
 
 export default Tag;

--- a/scm-ui/ui-components/src/Tag.tsx
+++ b/scm-ui/ui-components/src/Tag.tsx
@@ -29,6 +29,8 @@ import styled, { css } from "styled-components";
 type Props = {
   className?: string;
   color?: Color;
+  outlined?: boolean;
+  rounded?: boolean;
   icon?: string;
   label?: string;
   title?: string;
@@ -54,7 +56,9 @@ const InnerTag = styled.span<InnerTagProps>`
 const Tag: FC<Props> = ({
   className,
   color = "light",
+  outlined,
   size = "normal",
+  rounded,
   icon,
   label,
   title,
@@ -79,7 +83,10 @@ const Tag: FC<Props> = ({
   return (
     <>
       <InnerTag
-        className={classNames("tag", `is-${color}`, `is-${size}`, className)}
+        className={classNames("tag", `is-${color}`, `is-${size}`, className, {
+          "is-outlined": outlined,
+          "is-rounded": rounded,
+        })}
         title={title}
         onClick={onClick}
         small={size === "small"}

--- a/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
+++ b/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
@@ -4821,7 +4821,7 @@ exports[`Storyshots Diff Binaries 1`] = `
               Main.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -5040,7 +5040,7 @@ exports[`Storyshots Diff Binaries 1`] = `
               conflict.png
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               add
             </span>
@@ -5106,7 +5106,7 @@ exports[`Storyshots Diff Collapsed 1`] = `
               src/main/java/com/cloudogu/scm/review/events/EventListener.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -5219,7 +5219,7 @@ exports[`Storyshots Diff Collapsed 1`] = `
               src/main/js/ChangeNotification.tsx
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -5332,7 +5332,7 @@ exports[`Storyshots Diff Collapsed 1`] = `
               src/main/resources/locales/de/plugins.json
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -5445,7 +5445,7 @@ exports[`Storyshots Diff Collapsed 1`] = `
               src/main/resources/locales/en/plugins.json
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -5558,7 +5558,7 @@ exports[`Storyshots Diff Collapsed 1`] = `
               src/test/java/com/cloudogu/scm/review/events/ClientTest.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -5671,7 +5671,7 @@ exports[`Storyshots Diff Collapsed 1`] = `
               Main.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -5793,7 +5793,7 @@ exports[`Storyshots Diff CollapsingWithFunction 1`] = `
               src/main/java/com/cloudogu/scm/review/events/EventListener.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -5868,7 +5868,7 @@ exports[`Storyshots Diff CollapsingWithFunction 1`] = `
               src/main/js/ChangeNotification.tsx
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -6726,7 +6726,7 @@ exports[`Storyshots Diff CollapsingWithFunction 1`] = `
               src/main/resources/locales/de/plugins.json
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -7180,7 +7180,7 @@ exports[`Storyshots Diff CollapsingWithFunction 1`] = `
               src/main/resources/locales/en/plugins.json
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -7634,7 +7634,7 @@ exports[`Storyshots Diff CollapsingWithFunction 1`] = `
               src/test/java/com/cloudogu/scm/review/events/ClientTest.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -7709,7 +7709,7 @@ exports[`Storyshots Diff CollapsingWithFunction 1`] = `
               Main.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -7793,7 +7793,7 @@ exports[`Storyshots Diff Default 1`] = `
               src/main/java/com/cloudogu/scm/review/events/EventListener.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -8374,7 +8374,7 @@ exports[`Storyshots Diff Default 1`] = `
               src/main/js/ChangeNotification.tsx
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -9232,7 +9232,7 @@ exports[`Storyshots Diff Default 1`] = `
               src/main/resources/locales/de/plugins.json
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -9686,7 +9686,7 @@ exports[`Storyshots Diff Default 1`] = `
               src/main/resources/locales/en/plugins.json
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -10140,7 +10140,7 @@ exports[`Storyshots Diff Default 1`] = `
               src/test/java/com/cloudogu/scm/review/events/ClientTest.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -11201,7 +11201,7 @@ exports[`Storyshots Diff Default 1`] = `
               Main.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -11739,7 +11739,7 @@ exports[`Storyshots Diff Expandable 1`] = `
               src/main/java/com/cloudogu/scm/review/events/EventListener.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -12357,7 +12357,7 @@ exports[`Storyshots Diff Expandable 1`] = `
               src/main/js/ChangeNotification.tsx
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -13312,7 +13312,7 @@ exports[`Storyshots Diff Expandable 1`] = `
               src/main/resources/locales/de/plugins.json
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -13838,7 +13838,7 @@ exports[`Storyshots Diff Expandable 1`] = `
               src/main/resources/locales/en/plugins.json
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -14364,7 +14364,7 @@ exports[`Storyshots Diff Expandable 1`] = `
               src/test/java/com/cloudogu/scm/review/events/ClientTest.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -15580,7 +15580,7 @@ exports[`Storyshots Diff Expandable 1`] = `
               Main.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -16155,7 +16155,7 @@ exports[`Storyshots Diff File Annotation 1`] = `
               src/main/java/com/cloudogu/scm/review/events/EventListener.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -16740,7 +16740,7 @@ exports[`Storyshots Diff File Annotation 1`] = `
               src/main/js/ChangeNotification.tsx
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -17602,7 +17602,7 @@ exports[`Storyshots Diff File Annotation 1`] = `
               src/main/resources/locales/de/plugins.json
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -18060,7 +18060,7 @@ exports[`Storyshots Diff File Annotation 1`] = `
               src/main/resources/locales/en/plugins.json
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -18518,7 +18518,7 @@ exports[`Storyshots Diff File Annotation 1`] = `
               src/test/java/com/cloudogu/scm/review/events/ClientTest.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -19583,7 +19583,7 @@ exports[`Storyshots Diff File Annotation 1`] = `
               Main.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -20125,7 +20125,7 @@ exports[`Storyshots Diff File Controls 1`] = `
               src/main/java/com/cloudogu/scm/review/events/EventListener.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -20724,7 +20724,7 @@ exports[`Storyshots Diff File Controls 1`] = `
               src/main/js/ChangeNotification.tsx
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -21600,7 +21600,7 @@ exports[`Storyshots Diff File Controls 1`] = `
               src/main/resources/locales/de/plugins.json
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -22072,7 +22072,7 @@ exports[`Storyshots Diff File Controls 1`] = `
               src/main/resources/locales/en/plugins.json
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -22544,7 +22544,7 @@ exports[`Storyshots Diff File Controls 1`] = `
               src/test/java/com/cloudogu/scm/review/events/ClientTest.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -23623,7 +23623,7 @@ exports[`Storyshots Diff File Controls 1`] = `
               Main.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -24179,7 +24179,7 @@ exports[`Storyshots Diff Hunks 1`] = `
               src/main/java/com/cloudogu/scm/review/pullrequest/service/DefaultPullRequestService.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -25024,7 +25024,7 @@ exports[`Storyshots Diff Line Annotation 1`] = `
               src/main/java/com/cloudogu/scm/review/events/EventListener.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -25617,7 +25617,7 @@ exports[`Storyshots Diff Line Annotation 1`] = `
               src/main/js/ChangeNotification.tsx
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -26487,7 +26487,7 @@ exports[`Storyshots Diff Line Annotation 1`] = `
               src/main/resources/locales/de/plugins.json
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -26941,7 +26941,7 @@ exports[`Storyshots Diff Line Annotation 1`] = `
               src/main/resources/locales/en/plugins.json
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -27395,7 +27395,7 @@ exports[`Storyshots Diff Line Annotation 1`] = `
               src/test/java/com/cloudogu/scm/review/events/ClientTest.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -28456,7 +28456,7 @@ exports[`Storyshots Diff Line Annotation 1`] = `
               Main.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -29006,7 +29006,7 @@ exports[`Storyshots Diff OnClick 1`] = `
               src/main/java/com/cloudogu/scm/review/events/EventListener.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -29627,7 +29627,7 @@ exports[`Storyshots Diff OnClick 1`] = `
               src/main/js/ChangeNotification.tsx
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -30547,7 +30547,7 @@ exports[`Storyshots Diff OnClick 1`] = `
               src/main/resources/locales/de/plugins.json
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -31031,7 +31031,7 @@ exports[`Storyshots Diff OnClick 1`] = `
               src/main/resources/locales/en/plugins.json
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -31515,7 +31515,7 @@ exports[`Storyshots Diff OnClick 1`] = `
               src/test/java/com/cloudogu/scm/review/events/ClientTest.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -32652,7 +32652,7 @@ exports[`Storyshots Diff OnClick 1`] = `
               Main.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -33226,7 +33226,7 @@ exports[`Storyshots Diff Side-By-Side 1`] = `
               src/main/java/com/cloudogu/scm/review/events/EventListener.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -33900,7 +33900,7 @@ exports[`Storyshots Diff Side-By-Side 1`] = `
               src/main/js/ChangeNotification.tsx
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -34848,7 +34848,7 @@ exports[`Storyshots Diff Side-By-Side 1`] = `
               src/main/resources/locales/de/plugins.json
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -35354,7 +35354,7 @@ exports[`Storyshots Diff Side-By-Side 1`] = `
               src/main/resources/locales/en/plugins.json
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -35860,7 +35860,7 @@ exports[`Storyshots Diff Side-By-Side 1`] = `
               src/test/java/com/cloudogu/scm/review/events/ClientTest.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -37090,7 +37090,7 @@ exports[`Storyshots Diff Side-By-Side 1`] = `
               Main.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -37701,7 +37701,7 @@ exports[`Storyshots Diff SyntaxHighlighting (Markdown) 1`] = `
               CHANGELOG.md
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -38064,7 +38064,7 @@ exports[`Storyshots Diff SyntaxHighlighting 1`] = `
               src/main/java/com/cloudogu/scm/review/events/EventListener.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -38645,7 +38645,7 @@ exports[`Storyshots Diff SyntaxHighlighting 1`] = `
               src/main/js/ChangeNotification.tsx
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -39503,7 +39503,7 @@ exports[`Storyshots Diff SyntaxHighlighting 1`] = `
               src/main/resources/locales/de/plugins.json
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -39957,7 +39957,7 @@ exports[`Storyshots Diff SyntaxHighlighting 1`] = `
               src/main/resources/locales/en/plugins.json
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -40411,7 +40411,7 @@ exports[`Storyshots Diff SyntaxHighlighting 1`] = `
               src/test/java/com/cloudogu/scm/review/events/ClientTest.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -41472,7 +41472,7 @@ exports[`Storyshots Diff SyntaxHighlighting 1`] = `
               Main.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -42010,7 +42010,7 @@ exports[`Storyshots Diff WithLinkToFile 1`] = `
               src/main/java/com/cloudogu/scm/review/events/EventListener.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -42628,7 +42628,7 @@ exports[`Storyshots Diff WithLinkToFile 1`] = `
               src/main/js/ChangeNotification.tsx
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -43583,7 +43583,7 @@ exports[`Storyshots Diff WithLinkToFile 1`] = `
               src/main/resources/locales/de/plugins.json
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -44109,7 +44109,7 @@ exports[`Storyshots Diff WithLinkToFile 1`] = `
               src/main/resources/locales/en/plugins.json
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -44635,7 +44635,7 @@ exports[`Storyshots Diff WithLinkToFile 1`] = `
               src/test/java/com/cloudogu/scm/review/events/ClientTest.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -45851,7 +45851,7 @@ exports[`Storyshots Diff WithLinkToFile 1`] = `
               Main.java
             </span>
             <span
-              className="tag is-info is-outlined DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR is-rounded has-text-weight-normal"
+              className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal DiffFile__ChangeTypeTag-sc-10deuqx-5 cXFjDR has-text-weight-normal is-outlined is-rounded"
             >
               modify
             </span>
@@ -63189,15 +63189,19 @@ exports[`Storyshots RepositoryEntry Archived 1`] = `
           <p
             className="shorten-text is-marginless"
           >
-            <strong>
-              heartOfGold
-            </strong>
-             
             <span
-              className="RepositoryEntry__RepositoryTag-sc-6jys82-0 jSnwjx"
-              title="archive.tooltip"
+              className="RepositoryEntry__Title-sc-6jys82-0 eaqclL"
             >
-              repository.archived
+              <strong>
+                heartOfGold
+              </strong>
+               
+              <span
+                className="Tag__InnerTag-ql67az-0 kOFYBe tag is-light is-small"
+                title="archive.tooltip"
+              >
+                repository.archived
+              </span>
             </span>
           </p>
           <p
@@ -63340,10 +63344,14 @@ exports[`Storyshots RepositoryEntry Avatar EP 1`] = `
           <p
             className="shorten-text is-marginless"
           >
-            <strong>
-              heartOfGold
-            </strong>
-             
+            <span
+              className="RepositoryEntry__Title-sc-6jys82-0 eaqclL"
+            >
+              <strong>
+                heartOfGold
+              </strong>
+               
+            </span>
           </p>
           <p
             className="shorten-text"
@@ -63485,13 +63493,17 @@ exports[`Storyshots RepositoryEntry Before Title EP 1`] = `
           <p
             className="shorten-text is-marginless"
           >
-            <i
-              className="far fa-star"
-            />
-            <strong>
-              heartOfGold
-            </strong>
-             
+            <span
+              className="RepositoryEntry__Title-sc-6jys82-0 eaqclL"
+            >
+              <i
+                className="far fa-star"
+              />
+              <strong>
+                heartOfGold
+              </strong>
+               
+            </span>
           </p>
           <p
             className="shorten-text"
@@ -63633,10 +63645,14 @@ exports[`Storyshots RepositoryEntry Default 1`] = `
           <p
             className="shorten-text is-marginless"
           >
-            <strong>
-              heartOfGold
-            </strong>
-             
+            <span
+              className="RepositoryEntry__Title-sc-6jys82-0 eaqclL"
+            >
+              <strong>
+                heartOfGold
+              </strong>
+               
+            </span>
           </p>
           <p
             className="shorten-text"
@@ -63778,15 +63794,175 @@ exports[`Storyshots RepositoryEntry Exporting 1`] = `
           <p
             className="shorten-text is-marginless"
           >
-            <strong>
-              heartOfGold
-            </strong>
-             
             <span
-              className="RepositoryEntry__RepositoryTag-sc-6jys82-0 jSnwjx"
-              title="exporting.tooltip"
+              className="RepositoryEntry__Title-sc-6jys82-0 eaqclL"
             >
-              repository.exporting
+              <strong>
+                heartOfGold
+              </strong>
+               
+              <span
+                className="Tag__InnerTag-ql67az-0 kOFYBe tag is-light is-small"
+                title="exporting.tooltip"
+              >
+                repository.exporting
+              </span>
+            </span>
+          </p>
+          <p
+            className="shorten-text"
+          >
+            The starship Heart of Gold was the first spacecraft to make use of the Infinite Improbability Drive
+          </p>
+        </div>
+      </div>
+      <div
+        className="CardColumn__FooterWrapper-sc-1w6lsih-3 kYSWZY level is-flex"
+      >
+        <div
+          className="CardColumn__RightMarginDiv-sc-1w6lsih-6 hazmI level-left is-hidden-mobile"
+        >
+          <a
+            className="RepositoryEntryLink__PointerEventsLink-sc-1hpqj0w-0 hOdNxe level-item"
+            href="/repo/hitchhiker/heartOfGold/branches/"
+            onClick={[Function]}
+          >
+            <span
+              className="tooltip has-tooltip-top"
+              data-tooltip="repositoryRoot.tooltip.branches"
+            >
+              <i
+                className="fas fa-code-branch has-text-inherit fa-lg"
+              />
+            </span>
+          </a>
+          <a
+            className="RepositoryEntryLink__PointerEventsLink-sc-1hpqj0w-0 hOdNxe level-item"
+            href="/repo/hitchhiker/heartOfGold/tags/"
+            onClick={[Function]}
+          >
+            <span
+              className="tooltip has-tooltip-top"
+              data-tooltip="repositoryRoot.tooltip.tags"
+            >
+              <i
+                className="fas fa-tags has-text-inherit fa-lg"
+              />
+            </span>
+          </a>
+          <a
+            className="RepositoryEntryLink__PointerEventsLink-sc-1hpqj0w-0 hOdNxe level-item"
+            href="/repo/hitchhiker/heartOfGold/code/changesets/"
+            onClick={[Function]}
+          >
+            <span
+              className="tooltip has-tooltip-top"
+              data-tooltip="repositoryRoot.tooltip.commits"
+            >
+              <i
+                className="fas fa-exchange-alt has-text-inherit fa-lg"
+              />
+            </span>
+          </a>
+          <a
+            className="RepositoryEntryLink__PointerEventsLink-sc-1hpqj0w-0 hOdNxe level-item"
+            href="/repo/hitchhiker/heartOfGold/code/sources/"
+            onClick={[Function]}
+          >
+            <span
+              className="tooltip has-tooltip-top"
+              data-tooltip="repositoryRoot.tooltip.sources"
+            >
+              <i
+                className="fas fa-code has-text-inherit fa-lg"
+              />
+            </span>
+          </a>
+          <a
+            className="RepositoryEntryLink__PointerEventsLink-sc-1hpqj0w-0 hOdNxe level-item"
+            href="/repo/hitchhiker/heartOfGold/settings/general"
+            onClick={[Function]}
+          >
+            <span
+              className="tooltip has-tooltip-top"
+              data-tooltip="repositoryRoot.tooltip.settings"
+            >
+              <i
+                className="fas fa-cog has-text-inherit fa-lg"
+              />
+            </span>
+          </a>
+        </div>
+        <div
+          className="CardColumn__InheritFlexShrinkDiv-sc-1w6lsih-7 bmCbDN level-right is-block is-mobile is-marginless shorten-text"
+        >
+          <small
+            className="level-item"
+          >
+            <time
+              className="DateElement-sc-1schp8c-0 cinWxa"
+              title="2020-03-23 09:26:01"
+            >
+              3 days ago
+            </time>
+          </small>
+        </div>
+      </div>
+    </div>
+  </article>
+</div>
+`;
+
+exports[`Storyshots RepositoryEntry HealthCheck Failure 1`] = `
+<div
+  className="RepositoryEntrystories__Spacing-toppdg-0 gZhLog box box-link-shadow"
+>
+  <a
+    className="overlay-column"
+    href="/repo/hitchhiker/heartOfGold"
+    onClick={[Function]}
+  />
+  <article
+    className="CardColumn__NoEventWrapper-sc-1w6lsih-0 cvqkqR media"
+  >
+    <figure
+      className="CardColumn__AvatarWrapper-sc-1w6lsih-1 jBSrYP media-left"
+    >
+      <p
+        className="RepositoryAvatar__Avatar-uh53vb-0 iYRgUJ image is-64x64"
+      >
+        <img
+          alt="Logo"
+          src="test-file-stub"
+        />
+      </p>
+    </figure>
+    <div
+      className="CardColumn__FlexFullHeight-sc-1w6lsih-2 dvHFki media-content text-box is-flex"
+    >
+      <div
+        className="is-flex"
+      >
+        <div
+          className="CardColumn__ContentLeft-sc-1w6lsih-4 heSQMX content"
+        >
+          <p
+            className="shorten-text is-marginless"
+          >
+            <span
+              className="RepositoryEntry__Title-sc-6jys82-0 eaqclL"
+            >
+              <strong>
+                heartOfGold
+              </strong>
+               
+              <span
+                className="Tag__InnerTag-ql67az-0 kOFYBe tag is-danger is-small"
+                onClick={[Function]}
+                title="healthCheckFailure.tooltip"
+              >
+                repository.healthCheckFailure
+              </span>
             </span>
           </p>
           <p
@@ -63929,21 +64105,25 @@ exports[`Storyshots RepositoryEntry MultiRepositoryTags 1`] = `
           <p
             className="shorten-text is-marginless"
           >
-            <strong>
-              heartOfGold
-            </strong>
-             
             <span
-              className="RepositoryEntry__RepositoryTag-sc-6jys82-0 jSnwjx"
-              title="archive.tooltip"
+              className="RepositoryEntry__Title-sc-6jys82-0 eaqclL"
             >
-              repository.archived
-            </span>
-            <span
-              className="RepositoryEntry__RepositoryTag-sc-6jys82-0 jSnwjx"
-              title="exporting.tooltip"
-            >
-              repository.exporting
+              <strong>
+                heartOfGold
+              </strong>
+               
+              <span
+                className="Tag__InnerTag-ql67az-0 kOFYBe tag is-light is-small"
+                title="archive.tooltip"
+              >
+                repository.archived
+              </span>
+              <span
+                className="Tag__InnerTag-ql67az-0 kOFYBe tag is-light is-small"
+                title="exporting.tooltip"
+              >
+                repository.exporting
+              </span>
             </span>
           </p>
           <p
@@ -64086,10 +64266,14 @@ exports[`Storyshots RepositoryEntry Quick Link EP 1`] = `
           <p
             className="shorten-text is-marginless"
           >
-            <strong>
-              heartOfGold
-            </strong>
-             
+            <span
+              className="RepositoryEntry__Title-sc-6jys82-0 eaqclL"
+            >
+              <strong>
+                heartOfGold
+              </strong>
+               
+            </span>
           </p>
           <p
             className="shorten-text"
@@ -64166,6 +64350,174 @@ exports[`Storyshots RepositoryEntry Quick Link EP 1`] = `
             <i
               className="fas fa-fas fa-code-branch fa-rotate-180 fa-fw has-text-inherit fa-lg"
             />
+          </a>
+          <a
+            className="RepositoryEntryLink__PointerEventsLink-sc-1hpqj0w-0 hOdNxe level-item"
+            href="/repo/hitchhiker/heartOfGold/settings/general"
+            onClick={[Function]}
+          >
+            <span
+              className="tooltip has-tooltip-top"
+              data-tooltip="repositoryRoot.tooltip.settings"
+            >
+              <i
+                className="fas fa-cog has-text-inherit fa-lg"
+              />
+            </span>
+          </a>
+        </div>
+        <div
+          className="CardColumn__InheritFlexShrinkDiv-sc-1w6lsih-7 bmCbDN level-right is-block is-mobile is-marginless shorten-text"
+        >
+          <small
+            className="level-item"
+          >
+            <time
+              className="DateElement-sc-1schp8c-0 cinWxa"
+              title="2020-03-23 09:26:01"
+            >
+              3 days ago
+            </time>
+          </small>
+        </div>
+      </div>
+    </div>
+  </article>
+</div>
+`;
+
+exports[`Storyshots RepositoryEntry RepositoryFlag EP 1`] = `
+<div
+  className="RepositoryEntrystories__Spacing-toppdg-0 gZhLog box box-link-shadow"
+>
+  <a
+    className="overlay-column"
+    href="/repo/hitchhiker/heartOfGold"
+    onClick={[Function]}
+  />
+  <article
+    className="CardColumn__NoEventWrapper-sc-1w6lsih-0 cvqkqR media"
+  >
+    <figure
+      className="CardColumn__AvatarWrapper-sc-1w6lsih-1 jBSrYP media-left"
+    >
+      <p
+        className="RepositoryAvatar__Avatar-uh53vb-0 iYRgUJ image is-64x64"
+      >
+        <img
+          alt="Logo"
+          src="test-file-stub"
+        />
+      </p>
+    </figure>
+    <div
+      className="CardColumn__FlexFullHeight-sc-1w6lsih-2 dvHFki media-content text-box is-flex"
+    >
+      <div
+        className="is-flex"
+      >
+        <div
+          className="CardColumn__ContentLeft-sc-1w6lsih-4 heSQMX content"
+        >
+          <p
+            className="shorten-text is-marginless"
+          >
+            <span
+              className="RepositoryEntry__Title-sc-6jys82-0 eaqclL"
+            >
+              <strong>
+                heartOfGold
+              </strong>
+               
+              <span
+                className="Tag__InnerTag-ql67az-0 kOFYBe tag is-danger is-small"
+                onClick={[Function]}
+                title="healthCheckFailure.tooltip"
+              >
+                repository.healthCheckFailure
+              </span>
+              <span
+                className="Tag__InnerTag-ql67az-0 kOFYBe tag is-success is-small"
+                title="awesome"
+              >
+                awesome
+              </span>
+              <span
+                className="Tag__InnerTag-ql67az-0 kOFYBe tag is-warning is-small"
+                title="ouhhh..."
+              >
+                ouhhh...
+              </span>
+            </span>
+          </p>
+          <p
+            className="shorten-text"
+          >
+            The starship Heart of Gold was the first spacecraft to make use of the Infinite Improbability Drive
+          </p>
+        </div>
+      </div>
+      <div
+        className="CardColumn__FooterWrapper-sc-1w6lsih-3 kYSWZY level is-flex"
+      >
+        <div
+          className="CardColumn__RightMarginDiv-sc-1w6lsih-6 hazmI level-left is-hidden-mobile"
+        >
+          <a
+            className="RepositoryEntryLink__PointerEventsLink-sc-1hpqj0w-0 hOdNxe level-item"
+            href="/repo/hitchhiker/heartOfGold/branches/"
+            onClick={[Function]}
+          >
+            <span
+              className="tooltip has-tooltip-top"
+              data-tooltip="repositoryRoot.tooltip.branches"
+            >
+              <i
+                className="fas fa-code-branch has-text-inherit fa-lg"
+              />
+            </span>
+          </a>
+          <a
+            className="RepositoryEntryLink__PointerEventsLink-sc-1hpqj0w-0 hOdNxe level-item"
+            href="/repo/hitchhiker/heartOfGold/tags/"
+            onClick={[Function]}
+          >
+            <span
+              className="tooltip has-tooltip-top"
+              data-tooltip="repositoryRoot.tooltip.tags"
+            >
+              <i
+                className="fas fa-tags has-text-inherit fa-lg"
+              />
+            </span>
+          </a>
+          <a
+            className="RepositoryEntryLink__PointerEventsLink-sc-1hpqj0w-0 hOdNxe level-item"
+            href="/repo/hitchhiker/heartOfGold/code/changesets/"
+            onClick={[Function]}
+          >
+            <span
+              className="tooltip has-tooltip-top"
+              data-tooltip="repositoryRoot.tooltip.commits"
+            >
+              <i
+                className="fas fa-exchange-alt has-text-inherit fa-lg"
+              />
+            </span>
+          </a>
+          <a
+            className="RepositoryEntryLink__PointerEventsLink-sc-1hpqj0w-0 hOdNxe level-item"
+            href="/repo/hitchhiker/heartOfGold/code/sources/"
+            onClick={[Function]}
+          >
+            <span
+              className="tooltip has-tooltip-top"
+              data-tooltip="repositoryRoot.tooltip.sources"
+            >
+              <i
+                className="fas fa-code has-text-inherit fa-lg"
+              />
+            </span>
           </a>
           <a
             className="RepositoryEntryLink__PointerEventsLink-sc-1hpqj0w-0 hOdNxe level-item"
@@ -78694,7 +79046,7 @@ exports[`Storyshots Tag Clickable 1`] = `
   className="Tagstories__Wrapper-wsn8kx-0 biUGWd"
 >
   <span
-    className="tag is-light"
+    className="Tag__InnerTag-ql67az-0 hGiieq tag is-light is-normal"
     onClick={[Function]}
   >
     Click here
@@ -78708,55 +79060,91 @@ exports[`Storyshots Tag Colors 1`] = `
 >
   <div>
     <div
-      className="Tagstories__Spacing-wsn8kx-1 foTIwu"
+      className="Tagstories__Spacing-wsn8kx-1 eufxAm"
     >
       <span
-        className="tag is-primary"
+        className="Tag__InnerTag-ql67az-0 hGiieq tag is-black is-normal"
+      >
+        black
+      </span>
+    </div>
+    <div
+      className="Tagstories__Spacing-wsn8kx-1 eufxAm"
+    >
+      <span
+        className="Tag__InnerTag-ql67az-0 hGiieq tag is-dark is-normal"
+      >
+        dark
+      </span>
+    </div>
+    <div
+      className="Tagstories__Spacing-wsn8kx-1 eufxAm"
+    >
+      <span
+        className="Tag__InnerTag-ql67az-0 hGiieq tag is-light is-normal"
+      >
+        light
+      </span>
+    </div>
+    <div
+      className="Tagstories__Spacing-wsn8kx-1 eufxAm"
+    >
+      <span
+        className="Tag__InnerTag-ql67az-0 hGiieq tag is-white is-normal"
+      >
+        white
+      </span>
+    </div>
+    <div
+      className="Tagstories__Spacing-wsn8kx-1 eufxAm"
+    >
+      <span
+        className="Tag__InnerTag-ql67az-0 hGiieq tag is-primary is-normal"
       >
         primary
       </span>
     </div>
     <div
-      className="Tagstories__Spacing-wsn8kx-1 foTIwu"
+      className="Tagstories__Spacing-wsn8kx-1 eufxAm"
     >
       <span
-        className="tag is-link"
+        className="Tag__InnerTag-ql67az-0 hGiieq tag is-link is-normal"
       >
         link
       </span>
     </div>
     <div
-      className="Tagstories__Spacing-wsn8kx-1 foTIwu"
+      className="Tagstories__Spacing-wsn8kx-1 eufxAm"
     >
       <span
-        className="tag is-info"
+        className="Tag__InnerTag-ql67az-0 hGiieq tag is-info is-normal"
       >
         info
       </span>
     </div>
     <div
-      className="Tagstories__Spacing-wsn8kx-1 foTIwu"
+      className="Tagstories__Spacing-wsn8kx-1 eufxAm"
     >
       <span
-        className="tag is-success"
+        className="Tag__InnerTag-ql67az-0 hGiieq tag is-success is-normal"
       >
         success
       </span>
     </div>
     <div
-      className="Tagstories__Spacing-wsn8kx-1 foTIwu"
+      className="Tagstories__Spacing-wsn8kx-1 eufxAm"
     >
       <span
-        className="tag is-warning"
+        className="Tag__InnerTag-ql67az-0 hGiieq tag is-warning is-normal"
       >
         warning
       </span>
     </div>
     <div
-      className="Tagstories__Spacing-wsn8kx-1 foTIwu"
+      className="Tagstories__Spacing-wsn8kx-1 eufxAm"
     >
       <span
-        className="tag is-danger"
+        className="Tag__InnerTag-ql67az-0 hGiieq tag is-danger is-normal"
       >
         danger
       </span>
@@ -78770,10 +79158,103 @@ exports[`Storyshots Tag Default 1`] = `
   className="Tagstories__Wrapper-wsn8kx-0 biUGWd"
 >
   <span
-    className="tag is-light"
+    className="Tag__InnerTag-ql67az-0 hGiieq tag is-light is-normal"
   >
     Default tag
   </span>
+</div>
+`;
+
+exports[`Storyshots Tag Outlined 1`] = `
+<div
+  className="Tagstories__Wrapper-wsn8kx-0 biUGWd"
+>
+  <div>
+    <div
+      className="Tagstories__Spacing-wsn8kx-1 eufxAm"
+    >
+      <span
+        className="Tag__InnerTag-ql67az-0 hGiieq tag is-success is-normal is-outlined"
+      >
+        success
+      </span>
+    </div>
+    <div
+      className="Tagstories__Spacing-wsn8kx-1 eufxAm"
+    >
+      <span
+        className="Tag__InnerTag-ql67az-0 hGiieq tag is-black is-normal is-outlined"
+      >
+        black
+      </span>
+    </div>
+    <div
+      className="Tagstories__Spacing-wsn8kx-1 eufxAm"
+    >
+      <span
+        className="Tag__InnerTag-ql67az-0 hGiieq tag is-danger is-normal is-outlined"
+      >
+        danger
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Tag Rounded 1`] = `
+<div
+  className="Tagstories__Wrapper-wsn8kx-0 biUGWd"
+>
+  <span
+    className="Tag__InnerTag-ql67az-0 hGiieq tag is-dark is-normal is-rounded"
+  >
+    Rounded tag
+  </span>
+</div>
+`;
+
+exports[`Storyshots Tag Sizes 1`] = `
+<div
+  className="Tagstories__Wrapper-wsn8kx-0 biUGWd"
+>
+  <div>
+    <div
+      className="Tagstories__Spacing-wsn8kx-1 eufxAm"
+    >
+      <span
+        className="Tag__InnerTag-ql67az-0 kOFYBe tag is-light is-small"
+      >
+        small
+      </span>
+    </div>
+    <div
+      className="Tagstories__Spacing-wsn8kx-1 eufxAm"
+    >
+      <span
+        className="Tag__InnerTag-ql67az-0 hGiieq tag is-light is-normal"
+      >
+        normal
+      </span>
+    </div>
+    <div
+      className="Tagstories__Spacing-wsn8kx-1 eufxAm"
+    >
+      <span
+        className="Tag__InnerTag-ql67az-0 hGiieq tag is-light is-medium"
+      >
+        medium
+      </span>
+    </div>
+    <div
+      className="Tagstories__Spacing-wsn8kx-1 eufxAm"
+    >
+      <span
+        className="Tag__InnerTag-ql67az-0 hGiieq tag is-light is-large"
+      >
+        large
+      </span>
+    </div>
+  </div>
 </div>
 `;
 
@@ -78782,7 +79263,7 @@ exports[`Storyshots Tag With Icon 1`] = `
   className="Tagstories__Wrapper-wsn8kx-0 biUGWd"
 >
   <span
-    className="tag is-light"
+    className="Tag__InnerTag-ql67az-0 hGiieq tag is-light is-normal"
   >
     <i
       className="fas fa-bolt"
@@ -78798,7 +79279,7 @@ exports[`Storyshots Tag With title 1`] = `
   className="Tagstories__Wrapper-wsn8kx-0 biUGWd"
 >
   <span
-    className="tag is-light"
+    className="Tag__InnerTag-ql67az-0 hGiieq tag is-light is-normal"
     title="good job"
   >
     hover me

--- a/scm-ui/ui-components/src/forms/TagGroup.tsx
+++ b/scm-ui/ui-components/src/forms/TagGroup.tsx
@@ -56,7 +56,7 @@ export default class TagGroup extends React.Component<Props> {
           return (
             <div className="control" key={key}>
               <div className="tags has-addons">
-                <Tag color="info is-outlined" label={item.displayName} onRemove={() => this.removeEntry(item)} />
+                <Tag color="info" outlined={true} label={item.displayName} onRemove={() => this.removeEntry(item)} />
               </div>
             </div>
           );
@@ -66,7 +66,7 @@ export default class TagGroup extends React.Component<Props> {
   }
 
   removeEntry = (item: DisplayedUser) => {
-    const newItems = this.props.items.filter(name => name !== item);
+    const newItems = this.props.items.filter((name) => name !== item);
     this.props.onRemove(newItems);
   };
 }

--- a/scm-ui/ui-components/src/repos/DiffFile.tsx
+++ b/scm-ui/ui-components/src/repos/DiffFile.tsx
@@ -396,10 +396,17 @@ class DiffFile extends React.Component<Props, State> {
     if (key === value) {
       value = file.type;
     }
-    const color =
-      value === "added" ? "success is-outlined" : value === "deleted" ? "danger is-outlined" : "info is-outlined";
 
-    return <ChangeTypeTag className={classNames("is-rounded", "has-text-weight-normal")} color={color} label={value} />;
+    const color = value === "added" ? "success" : value === "deleted" ? "danger" : "info";
+    return (
+      <ChangeTypeTag
+        className={classNames("has-text-weight-normal")}
+        rounded={true}
+        outlined={true}
+        color={color}
+        label={value}
+      />
+    );
   };
 
   hasContent = (file: FileDiff) => file && !file.isBinary && file.hunks && file.hunks.length > 0;

--- a/scm-ui/ui-components/src/repos/RepositoryEntry.stories.tsx
+++ b/scm-ui/ui-components/src/repos/RepositoryEntry.stories.tsx
@@ -93,9 +93,9 @@ const healthCheckFailedRepository = {
       id: "4211",
       summary: "Something failed",
       description: "Something realy bad happend",
-      url: "http://why.is-the-url.required",
-    },
-  ],
+      url: "https://something-realy-bad.happend"
+    }
+  ]
 };
 const archivedExportingRepository = { ...repository, archived: true, exporting: true };
 

--- a/scm-ui/ui-components/src/repos/RepositoryEntry.stories.tsx
+++ b/scm-ui/ui-components/src/repos/RepositoryEntry.stories.tsx
@@ -33,6 +33,8 @@ import { Repository } from "@scm-manager/ui-types";
 import Image from "../Image";
 import Icon from "../Icon";
 import { MemoryRouter } from "react-router-dom";
+import { Color } from "../styleConstants";
+import RepositoryFlag from "./RepositoryFlag";
 
 const baseDate = "2020-03-26T12:13:42+02:00";
 
@@ -46,6 +48,14 @@ const bindAvatar = (binder: Binder, avatar: string) => {
   binder.bind("repos.repository-avatar", () => {
     return <Image src={avatar} alt="Logo" />;
   });
+};
+
+const bindFlag = (binder: Binder, color: Color, label: string) => {
+  binder.bind("repository.card.flags", () => (
+    <RepositoryFlag title={label} color={color}>
+      {label}
+    </RepositoryFlag>
+  ));
 };
 
 const bindBeforeTitle = (binder: Binder, extension: ReactNode) => {
@@ -76,6 +86,17 @@ const QuickLink = (
 
 const archivedRepository = { ...repository, archived: true };
 const exportingRepository = { ...repository, exporting: true };
+const healthCheckFailedRepository = {
+  ...repository,
+  healthCheckFailures: [
+    {
+      id: "4211",
+      summary: "Something failed",
+      description: "Something realy bad happend",
+      url: "http://why.is-the-url.required",
+    },
+  ],
+};
 const archivedExportingRepository = { ...repository, archived: true, exporting: true };
 
 storiesOf("RepositoryEntry", module)
@@ -108,6 +129,18 @@ storiesOf("RepositoryEntry", module)
     const binder = new Binder("title");
     bindAvatar(binder, Git);
     return withBinder(binder, exportingRepository);
+  })
+  .add("HealthCheck Failure", () => {
+    const binder = new Binder("title");
+    bindAvatar(binder, Git);
+    return withBinder(binder, healthCheckFailedRepository);
+  })
+  .add("RepositoryFlag EP", () => {
+    const binder = new Binder("title");
+    bindAvatar(binder, Git);
+    bindFlag(binder, "success", "awesome");
+    bindFlag(binder, "warning", "ouhhh...");
+    return withBinder(binder, healthCheckFailedRepository);
   })
   .add("MultiRepositoryTags", () => {
     const binder = new Binder("title");

--- a/scm-ui/ui-components/src/repos/RepositoryEntry.tsx
+++ b/scm-ui/ui-components/src/repos/RepositoryEntry.tsx
@@ -30,6 +30,7 @@ import { ExtensionPoint } from "@scm-manager/ui-extensions";
 import { withTranslation, WithTranslation } from "react-i18next";
 import styled from "styled-components";
 import HealthCheckFailureDetail from "./HealthCheckFailureDetail";
+import RepositoryFlag from "./RepositoryFlag";
 
 type DateProp = Date | string;
 
@@ -44,37 +45,23 @@ type State = {
   showHealthCheck: boolean;
 };
 
-const RepositoryTag = styled.span`
-  margin-left: 0.2rem;
-  background-color: #9a9a9a;
-  padding: 0.25rem;
-  border-radius: 5px;
-  color: white;
-  overflow: visible;
-  pointer-events: all;
-  font-weight: bold;
-  font-size: 0.7rem;
-`;
-const RepositoryWarnTag = styled.span`
-  margin-left: 0.2rem;
-  background-color: #f14668;
-  padding: 0.25rem;
-  border-radius: 5px;
-  color: white;
-  overflow: visible;
-  pointer-events: all;
-  font-weight: bold;
-  font-size: 0.7rem;
-  cursor: help;
+const Title = styled.span`
+  display: flex;
+  align-items: center;
+
+  & > * {
+    margin-right: 0.25rem;
+  }
 `;
 
 class RepositoryEntry extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
-      showHealthCheck: false
+      showHealthCheck: false,
     };
   }
+
   createLink = (repository: Repository) => {
     return `/repo/${repository.namespace}/${repository.name}`;
   };
@@ -170,31 +157,33 @@ class RepositoryEntry extends React.Component<Props, State> {
     const { repository, t } = this.props;
     const repositoryFlags = [];
     if (repository.archived) {
-      repositoryFlags.push(<RepositoryTag title={t("archive.tooltip")}>{t("repository.archived")}</RepositoryTag>);
+      repositoryFlags.push(<RepositoryFlag title={t("archive.tooltip")}>{t("repository.archived")}</RepositoryFlag>);
     }
 
     if (repository.exporting) {
-      repositoryFlags.push(<RepositoryTag title={t("exporting.tooltip")}>{t("repository.exporting")}</RepositoryTag>);
+      repositoryFlags.push(<RepositoryFlag title={t("exporting.tooltip")}>{t("repository.exporting")}</RepositoryFlag>);
     }
 
     if (repository.healthCheckFailures && repository.healthCheckFailures.length > 0) {
       repositoryFlags.push(
-        <RepositoryWarnTag
+        <RepositoryFlag
+          color="danger"
           title={t("healthCheckFailure.tooltip")}
           onClick={() => {
             this.setState({ showHealthCheck: true });
           }}
         >
           {t("repository.healthCheckFailure")}
-        </RepositoryWarnTag>
+        </RepositoryFlag>
       );
     }
 
     return (
-      <>
+      <Title>
         <ExtensionPoint name="repository.card.beforeTitle" props={{ repository }} />
-        <strong>{repository.name}</strong> {repositoryFlags.map(flag => flag)}
-      </>
+        <strong>{repository.name}</strong> {repositoryFlags}
+        <ExtensionPoint name="repository.card.flags" props={{ repository }} renderAll={true} />
+      </Title>
     );
   };
 

--- a/scm-ui/ui-components/src/repos/RepositoryFlag.tsx
+++ b/scm-ui/ui-components/src/repos/RepositoryFlag.tsx
@@ -24,16 +24,17 @@
 
 import React, { FC } from "react";
 import Tag from "../Tag";
-import { Color } from "../styleConstants";
+import { Color, Size } from "../styleConstants";
 
 type Props = {
   color?: Color;
   title?: string;
   onClick?: () => void;
+  size?: Size;
 };
 
-const RepositoryFlag: FC<Props> = ({ children, ...props }) => (
-  <Tag size="small" {...props}>
+const RepositoryFlag: FC<Props> = ({ children, size = "small", ...props }) => (
+  <Tag size={size} {...props}>
     {children}
   </Tag>
 );

--- a/scm-ui/ui-components/src/repos/RepositoryFlag.tsx
+++ b/scm-ui/ui-components/src/repos/RepositoryFlag.tsx
@@ -22,39 +22,20 @@
  * SOFTWARE.
  */
 
-import { ExtensionPointDefinition } from "./binder";
-import {
-  IndexResources,
-  NamespaceStrategies,
-  Repository,
-  RepositoryCreation,
-  RepositoryTypeCollection,
-} from "@scm-manager/ui-types";
+import React, { FC } from "react";
+import Tag from "../Tag";
+import { Color } from "../styleConstants";
 
-type RepositoryCreatorSubFormProps = {
-  repository: RepositoryCreation;
-  onChange: (repository: RepositoryCreation) => void;
-  setValid: (valid: boolean) => void;
-  disabled?: boolean;
+type Props = {
+  color?: Color;
+  title?: string;
+  onClick?: () => void;
 };
 
-export type RepositoryCreatorComponentProps = {
-  namespaceStrategies: NamespaceStrategies;
-  repositoryTypes: RepositoryTypeCollection;
-  index: IndexResources;
+const RepositoryFlag: FC<Props> = ({ children, ...props }) => (
+  <Tag size="small" {...props}>
+    {children}
+  </Tag>
+);
 
-  nameForm: React.ComponentType<RepositoryCreatorSubFormProps>;
-  informationForm: React.ComponentType<RepositoryCreatorSubFormProps>;
-};
-
-export type RepositoryCreatorExtension = {
-  subtitle: string;
-  path: string;
-  icon: string;
-  label: string;
-  component: React.ComponentType<RepositoryCreatorComponentProps>;
-};
-
-export type RepositoryCreator = ExtensionPointDefinition<"repos.creator", RepositoryCreatorExtension>;
-
-export type RepositoryCardFlags = ExtensionPointDefinition<"repository.card.flags", { repository: Repository }>;
+export default RepositoryFlag;

--- a/scm-ui/ui-components/src/repos/index.ts
+++ b/scm-ui/ui-components/src/repos/index.ts
@@ -29,10 +29,11 @@ import {
   AnnotationFactory,
   AnnotationFactoryContext,
   DiffEventHandler,
-  DiffEventContext
+  DiffEventContext,
 } from "./DiffTypes";
 
 import { FileDiff as File, FileChangeType, Hunk, Change, ChangeType } from "@scm-manager/ui-types";
+
 export { diffs };
 
 export * from "./annotate";
@@ -46,6 +47,7 @@ export { default as LoadingDiff } from "./LoadingDiff";
 export { DefaultCollapsed, DefaultCollapsedFunction } from "./defaultCollapsed";
 export { default as RepositoryAvatar } from "./RepositoryAvatar";
 export { default as RepositoryEntry } from "./RepositoryEntry";
+export { default as RepositoryFlag } from "./RepositoryFlag";
 export { default as RepositoryEntryLink } from "./RepositoryEntryLink";
 export { default as JumpToFileButton } from "./JumpToFileButton";
 export { default as CommitAuthor } from "./CommitAuthor";
@@ -61,5 +63,5 @@ export {
   AnnotationFactory,
   AnnotationFactoryContext,
   DiffEventHandler,
-  DiffEventContext
+  DiffEventContext,
 };

--- a/scm-ui/ui-components/src/styleConstants.ts
+++ b/scm-ui/ui-components/src/styleConstants.ts
@@ -22,39 +22,19 @@
  * SOFTWARE.
  */
 
-import { ExtensionPointDefinition } from "./binder";
-import {
-  IndexResources,
-  NamespaceStrategies,
-  Repository,
-  RepositoryCreation,
-  RepositoryTypeCollection,
-} from "@scm-manager/ui-types";
+export const colors = [
+  "black",
+  "dark",
+  "light",
+  "white",
+  "primary",
+  "link",
+  "info",
+  "success",
+  "warning",
+  "danger",
+] as const;
+export type Color = typeof colors[number];
 
-type RepositoryCreatorSubFormProps = {
-  repository: RepositoryCreation;
-  onChange: (repository: RepositoryCreation) => void;
-  setValid: (valid: boolean) => void;
-  disabled?: boolean;
-};
-
-export type RepositoryCreatorComponentProps = {
-  namespaceStrategies: NamespaceStrategies;
-  repositoryTypes: RepositoryTypeCollection;
-  index: IndexResources;
-
-  nameForm: React.ComponentType<RepositoryCreatorSubFormProps>;
-  informationForm: React.ComponentType<RepositoryCreatorSubFormProps>;
-};
-
-export type RepositoryCreatorExtension = {
-  subtitle: string;
-  path: string;
-  icon: string;
-  label: string;
-  component: React.ComponentType<RepositoryCreatorComponentProps>;
-};
-
-export type RepositoryCreator = ExtensionPointDefinition<"repos.creator", RepositoryCreatorExtension>;
-
-export type RepositoryCardFlags = ExtensionPointDefinition<"repository.card.flags", { repository: Repository }>;
+export const sizes = ["small", "normal", "medium", "large"] as const;
+export type Size = typeof sizes[number];

--- a/scm-ui/ui-webapp/src/repos/components/RepositoryDetailTable.tsx
+++ b/scm-ui/ui-webapp/src/repos/components/RepositoryDetailTable.tsx
@@ -25,7 +25,6 @@ import React from "react";
 import { WithTranslation, withTranslation } from "react-i18next";
 import { Repository } from "@scm-manager/ui-types";
 import { DateFromNow, MailLink } from "@scm-manager/ui-components";
-import { ExtensionPoint } from "@scm-manager/ui-extensions";
 
 type Props = WithTranslation & {
   repository: Repository;

--- a/scm-ui/ui-webapp/src/repos/components/form/RepositoryFormSwitcher.tsx
+++ b/scm-ui/ui-webapp/src/repos/components/form/RepositoryFormSwitcher.tsx
@@ -26,6 +26,7 @@ import React, { FC } from "react";
 import styled from "styled-components";
 import { Button, ButtonAddons, Icon, Level, urls } from "@scm-manager/ui-components";
 import { useLocation } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 
 const MarginIcon = styled(Icon)`
   padding-right: 0.5rem;
@@ -58,11 +59,12 @@ const RepositoryFormButton: FC<RepositoryForm> = ({ path, icon, label }) => {
   const location = useLocation();
   const href = urls.concat("/repos/create", path);
   const isSelected = href === location.pathname;
+  const [t] = useTranslation(["repos", "plugins"]);
 
   return (
     <SmallButton color={isSelected ? "link is-selected" : undefined} link={!isSelected ? href : undefined}>
       <MarginIcon name={icon} color={isSelected ? "white" : "default"} />
-      <p className="is-hidden-mobile is-hidden-tablet-only">{label}</p>
+      <p className="is-hidden-mobile is-hidden-tablet-only">{t(`plugins:${label}`, label)}</p>
     </SmallButton>
   );
 };
@@ -75,7 +77,7 @@ const RepositoryFormSwitcher: FC<Props> = ({ forms }) => (
   <TopLevel
     right={
       <ButtonAddons>
-        {(forms || []).map(form => (
+        {(forms || []).map((form) => (
           <RepositoryFormButton key={form.path} {...form} />
         ))}
       </ButtonAddons>

--- a/scm-ui/ui-webapp/src/repos/containers/RepositoryRoot.tsx
+++ b/scm-ui/ui-webapp/src/repos/containers/RepositoryRoot.tsx
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 import React, { useState } from "react";
-import { Redirect, Route, Link as RouteLink, Switch, useRouteMatch } from "react-router-dom";
+import { Link as RouteLink, Redirect, Route, Switch, useRouteMatch } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { binder, ExtensionPoint } from "@scm-manager/ui-extensions";
 import { Changeset, Link } from "@scm-manager/ui-types";
@@ -36,12 +36,13 @@ import {
   NavLink,
   Page,
   PrimaryContentColumn,
+  RepositoryFlag,
   SecondaryNavigation,
   SecondaryNavigationColumn,
   StateMenuContextProvider,
   SubNavigation,
   Tooltip,
-  urls
+  urls,
 } from "@scm-manager/ui-components";
 import RepositoryDetails from "../components/RepositoryDetails";
 import EditRepo from "./EditRepo";
@@ -57,25 +58,14 @@ import ChangesetView from "./ChangesetView";
 import SourceExtensions from "../sources/containers/SourceExtensions";
 import TagsOverview from "../tags/container/TagsOverview";
 import TagRoot from "../tags/container/TagRoot";
-import styled from "styled-components";
 import { useIndexLinks, useRepository } from "@scm-manager/ui-api";
+import styled from "styled-components";
 
-const RepositoryTag = styled.span`
-  margin-left: 0.2rem;
-  background-color: #9a9a9a;
-  padding: 0.4rem;
-  border-radius: 5px;
-  color: white;
+const TagGroup = styled.div`
   font-weight: bold;
-`;
-
-const RepositoryWarnTag = styled.span`
-  margin-left: 0.2rem;
-  background-color: #f14668;
-  padding: 0.4rem;
-  border-radius: 5px;
-  color: white;
-  font-weight: bold;
+  & > * {
+    margin-right: 0.25rem;
+  }
 `;
 
 type UrlParams = {
@@ -88,7 +78,7 @@ const useRepositoryFromUrl = (match: match<UrlParams>) => {
   const { data: repository, ...rest } = useRepository(namespace, name);
   return {
     repository,
-    ...rest
+    ...rest,
   };
 };
 
@@ -122,7 +112,7 @@ const RepositoryRoot = () => {
     error,
     repoLink: (indexLinks.repositories as Link)?.href,
     indexLinks,
-    match
+    match,
   };
 
   const redirectUrlFactory = binder.getExtension("repository.redirect", props);
@@ -133,16 +123,16 @@ const RepositoryRoot = () => {
     redirectedUrl = url + "/info";
   }
 
-  const fileControlFactoryFactory: (changeset: Changeset) => FileControlFactory = changeset => file => {
+  const fileControlFactoryFactory: (changeset: Changeset) => FileControlFactory = (changeset) => (file) => {
     const baseUrl = `${url}/code/sources`;
     const sourceLink = file.newPath && {
       url: `${baseUrl}/${changeset.id}/${file.newPath}/`,
-      label: t("diff.jumpToSource")
+      label: t("diff.jumpToSource"),
     };
     const targetLink = file.oldPath &&
       changeset._embedded?.parents?.length === 1 && {
         url: `${baseUrl}/${changeset._embedded.parents[0].id}/${file.oldPath}`,
-        label: t("diff.jumpToTarget")
+        label: t("diff.jumpToTarget"),
       };
 
     const links = [];
@@ -172,7 +162,7 @@ const RepositoryRoot = () => {
   if (repository.archived) {
     repositoryFlags.push(
       <Tooltip message={t("archive.tooltip")}>
-        <RepositoryTag className="is-size-6">{t("repository.archived")}</RepositoryTag>
+        <RepositoryFlag size="normal">{t("repository.archived")}</RepositoryFlag>
       </Tooltip>
     );
   }
@@ -180,7 +170,7 @@ const RepositoryRoot = () => {
   if (repository.exporting) {
     repositoryFlags.push(
       <Tooltip message={t("exporting.tooltip")}>
-        <RepositoryTag className="is-size-6">{t("repository.exporting")}</RepositoryTag>
+        <RepositoryFlag size="normal">{t("repository.exporting")}</RepositoryFlag>
       </Tooltip>
     );
   }
@@ -188,9 +178,9 @@ const RepositoryRoot = () => {
   if (repository.healthCheckFailures && repository.healthCheckFailures.length > 0) {
     repositoryFlags.push(
       <Tooltip message={t("healthCheckFailure.tooltip")}>
-        <RepositoryWarnTag className="is-size-6" onClick={() => setShowHealthCheck(true)}>
+        <RepositoryFlag size="normal" onClick={() => setShowHealthCheck(true)} color="danger">
           {t("repository.healthCheckFailure")}
-        </RepositoryWarnTag>
+        </RepositoryFlag>
       </Tooltip>
     );
   }
@@ -207,7 +197,7 @@ const RepositoryRoot = () => {
   const extensionProps = {
     repository,
     url,
-    indexLinks
+    indexLinks,
   };
 
   const matchesBranches = (route: any) => {
@@ -258,7 +248,7 @@ const RepositoryRoot = () => {
         afterTitle={
           <>
             <ExtensionPoint name={"repository.afterTitle"} props={{ repository }} />
-            {repositoryFlags.map(flag => flag)}
+            <TagGroup>{repositoryFlags.map((flag) => flag)}</TagGroup>
           </>
         }
       >

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/RepositoryExportResource.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/RepositoryExportResource.java
@@ -39,7 +39,6 @@ import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import sonia.scm.BadRequestException;
 import sonia.scm.ConcurrentModificationException;
 import sonia.scm.NotFoundException;
-import sonia.scm.Type;
 import sonia.scm.importexport.ExportFileExtensionResolver;
 import sonia.scm.importexport.ExportNotificationHandler;
 import sonia.scm.importexport.ExportService;
@@ -50,6 +49,7 @@ import sonia.scm.repository.NamespaceAndName;
 import sonia.scm.repository.Repository;
 import sonia.scm.repository.RepositoryManager;
 import sonia.scm.repository.RepositoryPermissions;
+import sonia.scm.repository.RepositoryType;
 import sonia.scm.repository.api.BundleCommandBuilder;
 import sonia.scm.repository.api.Command;
 import sonia.scm.repository.api.ExportFailedException;
@@ -442,7 +442,7 @@ public class RepositoryExportResource {
     if (!type.equals(repository.getType())) {
       throw new WrongTypeException(repository);
     }
-    Type repositoryType = type(manager, type);
+    RepositoryType repositoryType = type(manager, type);
     checkSupport(repositoryType, Command.BUNDLE);
     return repository;
   }

--- a/scm-webapp/src/main/java/sonia/scm/importexport/FromBundleImporter.java
+++ b/scm-webapp/src/main/java/sonia/scm/importexport/FromBundleImporter.java
@@ -28,7 +28,6 @@ import com.google.common.io.Files;
 import org.apache.shiro.SecurityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sonia.scm.Type;
 import sonia.scm.event.ScmEventBus;
 import sonia.scm.repository.ImportRepositoryHookEvent;
 import sonia.scm.repository.InternalRepositoryException;
@@ -38,6 +37,7 @@ import sonia.scm.repository.RepositoryImportEvent;
 import sonia.scm.repository.RepositoryManager;
 import sonia.scm.repository.RepositoryPermission;
 import sonia.scm.repository.RepositoryPermissions;
+import sonia.scm.repository.RepositoryType;
 import sonia.scm.repository.api.Command;
 import sonia.scm.repository.api.RepositoryService;
 import sonia.scm.repository.api.RepositoryServiceFactory;
@@ -78,7 +78,7 @@ public class FromBundleImporter {
   public Repository importFromBundle(boolean compressed, InputStream inputStream, Repository repository) {
     RepositoryPermissions.create().check();
 
-    Type t = type(manager, repository.getType());
+    RepositoryType t = type(manager, repository.getType());
     checkSupport(t, Command.UNBUNDLE);
 
     repository.setPermissions(singletonList(

--- a/scm-webapp/src/main/java/sonia/scm/importexport/FromUrlImporter.java
+++ b/scm-webapp/src/main/java/sonia/scm/importexport/FromUrlImporter.java
@@ -31,7 +31,6 @@ import org.apache.shiro.SecurityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sonia.scm.AlreadyExistsException;
-import sonia.scm.Type;
 import sonia.scm.event.ScmEventBus;
 import sonia.scm.repository.InternalRepositoryException;
 import sonia.scm.repository.Repository;
@@ -39,6 +38,7 @@ import sonia.scm.repository.RepositoryImportEvent;
 import sonia.scm.repository.RepositoryManager;
 import sonia.scm.repository.RepositoryPermission;
 import sonia.scm.repository.RepositoryPermissions;
+import sonia.scm.repository.RepositoryType;
 import sonia.scm.repository.api.Command;
 import sonia.scm.repository.api.ImportFailedException;
 import sonia.scm.repository.api.PullCommandBuilder;
@@ -73,7 +73,7 @@ public class FromUrlImporter {
   }
 
   public Repository importFromUrl(RepositoryImportParameters parameters, Repository repository) {
-    Type t = type(manager, repository.getType());
+    RepositoryType t = type(manager, repository.getType());
     RepositoryPermissions.create().check();
     checkSupport(t, Command.PULL);
 

--- a/scm-webapp/src/main/java/sonia/scm/importexport/RepositoryTypeSupportChecker.java
+++ b/scm-webapp/src/main/java/sonia/scm/importexport/RepositoryTypeSupportChecker.java
@@ -27,14 +27,11 @@ package sonia.scm.importexport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sonia.scm.BadRequestException;
-import sonia.scm.Type;
 import sonia.scm.repository.RepositoryHandler;
 import sonia.scm.repository.RepositoryManager;
 import sonia.scm.repository.RepositoryType;
 import sonia.scm.repository.api.Command;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
 import java.util.Set;
 
 import static sonia.scm.ContextEntry.ContextBuilder.noContext;
@@ -44,7 +41,7 @@ public class RepositoryTypeSupportChecker {
   private RepositoryTypeSupportChecker() {
   }
 
-  private static final Logger logger = LoggerFactory.getLogger(RepositoryTypeSupportChecker.class);
+  private static final Logger LOG = LoggerFactory.getLogger(RepositoryTypeSupportChecker.class);
 
   /**
    * Check repository type for support for the given command.
@@ -52,31 +49,28 @@ public class RepositoryTypeSupportChecker {
    * @param type repository type
    * @param cmd  command
    */
-  public static void checkSupport(Type type, Command cmd) {
-    if (!(type instanceof RepositoryType)) {
-      logger.warn("type {} is not a repository type", type.getName());
-      throw new WebApplicationException(Response.Status.BAD_REQUEST);
-    }
-
-    Set<Command> cmds = ((RepositoryType) type).getSupportedCommands();
+  public static void checkSupport(RepositoryType type, Command cmd) {
+    Set<Command> cmds = type.getSupportedCommands();
     if (!cmds.contains(cmd)) {
-      logger.warn("type {} does not support this command {}",
+      LOG.debug("type {} does not support this command {}",
         type.getName(),
-        cmd.name());
+        cmd);
       throw new IllegalTypeForImportException("type does not support command");
     }
   }
 
-  @SuppressWarnings("javasecurity:S5145") // the type parameter is validated in the resource to only contain valid characters (\w)
-  public static Type type(RepositoryManager manager, String type) {
+  @SuppressWarnings("javasecurity:S5145")
+  // the type parameter is validated in the resource to only contain valid characters (\w)
+  public static RepositoryType type(RepositoryManager manager, String type) {
     RepositoryHandler handler = manager.getHandler(type);
     if (handler == null) {
-      logger.warn("no handler for type {} found", type);
+      LOG.debug("no handler for type {} found", type);
       throw new IllegalTypeForImportException("unsupported repository type: " + type);
     }
     return handler.getType();
   }
 
+  @SuppressWarnings("java:S110") // this is fine for exceptions
   private static class IllegalTypeForImportException extends BadRequestException {
     public IllegalTypeForImportException(String message) {
       super(noContext(), message);


### PR DESCRIPTION
## Proposed changes

This change allows plugin authors to decorate repository cards with flags. The change modifies also how the existing flags (archive, exporting, health check failure) are rendered.

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests
- [X] New ui components are tested inside the storybook (module ui-components only) 

**Reviewer**:
- [x] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [x] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
