### PR TITLE
New configuration form

### DIFF
--- a/scm-ui/ui-api/src/configLink.test.ts
+++ b/scm-ui/ui-api/src/configLink.test.ts
@@ -83,7 +83,7 @@ describe("useConfigLink tests", () => {
   it("should call update url", async () => {
     const queryClient = createInfiniteCachingClient();
 
-    fetchMock.getOnce("/api/v2/my/config", myConfig);
+    fetchMock.get("/api/v2/my/config", myConfig);
 
     const { result, waitFor, waitForNextUpdate } = renderHook(() => useConfigLink<MyConfig>("/my/config"), {
       wrapper: createWrapper(undefined, queryClient),
@@ -124,7 +124,7 @@ describe("useConfigLink tests", () => {
   it("should capture content type update url", async () => {
     const queryClient = createInfiniteCachingClient();
 
-    fetchMock.getOnce("/api/v2/my/config", {
+    fetchMock.get("/api/v2/my/config", {
       headers: {
         "Content-Type": "application/myconfig+json",
       },

--- a/scm-ui/ui-api/src/configLink.test.ts
+++ b/scm-ui/ui-api/src/configLink.test.ts
@@ -1,0 +1,169 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import fetchMock from "fetch-mock-jest";
+import { HalRepresentation } from "@scm-manager/ui-types";
+import { renderHook } from "@testing-library/react-hooks";
+import createWrapper from "./tests/createWrapper";
+import { useConfigLink } from "./configLink";
+import createInfiniteCachingClient from "./tests/createInfiniteCachingClient";
+import { act } from "react-test-renderer";
+
+describe("useConfigLink tests", () => {
+  type MyConfig = HalRepresentation & {
+    name: string;
+  };
+
+  const myReadOnlyConfig: MyConfig = {
+    name: "Hansolo",
+    _links: {},
+  };
+
+  const myConfig: MyConfig = {
+    name: "Lea",
+    _links: {
+      update: {
+        href: "/my/config-write",
+      },
+    },
+  };
+
+  afterEach(() => {
+    fetchMock.reset();
+  });
+
+  const fetchConfiguration = async (config: MyConfig) => {
+    fetchMock.getOnce("/api/v2/my/config", config);
+
+    const queryClient = createInfiniteCachingClient();
+
+    const { result, waitFor } = renderHook(() => useConfigLink<MyConfig>("/my/config"), {
+      wrapper: createWrapper(undefined, queryClient),
+    });
+    await waitFor(() => {
+      return !!result.current.initialConfiguration;
+    });
+
+    return result.current;
+  };
+
+  it("should return read only configuration without update link", async () => {
+    const { isReadOnly } = await fetchConfiguration(myReadOnlyConfig);
+
+    expect(isReadOnly).toBe(true);
+  });
+
+  it("should not be read only with update link", async () => {
+    const { isReadOnly } = await fetchConfiguration(myConfig);
+
+    expect(isReadOnly).toBe(false);
+  });
+
+  it("should call update url", async () => {
+    const queryClient = createInfiniteCachingClient();
+
+    fetchMock.getOnce("/api/v2/my/config", myConfig);
+
+    const { result, waitFor, waitForNextUpdate } = renderHook(() => useConfigLink<MyConfig>("/my/config"), {
+      wrapper: createWrapper(undefined, queryClient),
+    });
+
+    await waitFor(() => {
+      return !!result.current.initialConfiguration;
+    });
+
+    const { update } = result.current;
+
+    const lukesConfig = {
+      ...myConfig,
+      name: "Luke",
+    };
+
+    fetchMock.putOnce(
+      {
+        url: "/api/v2/my/config-write",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: lukesConfig,
+      },
+      {
+        status: 204,
+      }
+    );
+
+    await act(() => {
+      update(lukesConfig);
+      return waitForNextUpdate();
+    });
+
+    expect(result.current.isUpdated).toBe(true);
+  });
+
+  it("should capture content type update url", async () => {
+    const queryClient = createInfiniteCachingClient();
+
+    fetchMock.getOnce("/api/v2/my/config", {
+      headers: {
+        "Content-Type": "application/myconfig+json",
+      },
+      body: myConfig,
+    });
+
+    const { result, waitFor, waitForNextUpdate } = renderHook(() => useConfigLink<MyConfig>("/my/config"), {
+      wrapper: createWrapper(undefined, queryClient),
+    });
+
+    await waitFor(() => {
+      return !!result.current.initialConfiguration;
+    });
+
+    const { update } = result.current;
+
+    const lukesConfig = {
+      ...myConfig,
+      name: "Luke",
+    };
+
+    fetchMock.putOnce(
+      {
+        url: "/api/v2/my/config-write",
+        headers: {
+          "Content-Type": "application/myconfig+json",
+        },
+        body: lukesConfig,
+      },
+      {
+        status: 204,
+      }
+    );
+
+    await act(() => {
+      update(lukesConfig);
+      return waitForNextUpdate();
+    });
+
+    expect(result.current.isUpdated).toBe(true);
+  });
+});

--- a/scm-ui/ui-api/src/configLink.ts
+++ b/scm-ui/ui-api/src/configLink.ts
@@ -1,0 +1,82 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { useMutation, useQuery } from "react-query";
+import { apiClient } from "./apiclient";
+import { useCallback } from "react";
+import { HalRepresentation, Link } from "@scm-manager/ui-types";
+
+type Result<C extends HalRepresentation> = {
+  contentType: string;
+  configuration: C;
+};
+
+type MutationVariables<C extends HalRepresentation> = {
+  configuration: C;
+  contentType: string;
+  link: string;
+};
+
+export const useConfigLink = <C extends HalRepresentation>(link: string) => {
+  const { isLoading, error, data } = useQuery<Result<C>, Error>(["configLink", link], () =>
+    apiClient.get(link).then((response) => {
+      const contentType = response.headers.get("Content-Type") || "application/json";
+      return response.json().then((configuration: C) => ({ configuration, contentType }));
+    })
+  );
+
+  const {
+    isLoading: isUpdating,
+    error: mutationError,
+    mutate,
+    data: updateResponse,
+  } = useMutation<Response, Error, MutationVariables<C>>((vars: MutationVariables<C>) =>
+    apiClient.put(vars.link, vars.configuration, vars.contentType)
+  );
+
+  const isReadOnly = !data?.configuration._links.update;
+
+  const update = useCallback(
+    (configuration: C) => {
+      if (data && !isReadOnly) {
+        mutate({
+          configuration,
+          contentType: data.contentType,
+          link: (data.configuration._links.update as Link).href,
+        });
+      }
+    },
+    [mutate, data, isReadOnly]
+  );
+
+  return {
+    isLoading,
+    isUpdating,
+    isReadOnly,
+    error: error || mutationError,
+    initialConfiguration: data?.configuration,
+    update,
+    isUpdated: !!updateResponse,
+  };
+};

--- a/scm-ui/ui-api/src/index.ts
+++ b/scm-ui/ui-api/src/index.ts
@@ -47,6 +47,7 @@ export * from "./sources";
 export * from "./import";
 export * from "./diff";
 export * from "./notifications";
+export * from "./configLink";
 
 export { default as ApiProvider } from "./ApiProvider";
 export * from "./ApiProvider";

--- a/scm-ui/ui-components/src/config/Configuration.tsx
+++ b/scm-ui/ui-components/src/config/Configuration.tsx
@@ -217,3 +217,5 @@ class Configuration extends React.Component<Props, State> {
 }
 
 export default withTranslation("config")(Configuration);
+
+

--- a/scm-ui/ui-components/src/config/Configuration.tsx
+++ b/scm-ui/ui-components/src/config/Configuration.tsx
@@ -21,201 +21,51 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import React, { FormEvent } from "react";
-import { WithTranslation, withTranslation } from "react-i18next";
-import { Links, Link } from "@scm-manager/ui-types";
-import { apiClient, Level, SubmitButton, Loading, ErrorNotification } from "../";
+import React, { FC, FormEvent, useState } from "react";
+import { HalRepresentation } from "@scm-manager/ui-types";
+import { useConfigLink } from "@scm-manager/ui-api";
+import ConfigurationForm from "./ConfigurationForm";
 
 type RenderProps = {
   readOnly: boolean;
-  initialConfiguration: ConfigurationType;
-  onConfigurationChange: (p1: ConfigurationType, p2: boolean) => void;
+  initialConfiguration: HalRepresentation;
+  onConfigurationChange: (configuration: HalRepresentation, valid: boolean) => void;
 };
 
-type Props = WithTranslation & {
+type Props = {
   link: string;
   render: (props: RenderProps) => any; // ???
 };
 
-type ConfigurationType = {
-  _links: Links;
-} & object;
+const Configuration: FC<Props> = ({ link, render }) => {
+  const { initialConfiguration, update, ...formProps } = useConfigLink<HalRepresentation>(link);
+  const [configuration, setConfiguration] = useState<HalRepresentation>();
+  const [isValid, setIsValid] = useState(false);
 
-type State = {
-  error?: Error;
-  fetching: boolean;
-  modifying: boolean;
-  contentType?: string | null;
-  configChanged: boolean;
+  const onConfigurationChange = (config: HalRepresentation, valid: boolean) => {
+    setConfiguration(config);
+    setIsValid(valid);
+  };
 
-  configuration?: ConfigurationType;
-  modifiedConfiguration?: ConfigurationType;
-  valid: boolean;
+  const onSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (configuration) {
+      update(configuration);
+    }
+  };
+
+  return (
+    <ConfigurationForm isValid={isValid} onSubmit={onSubmit} {...formProps}>
+      {initialConfiguration
+        ? render({
+            readOnly: formProps.isReadOnly,
+            initialConfiguration,
+            onConfigurationChange,
+          })
+        : null}
+    </ConfigurationForm>
+  );
 };
 
-/**
- * GlobalConfiguration uses the render prop pattern to encapsulate the logic for
- * synchronizing the configuration with the backend.
- */
-class Configuration extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      fetching: true,
-      modifying: false,
-      configChanged: false,
-      valid: false
-    };
-  }
-
-  componentDidMount() {
-    const { link } = this.props;
-
-    apiClient
-      .get(link)
-      .then(this.captureContentType)
-      .then(response => response.json())
-      .then(this.loadConfig)
-      .catch(this.handleError);
-  }
-
-  captureContentType = (response: Response) => {
-    const contentType = response.headers.get("Content-Type");
-    this.setState({
-      contentType
-    });
-    return response;
-  };
-
-  getContentType = (): string => {
-    const { contentType } = this.state;
-    return contentType ? contentType : "application/json";
-  };
-
-  handleError = (error: Error) => {
-    this.setState({
-      error,
-      fetching: false,
-      modifying: false
-    });
-  };
-
-  loadConfig = (configuration: ConfigurationType) => {
-    this.setState({
-      configuration,
-      fetching: false,
-      error: undefined
-    });
-  };
-
-  getModificationUrl = (): string | undefined => {
-    const { configuration } = this.state;
-    if (configuration) {
-      const links = configuration._links;
-      if (links && links.update) {
-        const link = links.update as Link;
-        return link.href;
-      }
-    }
-  };
-
-  isReadOnly = (): boolean => {
-    const modificationUrl = this.getModificationUrl();
-    return !modificationUrl;
-  };
-
-  configurationChanged = (configuration: ConfigurationType, valid: boolean) => {
-    this.setState({
-      modifiedConfiguration: configuration,
-      valid
-    });
-  };
-
-  modifyConfiguration = (event: FormEvent) => {
-    event.preventDefault();
-
-    this.setState({
-      modifying: true,
-      error: undefined
-    });
-
-    const { modifiedConfiguration } = this.state;
-
-    const modificationUrl = this.getModificationUrl();
-    if (modificationUrl) {
-      apiClient
-        .put(modificationUrl, modifiedConfiguration, this.getContentType())
-        .then(() =>
-          this.setState({
-            modifying: false,
-            configChanged: true,
-            valid: false
-          })
-        )
-        .catch(this.handleError);
-    } else {
-      this.setState({
-        error: new Error("no modification link available")
-      });
-    }
-  };
-
-  renderConfigChangedNotification = () => {
-    if (this.state.configChanged) {
-      return (
-        <div className="notification is-primary">
-          <button
-            className="delete"
-            onClick={() =>
-              this.setState({
-                configChanged: false
-              })
-            }
-          />
-          {this.props.t("config.form.submit-success-notification")}
-        </div>
-      );
-    }
-    return null;
-  };
-
-  render() {
-    const { t } = this.props;
-    const { fetching, error, configuration, modifying, valid } = this.state;
-
-    if (fetching || !configuration) {
-      return <Loading />;
-    } else {
-      const readOnly = this.isReadOnly();
-
-      const renderProps: RenderProps = {
-        readOnly,
-        initialConfiguration: configuration,
-        onConfigurationChange: this.configurationChanged
-      };
-
-      return (
-        <>
-          {this.renderConfigChangedNotification()}
-          <form onSubmit={this.modifyConfiguration}>
-            {this.props.render(renderProps)}
-            {error && (
-              <>
-                <hr />
-                <ErrorNotification error={error} />
-              </>
-            )}
-            <hr />
-            <Level
-              right={<SubmitButton label={t("config.form.submit")} disabled={!valid || readOnly} loading={modifying} />}
-            />
-          </form>
-        </>
-      );
-    }
-  }
-}
-
-export default withTranslation("config")(Configuration);
-
-
+export default Configuration;

--- a/scm-ui/ui-components/src/config/ConfigurationForm.tsx
+++ b/scm-ui/ui-components/src/config/ConfigurationForm.tsx
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-import React, { FC, FormEvent, useState } from "react";
+import React, { FC, FormEvent, useEffect, useState } from "react";
 import { ErrorNotification, Level, SubmitButton } from "../index";
 import { useTranslation } from "react-i18next";
 import Loading from "../Loading";
@@ -37,16 +37,19 @@ type Props = {
   onSubmit: (e: FormEvent<HTMLFormElement>) => void;
 };
 
-const ConfigurationChangedNotification: FC<{ initialConfigChanged: boolean }> = ({ initialConfigChanged }) => {
-  const [configChanged, setConfigChanged] = useState(initialConfigChanged);
+const ConfigurationChangedNotification: FC<{ configChanged: boolean }> = ({ configChanged }) => {
   const [t] = useTranslation("config");
+  const [hide, setHide] = useState(false);
+  useEffect(() => {
+    setHide(false);
+  }, [configChanged]);
 
-  if (!configChanged) {
+  if (!configChanged || hide) {
     return null;
   }
   return (
     <div className="notification is-primary">
-      <button className="delete" onClick={() => setConfigChanged(false)} />
+      <button className="delete" onClick={() => setHide(true)} />
       {t("config.form.submit-success-notification")}
     </div>
   );
@@ -70,7 +73,7 @@ const ConfigurationForm: FC<Props> = ({
 
   return (
     <form onSubmit={onSubmit}>
-      <ConfigurationChangedNotification initialConfigChanged={isUpdated} />
+      <ConfigurationChangedNotification configChanged={isUpdated} />
       {children}
       {error && (
         <>

--- a/scm-ui/ui-components/src/config/ConfigurationForm.tsx
+++ b/scm-ui/ui-components/src/config/ConfigurationForm.tsx
@@ -1,0 +1,89 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import React, { FC, FormEvent, useState } from "react";
+import { ErrorNotification, Level, SubmitButton } from "../index";
+import { useTranslation } from "react-i18next";
+import Loading from "../Loading";
+
+type Props = {
+  isUpdating: boolean;
+  isUpdated: boolean;
+  isReadOnly: boolean;
+  isLoading: boolean;
+  isValid: boolean;
+  error?: Error | null;
+  onSubmit: (e: FormEvent<HTMLFormElement>) => void;
+};
+
+const ConfigurationChangedNotification: FC<{ initialConfigChanged: boolean }> = ({ initialConfigChanged }) => {
+  const [configChanged, setConfigChanged] = useState(initialConfigChanged);
+  const [t] = useTranslation("config");
+
+  if (!configChanged) {
+    return null;
+  }
+  return (
+    <div className="notification is-primary">
+      <button className="delete" onClick={() => setConfigChanged(false)} />
+      {t("config.form.submit-success-notification")}
+    </div>
+  );
+};
+
+const ConfigurationForm: FC<Props> = ({
+  isLoading,
+  isReadOnly,
+  isValid,
+  isUpdating,
+  isUpdated,
+  error,
+  onSubmit,
+  children,
+}) => {
+  const [t] = useTranslation("config");
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  return (
+    <form onSubmit={onSubmit}>
+      <ConfigurationChangedNotification initialConfigChanged={isUpdated} />
+      {children}
+      {error && (
+        <>
+          <hr />
+          <ErrorNotification error={error} />
+        </>
+      )}
+      <hr />
+      <Level
+        right={<SubmitButton label={t("config.form.submit")} disabled={!isValid || isReadOnly} loading={isUpdating} />}
+      />
+    </form>
+  );
+};
+
+export default ConfigurationForm;

--- a/scm-ui/ui-components/src/config/index.ts
+++ b/scm-ui/ui-components/src/config/index.ts
@@ -24,3 +24,4 @@
 
 export { default as ConfigurationBinder } from "./ConfigurationBinder";
 export { default as Configuration } from "./Configuration";
+export { default as ConfigurationForm } from "./ConfigurationForm";


### PR DESCRIPTION
## Proposed changes

This change introduces a new hook `useConfigLink` and a new component `ConfigurationForm`.
These combination should replace the old `Configuration` component, which is not typed and which could not be used with react-hook-form. A new configuration form could like the following:

```tsx
type Sample = HalRepresentation & {
  firstName: string;
  lastName: string;
};

const SampleConfiguration: FC<Props> = ({ link }) => {
  const { initialConfiguration, update, ...formProps } = useConfigLink<Sample>(link);
  const { register, formState, handleSubmit } = useForm<Sample>();

  return (
    <ConfigurationForm isValid={formState.isValid} onSubmit={handleSubmit(update)} {...formProps}>
      <InputField label="First Name" {...register("firstName")} />
      <InputField label="Last Name" {...register("lastName")} />
    </ConfigurationForm>
  );
};
```

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
