### PR TITLE
Add support for basic authentication with access token

### DIFF
--- a/gradle/changelog/basic_auth_with_access_token.yaml
+++ b/gradle/changelog/basic_auth_with_access_token.yaml
@@ -1,0 +1,2 @@
+- type: added
+  description: Support basic authentication with access token ([#1694](https://github.com/scm-manager/scm-manager/pulls/1694))


### PR DESCRIPTION
## Proposed changes

A special user __bearer_token with a valid access token as password can be used with basic authentication.

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
