### PR TITLE
Keep search result type if searched from result page

### DIFF
--- a/gradle/changelog/keep_type_on_search.yaml
+++ b/gradle/changelog/keep_type_on_search.yaml
@@ -1,0 +1,2 @@
+- type: Changed
+  description: Keep search result type if searched from result page ([#1764](https://github.com/scm-manager/scm-manager/pull/1764))

--- a/scm-ui/ui-components/src/search/Hit.tsx
+++ b/scm-ui/ui-components/src/search/Hit.tsx
@@ -42,7 +42,7 @@ type SearchResultType = FC & {
 };
 
 const Hit: SearchResultType = ({ children }) => {
-  return <article className="media p-1">{children}</article>;
+  return <article className="media">{children}</article>;
 };
 
 Hit.Title = ({ className, children }) => (

--- a/scm-ui/ui-components/src/search/TextHitField.tsx
+++ b/scm-ui/ui-components/src/search/TextHitField.tsx
@@ -49,15 +49,17 @@ const HighlightedTextField: FC<HighlightedTextFieldProps> = ({ field }) => (
   </>
 );
 
-const TextHitField: FC<Props> = ({ hit, field: fieldName, truncateValueAt = 0 }) => {
+const TextHitField: FC<Props> = ({ hit, field: fieldName, children, truncateValueAt = 0 }) => {
   const field = hit.fields[fieldName];
   if (!field) {
-    return null;
+    return <>{children}</>;
   } else if (isHighlightedHitField(field)) {
     return <HighlightedTextField field={field} />;
   } else {
     let value = field.value;
-    if (typeof value === "string" && truncateValueAt > 0 && value.length > truncateValueAt) {
+    if (value === "") {
+      return <>{children}</>;
+    } else if (typeof value === "string" && truncateValueAt > 0 && value.length > truncateValueAt) {
       value = value.substring(0, truncateValueAt) + "...";
     }
     return <>{value}</>;

--- a/scm-ui/ui-webapp/src/containers/OmniSearch.tsx
+++ b/scm-ui/ui-webapp/src/containers/OmniSearch.tsx
@@ -26,7 +26,7 @@ import { Hit, Links, ValueHitField } from "@scm-manager/ui-types";
 import styled from "styled-components";
 import { BackendError, useSearch } from "@scm-manager/ui-api";
 import classNames from "classnames";
-import { Link, useHistory } from "react-router-dom";
+import { Link, useHistory, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {
   Button,
@@ -322,6 +322,23 @@ const useShowResultsOnFocus = () => {
   };
 };
 
+const useSearchType = () => {
+  const location = useLocation();
+  const pathname = location.pathname;
+
+  let type = "repository";
+  if (pathname.startsWith("/search/")) {
+    const path = pathname.substring("/search/".length);
+    const index = path.indexOf("/");
+    if (index > 0) {
+      type = path.substring(0, index);
+    } else {
+      type = path;
+    }
+  }
+  return type;
+};
+
 const OmniSearch: FC = () => {
   const [query, setQuery] = useState("");
   const debouncedQuery = useDebounce(query, 250);
@@ -329,13 +346,14 @@ const OmniSearch: FC = () => {
   const { showResults, hideResults, ...handlers } = useShowResultsOnFocus();
   const [showHelp, setShowHelp] = useState(false);
   const history = useHistory();
+  const searchType = useSearchType();
 
   const openHelp = () => setShowHelp(true);
   const closeHelp = () => setShowHelp(false);
   const clearQuery = () => setQuery("");
 
   const gotoDetailSearch = () => {
-    history.push(`/search/repository/?q=${query}`);
+    history.push(`/search/${searchType}/?q=${query}`);
     hideResults();
   };
 


### PR DESCRIPTION
## Proposed changes

Whenever OmniSearch was used, the user was redirected to the repository results. However, if you are looking for a different type and want to refine your search after the first results, it makes sense to stay on the same type when searching again.
So whenever a search is started from the search result page the selected type keeps selected.

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
