### PR TITLE
Add DefaultBranchChangedEvent

### DIFF
--- a/gradle/changelog/default_branch_changed_event.yaml
+++ b/gradle/changelog/default_branch_changed_event.yaml
@@ -1,0 +1,2 @@
+- type: Added
+  description: Event which is fired whenever the default branch of a repository changes ([#1763](https://github.com/scm-manager/scm-manager/pull/1763))

--- a/scm-core/src/main/java/sonia/scm/repository/DefaultBranchChangedEvent.java
+++ b/scm-core/src/main/java/sonia/scm/repository/DefaultBranchChangedEvent.java
@@ -22,31 +22,22 @@
  * SOFTWARE.
  */
 
-package sonia.scm.api.v2.resources;
+package sonia.scm.repository;
 
-import com.github.legman.Subscribe;
-import sonia.scm.EagerSingleton;
-import sonia.scm.event.ScmEventBus;
-import sonia.scm.plugin.Extension;
-import sonia.scm.repository.ClearRepositoryCacheEvent;
-import sonia.scm.repository.RepositoryModificationEvent;
+import lombok.Value;
+import sonia.scm.event.Event;
 
-import java.util.Objects;
+/**
+ * Event is fired whenever the default branch of a repository was modified.
+ *
+ * @since 2.23.0
+ */
+@Event
+@Value
+public class DefaultBranchChangedEvent {
 
-@Extension
-@EagerSingleton
-public class GitRepositoryConfigChangeClearRepositoryCacheListener {
+  Repository repository;
+  String oldDefaultBranch;
+  String newDefaultBranch;
 
-  /**
-   * Receives {@link RepositoryModificationEvent} and fires a {@link ClearRepositoryCacheEvent} if
-   * the default branch of a git repository was modified.
-   *
-   * @param event repository modification event
-   */
-  @Subscribe
-  public void sendClearRepositoryCacheEvent(GitRepositoryConfigChangedEvent event) {
-    if (!Objects.equals(event.getOldConfig().getDefaultBranch(), event.getNewConfig().getDefaultBranch())) {
-      ScmEventBus.getInstance().post(new ClearRepositoryCacheEvent(event.getRepository()));
-    }
-  }
 }

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/GitRepositoryModifyListener.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/GitRepositoryModifyListener.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.repository;
 
 import com.github.legman.Subscribe;
@@ -51,12 +51,6 @@ public class GitRepositoryModifyListener {
     this.storeProvider = storeProvider;
   }
 
-  /**
-   * Receives {@link RepositoryModificationEvent} and fires a {@link ClearRepositoryCacheEvent} if
-   * the default branch of a git repository was modified.
-   *
-   * @param event repository modification event
-   */
   @Subscribe
   public void handleEvent(GitRepositoryConfigChangedEvent event){
     Repository repository = event.getRepository();

--- a/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/DefaultBranchChangedDispatcherTest.java
+++ b/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/DefaultBranchChangedDispatcherTest.java
@@ -1,0 +1,87 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.repository;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sonia.scm.api.v2.resources.GitRepositoryConfigChangedEvent;
+import sonia.scm.event.ScmEventBus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultBranchChangedDispatcherTest {
+
+  @Mock
+  private ScmEventBus eventBus;
+
+  @InjectMocks
+  private DefaultBranchChangedDispatcher dispatcher;
+
+  @Captor
+  private ArgumentCaptor<Object> eventCaptor;
+
+  private final Repository repository = RepositoryTestData.createHeartOfGold();
+
+  @Test
+  void shouldFireDefaultBranchChangedEvent() {
+    dispatcher.handleConfigUpdate(changedEvent("master", "main"));
+
+    verify(eventBus).post(eventCaptor.capture());
+    assertThat(eventCaptor.getValue())
+      .isInstanceOfSatisfying(DefaultBranchChangedEvent.class, event -> {
+        assertThat(event.getRepository()).isSameAs(repository);
+        assertThat(event.getOldDefaultBranch()).isEqualTo("master");
+        assertThat(event.getNewDefaultBranch()).isEqualTo("main");
+      });
+  }
+
+  @Test
+  void shouldNotFireEventIfDefaultBranchHasNotChanged() {
+    dispatcher.handleConfigUpdate(changedEvent("develop", "develop"));
+
+    verifyNoInteractions(eventBus);
+  }
+
+  private GitRepositoryConfigChangedEvent changedEvent(String oldDefaultBranch, String newDefaultBranch) {
+    return new GitRepositoryConfigChangedEvent(
+      repository, config(oldDefaultBranch), config(newDefaultBranch)
+    );
+  }
+
+  private GitRepositoryConfig config(String defaultBranch) {
+    GitRepositoryConfig config = new GitRepositoryConfig();
+    config.setDefaultBranch(defaultBranch);
+    return config;
+  }
+
+}


### PR DESCRIPTION
## Proposed changes

The DefaultBranchChangedEvent is fired whenever the default branch of repository changes.

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] New code is covered with unit tests
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
