### PR TITLE
Fix tag position for repos with fav star

### DIFF
--- a/gradle/changelog/repository_tag_position.yaml
+++ b/gradle/changelog/repository_tag_position.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Tag position for repository ([#1691](https://github.com/scm-manager/scm-manager/pull/1691))

--- a/scm-ui/ui-webapp/src/repos/containers/RepositoryRoot.tsx
+++ b/scm-ui/ui-webapp/src/repos/containers/RepositoryRoot.tsx
@@ -61,7 +61,7 @@ import TagRoot from "../tags/container/TagRoot";
 import { useIndexLinks, useRepository } from "@scm-manager/ui-api";
 import styled from "styled-components";
 
-const TagGroup = styled.div`
+const TagGroup = styled.span`
   font-weight: bold;
   & > * {
     margin-right: 0.25rem;


### PR DESCRIPTION
## Proposed changes

Fixes the position of repository tags (like 'archived')
when the extension point `repository.afterTitle` is bound
(for example in the landing page plugin with the fav star).

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
