### PR TITLE
Fix hg fileview resolves for same path on file and directory

### DIFF
--- a/gradle/changelog/hg_fileview_command.yaml
+++ b/gradle/changelog/hg_fileview_command.yaml
@@ -1,0 +1,2 @@
+- type: Fixed
+  description: Fix file detection on hg fileview command ([#1746](https://github.com/scm-manager/scm-manager/pull/1746))

--- a/scm-plugins/scm-hg-plugin/src/main/resources/sonia/scm/python/fileview.py
+++ b/scm-plugins/scm-hg-plugin/src/main/resources/sonia/scm/python/fileview.py
@@ -58,7 +58,7 @@ class File_Collector:
 
   def collect(self, paths, path = "", dir_only = False):
     for p in paths:
-      if p.startswith(path):
+      if p.startswith(path + b"/") or path == b"":
         self.attach(self.extract_name_without_parent(path, p), self.structure, dir_only)
 
   def attach(self, branch, trunk, dir_only = False):

--- a/scm-plugins/scm-hg-plugin/src/main/resources/sonia/scm/python/fileview_test.py
+++ b/scm-plugins/scm-hg-plugin/src/main/resources/sonia/scm/python/fileview_test.py
@@ -186,6 +186,21 @@ class Test_File_Viewer(unittest.TestCase):
     d = collector[0][1]
     self.assertDirectory(d, "d")
 
+  # https://github.com/scm-manager/scm-manager/issues/1719
+  def test_with_folder_and_file_same_name(self):
+    files = ["folder/ThisIsIt/ThisIsIt.sln", "folder/ThisIsIt/ThisIsIt/ThisIsIt.csproj"]
+    root = self.collect(files)
+    self.assertChildren(root, ["folder"])
+
+    root = self.collect(files, "folder")
+    self.assertChildren(root, ["folder/ThisIsIt"])
+
+    root = self.collect(files, "folder/ThisIsIt")
+    self.assertChildren(root, ["folder/ThisIsIt/ThisIsIt", "folder/ThisIsIt/ThisIsIt.sln"])
+
+    root = self.collect(files, "folder/ThisIsIt/ThisIsIt")
+    self.assertChildren(root, ["folder/ThisIsIt/ThisIsIt/ThisIsIt.csproj"])
+
 
   def collect(self, paths, path = "", recursive = False):
     revCtx = DummyRevContext(paths)

--- a/scm-ui/ui-webapp/src/repos/sources/containers/Sources.tsx
+++ b/scm-ui/ui-webapp/src/repos/sources/containers/Sources.tsx
@@ -26,7 +26,7 @@ import { useTranslation } from "react-i18next";
 import { useHistory, useLocation, useParams } from "react-router-dom";
 import { useSources } from "@scm-manager/ui-api";
 import { Branch, Repository } from "@scm-manager/ui-types";
-import { Breadcrumb, Loading, Notification } from "@scm-manager/ui-components";
+import { Breadcrumb, ErrorNotification, Loading, Notification } from "@scm-manager/ui-components";
 import FileTree from "../components/FileTree";
 import Content from "./Content";
 import CodeActionBar from "../../codeSection/components/CodeActionBar";
@@ -79,6 +79,10 @@ const Sources: FC<Props> = ({ repository, branches, selectedBranch, baseUrl }) =
     // expect if we have no branches (svn)
     enabled: !branches || !!selectedBranch,
   });
+
+  if (error) {
+    return <ErrorNotification error={error} />;
+  }
 
   if (isLoading || (!error && !file)) {
     return <Loading />;


### PR DESCRIPTION
## Proposed changes

Fixes #1744 & #1719

If a file and a directory with the same name existed somewhere at the same level in a Mercurial repository, our logic in the fileview command failed to collect them. The parent of the file was mistaken for the entire file path, resulting in confusing errors that the file could not be found in the manifest. With this fix, file detection should now be more secure than before.

To reproduce the error follow the instructions in issue #1719 

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
