### PR TITLE
Fix too heavy logging of SchemeBasedWebTokenGenerator

### DIFF
--- a/gradle/changelog/relax_logging.yaml
+++ b/gradle/changelog/relax_logging.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Too heavy logging of SchemeBasedWebTokenGenerator ([#1772](https://github.com/scm-manager/scm-manager/issues/1772) and [#1777](https://github.com/scm-manager/scm-manager/pull/1777))

--- a/scm-core/src/main/java/sonia/scm/web/SchemeBasedWebTokenGenerator.java
+++ b/scm-core/src/main/java/sonia/scm/web/SchemeBasedWebTokenGenerator.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.web;
 
 //~--- non-JDK imports --------------------------------------------------------
@@ -42,8 +42,7 @@ import javax.servlet.http.HttpServletRequest;
  * @author Sebastian Sdorra
  * @since 2.0.0
  */
-public abstract class SchemeBasedWebTokenGenerator implements WebTokenGenerator
-{
+public abstract class SchemeBasedWebTokenGenerator implements WebTokenGenerator {
 
   /** authorization header */
   private static final String HEADER_AUTHORIZATION = "Authorization";
@@ -51,54 +50,26 @@ public abstract class SchemeBasedWebTokenGenerator implements WebTokenGenerator
   /**
    * the logger for SchemeBasedWebTokenGenerator
    */
-  private static final Logger logger =
-    LoggerFactory.getLogger(SchemeBasedWebTokenGenerator.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SchemeBasedWebTokenGenerator.class);
 
-  //~--- methods --------------------------------------------------------------
+  protected abstract AuthenticationToken createToken(HttpServletRequest request, String scheme, String authorization);
 
-  /**
-   * Method description
-   *
-   *
-   * @param request
-   * @param scheme
-   * @param authorization
-   *
-   * @return
-   */
-  protected abstract AuthenticationToken createToken(
-    HttpServletRequest request, String scheme, String authorization);
-
-  /**
-   * Method description
-   *
-   *
-   * @param request
-   *
-   * @return
-   */
   @Override
-  public AuthenticationToken createToken(HttpServletRequest request)
-  {
+  public AuthenticationToken createToken(HttpServletRequest request) {
     AuthenticationToken token = null;
     String authorization = request.getHeader(HEADER_AUTHORIZATION);
 
-    if (!Strings.isNullOrEmpty(authorization))
-    {
+    if (!Strings.isNullOrEmpty(authorization)) {
       String[] parts = authorization.split("\\s+");
 
-      if (parts.length > 0)
-      {
+      if (parts.length > 0) {
         token = createToken(request, parts[0], parts[1]);
 
-        if (token == null)
-        {
-          logger.warn("could not create token from authentication header");
+        if (token == null) {
+          LOG.debug("could not create token from authentication header");
         }
-      }
-      else
-      {
-        logger.warn("found malformed authentication header");
+      } else {
+        LOG.warn("found malformed authentication header");
       }
     }
 


### PR DESCRIPTION
## Proposed changes

Reduce log level of `could not create token from authentication header from warn to debug, because it is normal that these message is logged if multiple SchemeBasedWebTokenGenerator are registered.

Fixes #1772 

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] New code is covered with unit tests
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
