### PR TITLE
Preserve request method on force base url

### DIFF
--- a/gradle/changelog/force_baseurl.yaml
+++ b/gradle/changelog/force_baseurl.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Preserve request method on force base url ([#1771](https://github.com/scm-manager/scm-manager/issues/1771) and [#1778](https://github.com/scm-manager/scm-manager/pull/1778))

--- a/scm-webapp/src/main/java/sonia/scm/filter/BaseUrlFilter.java
+++ b/scm-webapp/src/main/java/sonia/scm/filter/BaseUrlFilter.java
@@ -21,10 +21,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
-package sonia.scm.filter;
 
-//~--- non-JDK imports --------------------------------------------------------
+package sonia.scm.filter;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
@@ -33,8 +31,6 @@ import sonia.scm.config.ScmConfiguration;
 import sonia.scm.util.HttpUtil;
 import sonia.scm.util.Util;
 import sonia.scm.web.filter.HttpFilter;
-
-//~--- JDK imports ------------------------------------------------------------
 
 import java.io.IOException;
 
@@ -50,110 +46,48 @@ import sonia.scm.Priority;
  */
 @Priority(Filters.PRIORITY_BASEURL)
 @WebElement(Filters.PATTERN_ALL)
-public class BaseUrlFilter extends HttpFilter
-{
+public class BaseUrlFilter extends HttpFilter {
 
-  /**
-   * Constructs ...
-   *
-   *
-   * @param configuration
-   */
+  /** scm configuration */
+  private final ScmConfiguration configuration;
+
   @Inject
-  public BaseUrlFilter(ScmConfiguration configuration)
-  {
+  public BaseUrlFilter(ScmConfiguration configuration) {
     this.configuration = configuration;
   }
 
-  //~--- methods --------------------------------------------------------------
-
-  /**
-   * Method description
-   *
-   *
-   * @param requestUrl
-   * @param baseUrl
-   *
-   * @return
-   */
   @VisibleForTesting
-  boolean startsWith(String requestUrl, String baseUrl)
-  {
-    return HttpUtil.normalizeUrl(requestUrl).startsWith(
-      HttpUtil.normalizeUrl(baseUrl));
+  boolean startsWith(String requestUrl, String baseUrl) {
+    return HttpUtil.normalizeUrl(requestUrl).startsWith(HttpUtil.normalizeUrl(baseUrl));
   }
 
-  /**
-   * Method description
-   *
-   *
-   * @param request
-   * @param response
-   * @param chain
-   *
-   * @throws IOException
-   * @throws ServletException
-   */
   @Override
-  protected void doFilter(HttpServletRequest request,
-    HttpServletResponse response, FilterChain chain)
-    throws IOException, ServletException
-  {
-    if (Util.isEmpty(configuration.getBaseUrl()))
-    {
+  protected void doFilter(
+    HttpServletRequest request, HttpServletResponse response, FilterChain chain
+  ) throws IOException, ServletException {
+    if (Util.isEmpty(configuration.getBaseUrl())) {
       configuration.setBaseUrl(createDefaultBaseUrl(request));
     }
 
-    if (!configuration.isForceBaseUrl() || isBaseUrl(request))
-    {
+    if (!configuration.isForceBaseUrl() || isBaseUrl(request)) {
       chain.doFilter(request, response);
-    }
-    else
-    {
-      String url = HttpUtil.getCompleteUrl(configuration,
-                     HttpUtil.getStrippedURI(request));
-
+    } else {
+      String url = HttpUtil.getCompleteUrl(configuration, HttpUtil.getStrippedURI(request));
       response.sendRedirect(url);
     }
   }
 
-  /**
-   * Method description
-   *
-   *
-   * @param request
-   *
-   * @return
-   */
-  private String createDefaultBaseUrl(HttpServletRequest request)
-  {
+  private String createDefaultBaseUrl(HttpServletRequest request) {
     StringBuilder sb = new StringBuilder(request.getScheme());
 
     sb.append("://").append(request.getServerName()).append(":");
-    sb.append(String.valueOf(request.getServerPort()));
+    sb.append(request.getServerPort());
     sb.append(request.getContextPath());
 
     return sb.toString();
   }
 
-  //~--- get methods ----------------------------------------------------------
-
-  /**
-   * Method description
-   *
-   *
-   * @param request
-   *
-   * @return
-   */
-  private boolean isBaseUrl(HttpServletRequest request)
-  {
-    return startsWith(request.getRequestURL().toString(),
-      configuration.getBaseUrl());
+  private boolean isBaseUrl(HttpServletRequest request) {
+    return startsWith(request.getRequestURL().toString(), configuration.getBaseUrl());
   }
-
-  //~--- fields ---------------------------------------------------------------
-
-  /** scm configuration */
-  private final ScmConfiguration configuration;
 }

--- a/scm-webapp/src/main/java/sonia/scm/filter/BaseUrlFilter.java
+++ b/scm-webapp/src/main/java/sonia/scm/filter/BaseUrlFilter.java
@@ -73,7 +73,8 @@ public class BaseUrlFilter extends HttpFilter {
       chain.doFilter(request, response);
     } else {
       String url = HttpUtil.getCompleteUrl(configuration, HttpUtil.getStrippedURI(request));
-      response.sendRedirect(url);
+      response.setStatus(HttpServletResponse.SC_TEMPORARY_REDIRECT);
+      response.setHeader(HttpUtil.HEADER_LOCATION, url);
     }
   }
 

--- a/scm-webapp/src/test/java/sonia/scm/filter/BaseUrlFilterTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/filter/BaseUrlFilterTest.java
@@ -89,7 +89,8 @@ class BaseUrlFilterTest {
     filter.doFilter(request, response, chain);
 
     verifyNoInteractions(chain);
-    verify(response).sendRedirect("https://hitchhiker.com:443/scm/api/v2");
+    verify(response).setStatus(307);
+    verify(response).setHeader("Location", "https://hitchhiker.com:443/scm/api/v2");
   }
 
   @Test


### PR DESCRIPTION
## Proposed changes

The redirect which is used to force base url uses now 307 instead of 302 in order to preserve the request method.

See #1771

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] New code is covered with unit tests
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
