### PR TITLE
Fix search with best guess query containing hyphen

### DIFF
--- a/gradle/changelog/query_with_hypen.yaml
+++ b/gradle/changelog/query_with_hypen.yaml
@@ -1,0 +1,2 @@
+- type: Fixed
+  description: Fixed search queries containing hypens ([#1743](https://github.com/scm-manager/scm-manager/issues/1743) and [#1753](https://github.com/scm-manager/scm-manager/pull/1753))

--- a/scm-webapp/src/test/java/sonia/scm/search/LuceneQueryBuilderTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/search/LuceneQueryBuilderTest.java
@@ -63,6 +63,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("java:S5976")
 @SubjectAware(value = "trillian", permissions = "abc")
 @ExtendWith({MockitoExtension.class, ShiroExtension.class})
 class LuceneQueryBuilderTest {
@@ -104,6 +105,37 @@ class LuceneQueryBuilderTest {
     }
 
     QueryResult result = query(Person.class, "Trill");
+    assertThat(result.getTotalHits()).isOne();
+  }
+
+  @Test
+  void shouldMatchWithHyphen() throws IOException {
+    try (IndexWriter writer = writer()) {
+      writer.addDocument(personDoc("Trillian-McMillan"));
+    }
+
+    QueryResult result = query(Person.class, "Trillian-McMi");
+    assertThat(result.getTotalHits()).isOne();
+  }
+
+  @Test
+  void shouldMatchQueryWithMultipleFieldsAndHyphen() throws IOException {
+    try (IndexWriter writer = writer()) {
+      writer.addDocument(inetOrgPersonDoc("Trillian", "McMillan", "Trillian McMillan", "abc"));
+    }
+
+    QueryResult result = query(InetOrgPerson.class, "Trillian-McMi");
+    assertThat(result.getTotalHits()).isOne();
+  }
+
+
+  @Test
+  void shouldMatchExpertQueryWithHyphen() throws IOException {
+    try (IndexWriter writer = writer()) {
+      writer.addDocument(personDoc("Trillian-McMillan"));
+    }
+
+    QueryResult result = query(Person.class, "lastName:Trillian-McMi");
     assertThat(result.getTotalHits()).isOne();
   }
 


### PR DESCRIPTION
## Proposed changes

Split searched best guess query into single wildcard query terms.

Fixes #1743

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] New code is covered with unit tests
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
