### PR TITLE
Allow enrichment of embedded repositories on search hits

### DIFF
--- a/scm-core/src/main/java/sonia/scm/api/v2/resources/HalAppenderMapper.java
+++ b/scm-core/src/main/java/sonia/scm/api/v2/resources/HalAppenderMapper.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.api.v2.resources;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -49,11 +49,14 @@ public class HalAppenderMapper {
       }
 
       HalEnricherContext context = HalEnricherContext.of(ctx);
+      applyEnrichers(context, appender, source.getClass());
+    }
+  }
 
-      Iterable<HalEnricher> enrichers = registry.allByType(source.getClass());
-      for (HalEnricher enricher : enrichers) {
-        enricher.enrich(context, appender);
-      }
+  protected void applyEnrichers(HalEnricherContext context, HalAppender appender, Class<?> type) {
+    Iterable<HalEnricher> enrichers = registry.allByType(type);
+    for (HalEnricher enricher : enrichers) {
+      enricher.enrich(context, appender);
     }
   }
 

--- a/scm-core/src/main/java/sonia/scm/api/v2/resources/HalEnricherContext.java
+++ b/scm-core/src/main/java/sonia/scm/api/v2/resources/HalEnricherContext.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.api.v2.resources;
 
 import com.google.common.collect.ImmutableMap;
@@ -39,9 +39,9 @@ import java.util.Optional;
  */
 public final class HalEnricherContext {
 
-  private final Map<Class, Object> instanceMap;
+  private final Map<Class<?>, Object> instanceMap;
 
-  private HalEnricherContext(Map<Class,Object> instanceMap) {
+  private HalEnricherContext(Map<Class<?>,Object> instanceMap) {
     this.instanceMap = instanceMap;
   }
 
@@ -53,11 +53,20 @@ public final class HalEnricherContext {
    * @return context of given entries
    */
   public static HalEnricherContext of(Object... instances) {
-    ImmutableMap.Builder<Class, Object> builder = ImmutableMap.builder();
+    ImmutableMap.Builder<Class<?>, Object> builder = ImmutableMap.builder();
     for (Object instance : instances) {
       builder.put(instance.getClass(), instance);
     }
     return new HalEnricherContext(builder.build());
+  }
+
+  /**
+   * Return builder for {@link HalEnricherContext}.
+   * @return builder
+   * @since 2.23.0
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 
   /**
@@ -91,6 +100,37 @@ public final class HalEnricherContext {
     } else {
       throw new NoSuchElementException("No instance for given type present");
     }
+  }
+
+  /**
+   * Builder for {@link HalEnricherContext}.
+   *
+   * @since 2.23.0
+   */
+  public static class Builder {
+
+    private final ImmutableMap.Builder<Class<?>, Object> mapBuilder = ImmutableMap.builder();
+
+    /**
+     * Add an entry with the given type to the context.
+     * @param type type of the object
+     * @param object object
+     * @param <T> type of object
+     * @return {@code this}
+     */
+    public <T> Builder put(Class<? super T> type, T object) {
+      mapBuilder.put(type, object);
+      return this;
+    }
+
+    /**
+     * Returns the {@link HalEnricherContext}.
+     * @return context
+     */
+    public HalEnricherContext build() {
+      return new HalEnricherContext(mapBuilder.build());
+    }
+
   }
 
 }

--- a/scm-core/src/main/java/sonia/scm/repository/Repository.java
+++ b/scm-core/src/main/java/sonia/scm/repository/Repository.java
@@ -64,7 +64,7 @@ import java.util.Set;
     @Guard(guard = RepositoryPermissionGuard.class)
   }
 )
