### PR TITLE
Clear caches if gpg key was added or deleted

### DIFF
--- a/gradle/changelog/invalidate_caches_for_gpg_keys.yaml
+++ b/gradle/changelog/invalidate_caches_for_gpg_keys.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Clear related caches if gpg key was added or deleted ([#1701](https://github.com/scm-manager/scm-manager/pull/1701))

--- a/scm-core/src/main/java/sonia/scm/repository/api/RepositoryServiceFactory.java
+++ b/scm-core/src/main/java/sonia/scm/repository/api/RepositoryServiceFactory.java
@@ -369,12 +369,17 @@ public final class RepositoryServiceFactory {
 
     @Subscribe
     public void onEvent(PublicKeyDeletedEvent event) {
-      cacheManager.getCache(LogCommandBuilder.CACHE_NAME).clear();
+      invalidateCachesForChangedPublicKeys();
     }
 
     @Subscribe
     public void onEvent(PublicKeyCreatedEvent event) {
+      invalidateCachesForChangedPublicKeys();
+    }
+
+    private void invalidateCachesForChangedPublicKeys() {
       cacheManager.getCache(LogCommandBuilder.CACHE_NAME).clear();
+      cacheManager.getCache(TagsCommandBuilder.CACHE_NAME).clear();
     }
 
     @SuppressWarnings({"unchecked", "java:S3740", "rawtypes"})


### PR DESCRIPTION
## Proposed changes

Clear more caches if GPG key was added or deleted. It seems quite difficult to find the right way to invalidate partial caches so for now we keep purging everything. 

Maybe we could add an API to efficiently find out what parts of the cache can be removed.

Fixes #1668 

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
