### PR TITLE
Fix repository viewer for filenames which contains a hash

### DIFF
--- a/gradle/changelog/filename_with_hash.yaml
+++ b/gradle/changelog/filename_with_hash.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Repository viewer filename with hash ([#1766](https://github.com/scm-manager/scm-manager/issues/1766) and [#1776](https://github.com/scm-manager/scm-manager/pull/1776))

--- a/scm-ui/ui-components/src/Breadcrumb.tsx
+++ b/scm-ui/ui-components/src/Breadcrumb.tsx
@@ -144,7 +144,7 @@ const Breadcrumb: FC<Props> = ({
           return (
             <li className="is-active" key={index}>
               <Link className="is-ellipsis-overflow" to="#" aria-current="page">
-                {pathFragment}
+                {decodeURIComponent(pathFragment)}
               </Link>
             </li>
           );
@@ -156,7 +156,7 @@ const Breadcrumb: FC<Props> = ({
               title={pathFragment}
               to={baseUrl + "/" + encodeURIComponent(revision) + "/" + currPath}
             >
-              {pathFragment}
+              {decodeURIComponent(pathFragment)}
             </Link>
           </li>
         );

--- a/scm-ui/ui-webapp/src/repos/sources/components/content/FileLink.tsx
+++ b/scm-ui/ui-webapp/src/repos/sources/components/content/FileLink.tsx
@@ -54,7 +54,7 @@ export const createRelativeLink = (repositoryUrl: string) => {
 export const createFolderLink = (base: string, file: File) => {
   let link = base;
   if (file.path) {
-    let path = file.path;
+    let path = file.path.split("/").map(encodeURIComponent).join("/");
     if (path.startsWith("/")) {
       path = path.substring(1);
     }


### PR DESCRIPTION
## Proposed changes

Add missing url encoding for file links in the repository viewer.

Fixes #1766 

### Your checklist for this pull request
**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