-public class Repository extends BasicPropertiesAware implements ModelObject, PermissionObject {
+public class Repository extends BasicPropertiesAware implements ModelObject, PermissionObject, RepositoryCoordinates {
 
   private static final long serialVersionUID = 3486560714961909711L;
 
@@ -190,11 +190,12 @@ public class Repository extends BasicPropertiesAware implements ModelObject, Per
     return lastModified;
   }
 
-
+  @Override
   public String getName() {
     return name;
   }
 
+  @Override
   public String getNamespace() {
     return namespace;
   }

--- a/scm-core/src/main/java/sonia/scm/repository/RepositoryCoordinates.java
+++ b/scm-core/src/main/java/sonia/scm/repository/RepositoryCoordinates.java
@@ -1,0 +1,54 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.repository;
+
+import sonia.scm.TypedObject;
+
+/**
+ * Coordinates to identify a repository.
+ *
+ * @since 2.23.0
+ */
+public interface RepositoryCoordinates extends TypedObject {
+
+  /**
+   * Returns the internal id of the repository.
+   * @return internal id
+   */
+  String getId();
+
+  /**
+   * Returns the namespace of the repository.
+   *
+   * @return namespace
+   */
+  String getNamespace();
+
+  /**
+   * Returns the name of the repository.
+   * @return name
+   */
+  String getName();
+}

--- a/scm-ui/ui-types/src/Search.ts
+++ b/scm-ui/ui-types/src/Search.ts
@@ -22,7 +22,8 @@
  * SOFTWARE.
  */
 
-import { HalRepresentation, PagedCollection } from "./hal";
+import { HalRepresentationWithEmbedded, PagedCollection } from "./hal";
+import { Repository } from "./Repositories";
 
 export type ValueHitField = {
   highlighted: false;
@@ -36,7 +37,11 @@ export type HighlightedHitField = {
 
 export type HitField = ValueHitField | HighlightedHitField;
 
-export type Hit = HalRepresentation & {
+export type EmbeddedRepository = {
+  repository?: Repository;
+};
+
+export type Hit = HalRepresentationWithEmbedded<EmbeddedRepository> & {
   score: number;
   fields: { [name: string]: HitField };
 };

--- a/scm-ui/ui-webapp/src/containers/OmniSearch.tsx
+++ b/scm-ui/ui-webapp/src/containers/OmniSearch.tsx
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 import React, { FC, KeyboardEvent as ReactKeyboardEvent, MouseEvent, useCallback, useState, useEffect } from "react";
-import { Hit, Links, Repository, ValueHitField } from "@scm-manager/ui-types";
+import { Hit, Links, ValueHitField } from "@scm-manager/ui-types";
 import styled from "styled-components";
 import { BackendError, useSearch } from "@scm-manager/ui-api";
 import classNames from "classnames";
@@ -130,17 +130,10 @@ const AvatarSection: FC<HitProps> = ({ hit }) => {
   const name = useStringHitFieldValue(hit, "name");
   const type = useStringHitFieldValue(hit, "type");
 
-  if (!namespace || !name || !type) {
+  const repository = hit._embedded.repository;
+  if (!namespace || !name || !type || !repository) {
     return null;
   }
-
-  const repository: Repository = {
-    namespace,
-    name,
-    type,
-    _links: {},
-    _embedded: hit._embedded,
-  };
 
   return (
     <span className="mr-2">
@@ -278,7 +271,8 @@ const useShowResultsOnFocus = () => {
       };
 
       const onKeyUp = (e: KeyboardEvent) => {
-        if (e.which === 9) { // tab
+        if (e.which === 9) {
+          // tab
           const element = document.activeElement;
           if (!element || !isOnmiSearchElement(element)) {
             close();

--- a/scm-ui/ui-webapp/src/search/RepositoryHit.tsx
+++ b/scm-ui/ui-webapp/src/search/RepositoryHit.tsx
@@ -23,7 +23,6 @@
  */
 
 import React, { FC } from "react";
-import { Repository } from "@scm-manager/ui-types";
 import { Link } from "react-router-dom";
 import {
   useDateHitFieldValue,
@@ -43,17 +42,12 @@ const RepositoryHit: FC<HitProps> = ({ hit }) => {
   const creationDate = useDateHitFieldValue(hit, "creationDate");
   const date = lastModified || creationDate;
 
-  if (!namespace || !name || !type) {
+  // the embedded repository is only a subset of the repository (RepositoryCoordinates),
+  // so we should use the fields to get more information
+  const repository = hit._embedded.repository;
+  if (!namespace || !name || !type || !repository) {
     return null;
   }
-
-  const repository: Repository = {
-    namespace,
-    name,
-    type,
-    _links: {},
-    _embedded: hit._embedded,
-  };
 
   return (
     <Hit>


### PR DESCRIPTION
## Proposed changes

Add enricher support for embedded repositories by applying enricher for  RepositoryCoordinates.
RepositoryCoordinates will be used instead of the normal repository for the enrichment of the embedded repositories. This is required to avoid a large set of unwanted enrichments which are targeting the normal repository.

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] New code is covered with unit tests

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
