### PR TITLE
Add bounding box for plugin avatar

### DIFF
--- a/gradle/changelog/plugin_logo.yaml
+++ b/gradle/changelog/plugin_logo.yaml
@@ -1,0 +1,2 @@
+- type: Added
+  description: Add bounding box for plugin avatar ([#1749](https://github.com/scm-manager/scm-manager/pull/1749))

--- a/scm-ui/ui-webapp/src/admin/plugins/components/PluginAvatar.tsx
+++ b/scm-ui/ui-webapp/src/admin/plugins/components/PluginAvatar.tsx
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 import React from "react";
+import styled from "styled-components";
 import { ExtensionPoint } from "@scm-manager/ui-extensions";
 import { Plugin } from "@scm-manager/ui-types";
 import { Image } from "@scm-manager/ui-components";
@@ -30,20 +31,28 @@ type Props = {
   plugin: Plugin;
 };
 
+const BoundingBox = styled.p`
+  img {
+    object-fit: contain;
+    height: 64px;
+    width: 64px;
+  }
+`;
+
 export default class PluginAvatar extends React.Component<Props> {
   render() {
     const { plugin } = this.props;
     return (
-      <p className="image is-64x64">
+      <BoundingBox className="image is-64x64">
         <ExtensionPoint
           name="plugins.plugin-avatar"
           props={{
-            plugin
+            plugin,
           }}
         >
           <Image src={plugin.avatarUrl ? plugin.avatarUrl : "/images/blib.jpg"} alt="Logo" />
         </ExtensionPoint>
-      </p>
+      </BoundingBox>
     );
   }
 }


### PR DESCRIPTION
## Proposed changes

A bounding box must be specified so that no image overlaps the defined avatar area.

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
