### PR TITLE
Adds pullSecret option and simplifies Image usage

### DIFF
--- a/scm-packaging/helm/src/main/chart/templates/deployment.yaml
+++ b/scm-packaging/helm/src/main/chart/templates/deployment.yaml
@@ -45,6 +45,10 @@ spec:
         app: {{ include "scm-manager.name" . }}
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.image.pullSecret }}
+      {{- end }}
       initContainers:
       - name: volume-permissions
         image: alpine:3.8
@@ -113,11 +117,11 @@ spec:
         emptyDir: {}
       {{- end }}
       - name: config
-        configMap: 
+        configMap:
           name: {{ include "scm-manager.fullname" . }}
       {{- if .Values.plugins }}
       - name: scripts
-        configMap: 
+        configMap:
           name: {{ include "scm-manager.fullname" . }}-scripts
       {{- end }}
       {{- with .Values.extraVolumes }}

--- a/scm-packaging/helm/src/main/chart/templates/deployment.yaml
+++ b/scm-packaging/helm/src/main/chart/templates/deployment.yaml
@@ -51,17 +51,21 @@ spec:
       {{- end }}
       initContainers:
       - name: volume-permissions
-        image: alpine:3.8
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: IfNotPresent
         command: ['sh', '-c', 'chown 1000:1000 /data']
+        securityContext:
+          runAsUser: 0
         volumeMounts:
         - name: data
           mountPath: /data
       {{- if .Values.plugins }}
       - name: install-plugins
-        image: alpine:3.8
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: IfNotPresent
         command: ['sh', '/scripts/install-plugins.sh']
+        securityContext:
+          runAsUser: 0
         volumeMounts:
         - name: data
           mountPath: /data

--- a/scm-packaging/helm/src/main/chart/values.yaml
+++ b/scm-packaging/helm/src/main/chart/values.yaml
@@ -33,6 +33,8 @@ image:
   tag: ${dockerTag}
   # image.pullPolicy -- SCM-Manager image pull policy
   pullPolicy: IfNotPresent
+  # imaage.pullSecret -- Secret with credentials for the image registry
+  # pullSecret: registry-credentials
 
 # nameOverride -- Override the resource name prefix
 nameOverride: ""

--- a/scm-packaging/helm/src/main/chart/values.yaml
+++ b/scm-packaging/helm/src/main/chart/values.yaml
@@ -33,7 +33,7 @@ image:
   tag: ${dockerTag}
   # image.pullPolicy -- SCM-Manager image pull policy
   pullPolicy: IfNotPresent
-  # imaage.pullSecret -- Secret with credentials for the image registry
+  # image.pullSecret -- Secret with credentials for the image registry
   # pullSecret: registry-credentials
 
 # nameOverride -- Override the resource name prefix


### PR DESCRIPTION
## Proposed changes

Adds a value field to set a Secret to pull the image from an image registry with authentication, in case you need to host the image yourself and your registry has authentication.

To simplify the configuration we set the `initContainers` to use the same image as the application itself.

This has the following advantages:
- No additional configuration for image and pull Secret in values needed
- The used image is always up-to-date now. No need to maintain an extra alpine image.
- Faster startup times. No extra images have to be pulled.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [ ] Feature has been tested with different permissions
- [x] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
