### PR TITLE
Filter master branch correctly on initial mirror

### DIFF
--- a/gradle/changelog/master_on_initial_mirror.yaml
+++ b/gradle/changelog/master_on_initial_mirror.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Handle rejected master branch on initial mirror synchronization correctly ([#1747](https://github.com/scm-manager/scm-manager/pull/1747))


### PR DESCRIPTION
## Proposed changes

On the first synchronization, the clone has the implicit branch "master". This cannot be
changed in JGit. When we fetch the refs from the repository that should be mirrored, the
master branch of the clone will be updated to the revision of the remote repository (if
it has a master branch). If now the master branch shall be filtered from mirroring (ie.
if it is rejected), we normally would delete the ref in this clone. But because it is
the current branch, it cannot be deleted. We detect this, set this variable to
{@code true}, and later, after we have pushed the result, delete the master branch by
pushing an empty ref to the central repository.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] New code is covered with unit tests
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
