### PR TITLE
Fix branch selector display revision if selected instead of first branch

### DIFF
--- a/gradle/changelog/branch_selector.yaml
+++ b/gradle/changelog/branch_selector.yaml
@@ -1,0 +1,2 @@
+- type: Fixed
+  description: Branch selector display revision if selected instead of first branch ([#1767](https://github.com/scm-manager/scm-manager/pull/1767))

--- a/scm-ui/ui-components/src/BranchSelector.tsx
+++ b/scm-ui/ui-components/src/BranchSelector.tsx
@@ -64,6 +64,7 @@ const BranchSelector: FC<Props> = ({ branches, onSelectBranch, selectedBranch, l
                 onChange={(branch) => onSelectBranch(branches.filter((b) => b.name === branch)[0])}
                 disabled={!!disabled}
                 value={selectedBranch}
+                addValueToOptions={true}
               />
             </MinWidthControl>
           </NoBottomMarginField>

--- a/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
+++ b/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
@@ -56539,11 +56539,6 @@ Array [
         value="uscss-prometheus"
       >
         <option
-          value="uscss-prometheus"
-        >
-          uscss-prometheus
-        </option>
-        <option
           value="millennium-falcon"
         >
           Millennium Falcon
@@ -56593,6 +56588,46 @@ Array [
   <div
     className="mt-3"
   />,
+]
+`;
+
+exports[`Storyshots Forms|Select Preselect option 1`] = `
+Array [
+  <fieldset
+    className="field"
+  >
+    
+    <div
+      className="control select"
+    >
+      <select
+        onBlur={[Function]}
+        onChange={[Function]}
+        value="razor-crest"
+      >
+        <option
+          value="millennium-falcon"
+        >
+          Millennium Falcon
+        </option>
+        <option
+          value="razor-crest"
+        >
+          Razor Crest
+        </option>
+        <option
+          value="uscss-prometheus"
+        >
+          USCSS Prometheus
+        </option>
+      </select>
+    </div>
+  </fieldset>,
+  <div
+    className="mt-3"
+  >
+    razor-crest
+  </div>,
 ]
 `;
 

--- a/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
+++ b/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
@@ -56524,6 +56524,46 @@ exports[`Storyshots Forms|Radio With HelpText 1`] = `
 </div>
 `;
 
+exports[`Storyshots Forms|Select Add no existing value 1`] = `
+Array [
+  <fieldset
+    className="field"
+  >
+    
+    <div
+      className="control select"
+    >
+      <select
+        onBlur={[Function]}
+        onChange={[Function]}
+        value="uscss-prometheus"
+      >
+        <option
+          value="uscss-prometheus"
+        >
+          uscss-prometheus
+        </option>
+        <option
+          value="millennium-falcon"
+        >
+          Millennium Falcon
+        </option>
+        <option
+          value="razor-crest"
+        >
+          Razor Crest
+        </option>
+      </select>
+    </div>
+  </fieldset>,
+  <div
+    className="mt-3"
+  >
+    uscss-prometheus
+  </div>,
+]
+`;
+
 exports[`Storyshots Forms|Select Legacy Events 1`] = `
 Array [
   <fieldset

--- a/scm-ui/ui-components/src/forms/Select.stories.tsx
+++ b/scm-ui/ui-components/src/forms/Select.stories.tsx
@@ -170,9 +170,39 @@ const AddNoExistingValue: FC = () => {
   );
 };
 
+const PreselectOption: FC = () => {
+  const [value, setValue] = useState<string>("razor-crest");
+
+  return (
+    <>
+      <Select
+        options={[
+          {
+            label: "Millennium Falcon",
+            value: "millennium-falcon",
+          },
+          {
+            label: "Razor Crest",
+            value: "razor-crest",
+          },
+          {
+            label: "USCSS Prometheus",
+            value: "uscss-prometheus"
+          }
+        ]}
+        onChange={setValue}
+        value={value}
+      />
+      <div className="mt-3">{value}</div>
+    </>
+  );
+};
+
 storiesOf("Forms|Select", module)
   .addDecorator((storyFn) => <MemoryRouter>{storyFn()}</MemoryRouter>)
   .add("Add no existing value", () => <AddNoExistingValue />)
   .add("Ref", () => <Ref />)
   .add("Legacy Events", () => <LegacyEvents />)
-  .add("ReactHookForm", () => <ReactHookForm />);
+  .add("ReactHookForm", () => <ReactHookForm />)
+  .add("Preselect option", () => <PreselectOption />)
+;

--- a/scm-ui/ui-components/src/forms/Select.stories.tsx
+++ b/scm-ui/ui-components/src/forms/Select.stories.tsx
@@ -37,11 +37,11 @@ const Ref: FC = () => {
       <Select
         options={[
           { label: "foo", value: "true" },
-          { label: "bar", value: "false" }
+          { label: "bar", value: "false" },
         ]}
         value={selected}
         label={"Ref Radio Button"}
-        onChange={e => setSelected(e.target.value)}
+        onChange={(e) => setSelected(e.target.value)}
         ref={ref}
       />
       <Button
@@ -80,7 +80,7 @@ const ReactHookForm: FC = () => {
         <Select
           options={[
             { label: "Yes", value: "true" },
-            { label: "No", value: "false" }
+            { label: "No", value: "false" },
           ]}
           label="Remember Me"
           {...register("rememberMe")}
@@ -88,7 +88,7 @@ const ReactHookForm: FC = () => {
         <Select
           options={[
             { label: "Yes", value: "true" },
-            { label: "No", value: "false" }
+            { label: "No", value: "false" },
           ]}
           label="Scramble Password"
           {...register("scramblePassword")}
@@ -96,7 +96,7 @@ const ReactHookForm: FC = () => {
         <Select
           options={[
             { label: "Yes", value: "true" },
-            { label: "No", value: "false" }
+            { label: "No", value: "false" },
           ]}
           label="Disabled wont be submitted"
           defaultValue="false"
@@ -106,7 +106,7 @@ const ReactHookForm: FC = () => {
         <Select
           options={[
             { label: "Yes", value: "true" },
-            { label: "No", value: "false" }
+            { label: "No", value: "false" },
           ]}
           label="Readonly will be submitted"
           readOnly={true}
@@ -136,7 +136,7 @@ const LegacyEvents: FC = () => {
       <Select
         options={[
           { label: "Yes", value: "true" },
-          { label: "No", value: "false" }
+          { label: "No", value: "false" },
         ]}
         onChange={setValue}
       />
@@ -145,8 +145,34 @@ const LegacyEvents: FC = () => {
   );
 };
 
+const AddNoExistingValue: FC = () => {
+  const [value, setValue] = useState<string>("uscss-prometheus");
+
+  return (
+    <>
+      <Select
+        options={[
+          {
+            label: "Millennium Falcon",
+            value: "millennium-falcon",
+          },
+          {
+            label: "Razor Crest",
+            value: "razor-crest",
+          },
+        ]}
+        onChange={setValue}
+        addValueToOptions={true}
+        value={value}
+      />
+      <div className="mt-3">{value}</div>
+    </>
+  );
+};
+
 storiesOf("Forms|Select", module)
-  .addDecorator(storyFn => <MemoryRouter>{storyFn()}</MemoryRouter>)
+  .addDecorator((storyFn) => <MemoryRouter>{storyFn()}</MemoryRouter>)
+  .add("Add no existing value", () => <AddNoExistingValue />)
   .add("Ref", () => <Ref />)
   .add("Legacy Events", () => <LegacyEvents />)
   .add("ReactHookForm", () => <ReactHookForm />);

--- a/scm-ui/ui-components/src/forms/Select.tsx
+++ b/scm-ui/ui-components/src/forms/Select.tsx
@@ -66,10 +66,8 @@ const InnerSelect: FC<FieldProps<BaseProps, HTMLSelectElement, string>> = ({
   const field = useInnerRef(props.innerRef);
 
   let opts = options;
-  if (value && addValueToOptions) {
-    if (options.findIndex((o) => o.value === value) < 0) {
-      opts = [{ label: value, value }, ...options];
-    }
+  if (value && addValueToOptions && options.some((o) => o.value === value)) {
+    opts = [{ label: value, value }, ...options];
   }
 
   const handleInput = (event: ChangeEvent<HTMLSelectElement>) => {

--- a/scm-ui/ui-components/src/forms/Select.tsx
+++ b/scm-ui/ui-components/src/forms/Select.tsx
@@ -45,6 +45,7 @@ type BaseProps = {
   defaultValue?: string;
   readOnly?: boolean;
   className?: string;
+  addValueToOptions?: boolean;
 };
 
 const InnerSelect: FC<FieldProps<BaseProps, HTMLSelectElement, string>> = ({
@@ -58,9 +59,18 @@ const InnerSelect: FC<FieldProps<BaseProps, HTMLSelectElement, string>> = ({
   testId,
   readOnly,
   className,
+  options,
+  addValueToOptions,
   ...props
 }) => {
   const field = useInnerRef(props.innerRef);
+
+  let opts = options;
+  if (value && addValueToOptions) {
+    if (options.findIndex((o) => o.value === value) < 0) {
+      opts = [{ label: value, value }, ...options];
+    }
+  }
 
   const handleInput = (event: ChangeEvent<HTMLSelectElement>) => {
     if (props.onChange) {
@@ -113,7 +123,7 @@ const InnerSelect: FC<FieldProps<BaseProps, HTMLSelectElement, string>> = ({
           disabled={disabled}
           {...createAttributesForTesting(testId)}
         >
-          {props.options.map((opt) => {
+          {opts.map((opt) => {
             return (
               <option value={opt.value} key={"KEY_" + opt.value}>
                 {opt.label}


### PR DESCRIPTION
## Proposed changes

The select component displays the first option if the value is not part of the options. This behaviour breaks the BranchSelector which uses Select since version 2.22.0 (before it used the deprecated DropDown component). The BranchSelector has to display the revision if one is selected, which is not part of the options.
This change will add a addValueToOptions property to the Select component and restore the old behaviour.

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] New code is covered with unit tests
- [X] New ui components are tested inside the storybook (module ui-components only) 
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
