### PR TITLE
Prevent overwrite read only gpg keys

### DIFF
--- a/gradle/changelog/prevent_overwrite_read_only_gpg_keys.yaml
+++ b/gradle/changelog/prevent_overwrite_read_only_gpg_keys.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Prevent overwrite read-only gpg keys ([#1713](https://github.com/scm-manager/scm-manager/pull/1713))

--- a/scm-webapp/src/test/java/sonia/scm/security/gpg/PublicKeyStoreTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/security/gpg/PublicKeyStoreTest.java
@@ -169,6 +169,19 @@ class PublicKeyStoreTest {
     verify(eventBus, never()).post(any(PublicKeyDeletedEvent.class));
   }
 
+  @Test()
+  void shouldThrowOnOverwriteReadonlyKey() throws IOException {
+    String rawKey = GPGTestHelper.readResourceAsString("single.asc");
+    keyStore.add("SCM Package Key", "trillian", rawKey, true);
+    Optional<RawGpgKey> key = keyStore.findById("0x975922F193B07D6E");
+
+    assertThat(key).isPresent();
+
+    assertThrows(DeletingReadonlyKeyNotAllowedException.class, () -> keyStore.add("Some other entry with same raw key", "trillian", rawKey, false));
+
+    verify(eventBus, never()).post(any(PublicKeyDeletedEvent.class));
+  }
+
   @Test
   void shouldReturnEmptyListIfNoKeysAvailable() {
     List<RawGpgKey> keys = keyStore.findByUsername("zaphod");


### PR DESCRIPTION
## Proposed changes

It was possible to download the default SCM-Manager gpg keys and overwrite them with the same raw key. This made the new key deletable. This behaviour is not longer possible.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
