### PR TITLE
Fix overflow of quick search results with long repository names

### DIFF
--- a/gradle/changelog/quicksearch_overflow.yaml
+++ b/gradle/changelog/quicksearch_overflow.yaml
@@ -1,0 +1,2 @@
+- type: Fixed
+  description: Fix overflow of quick search results with long repository names ([#1739](https://github.com/scm-manager/scm-manager/pull/1739))

--- a/scm-ui/ui-webapp/src/containers/OmniSearch.tsx
+++ b/scm-ui/ui-webapp/src/containers/OmniSearch.tsx
@@ -101,6 +101,10 @@ const ResultHeading = styled.div`
   padding: 0.375rem 0.5rem;
 `;
 
+const DropdownMenu = styled.div`
+  max-width: 20rem;
+`;
+
 const Hits: FC<HitsProps> = ({ hits, index, clear }) => {
   const id = useCallback(namespaceAndName, [hits]);
   const [t] = useTranslation("commons");
@@ -115,7 +119,10 @@ const Hits: FC<HitsProps> = ({ hits, index, clear }) => {
       {hits.map((hit, idx) => (
         <div key={id(hit)} onMouseDown={(e) => e.preventDefault()} onClick={clear}>
           <Link
-            className={classNames("dropdown-item", "has-text-weight-medium", { "is-active": idx === index })}
+            className={classNames("dropdown-item", "has-text-weight-medium", "is-ellipsis-overflow", {
+              "is-active": idx === index,
+            })}
+            title={id(hit)}
             to={`/repo/${id(hit)}`}
           >
             {id(hit)}
@@ -195,7 +202,7 @@ const useShowResultsOnFocus = () => {
     showResults,
     onClick: (e: MouseEvent<HTMLInputElement>) => e.stopPropagation(),
     onFocus: () => setShowResults(true),
-    onBlur: () => setShowResults(false)
+    onBlur: () => setShowResults(false),
   };
 };
 
@@ -234,10 +241,10 @@ const OmniSearch: FC = () => {
               </span>
             )}
           </div>
-          <div className="dropdown-menu">
+          <DropdownMenu className="dropdown-menu">
             {error ? <SearchErrorNotification error={error} /> : null}
             {!error && data ? <Hits clear={clearQuery} index={index} hits={data._embedded.hits} /> : null}
-          </div>
+          </DropdownMenu>
         </div>
       </div>
     </Field>


### PR DESCRIPTION
## Proposed changes

Fixes overflow of quick search results with long repository names.

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
