### PR TITLE
Remove deletion of modalRoot node

### DIFF
--- a/gradle/changelog/nested_modal.yaml
+++ b/gradle/changelog/nested_modal.yaml
@@ -1,0 +1,2 @@
+- type: Fixed
+  description: Remove deletion of empty modalRoot node to allow a different modal to continue to exist ([#1779](https://github.com/scm-manager/scm-manager/pull/1779))

--- a/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
+++ b/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
@@ -72169,6 +72169,8 @@ exports[`Storyshots Modal|Modal Default 1`] = `null`;
 
 exports[`Storyshots Modal|Modal Long content 1`] = `null`;
 
+exports[`Storyshots Modal|Modal Nested 1`] = `null`;
+
 exports[`Storyshots Modal|Modal With form elements 1`] = `null`;
 
 exports[`Storyshots Modal|Modal With long tooltips 1`] = `null`;

--- a/scm-ui/ui-components/src/modals/Modal.stories.tsx
+++ b/scm-ui/ui-components/src/modals/Modal.stories.tsx
@@ -72,7 +72,7 @@ const withFormElementsFooter = (
 );
 
 storiesOf("Modal|Modal", module)
-  .addDecorator(story => <MemoryRouter initialEntries={["/"]}>{story()}</MemoryRouter>)
+  .addDecorator((story) => <MemoryRouter initialEntries={["/"]}>{story()}</MemoryRouter>)
   .add("Default", () => (
     <NonCloseableModal>
       <p>{text}</p>
@@ -82,6 +82,11 @@ storiesOf("Modal|Modal", module)
     <CloseableModal>
       <p>{text}</p>
     </CloseableModal>
+  ))
+  .add("Nested", () => (
+    <NestedModal>
+      <p>{text}</p>
+    </NestedModal>
   ))
   .add("With form elements", () => (
     <Modal
@@ -220,4 +225,36 @@ const CloseableModal: FC = ({ children }) => {
   };
 
   return <Modal body={children} closeFunction={toggleModal} active={show} title={"Hitchhiker Modal"} />;
+};
+
+const NestedModal: FC = ({ children }) => {
+  const [showOuter, setShowOuter] = useState(true);
+  const [showInner, setShowInner] = useState(false);
+  const outerBody = (
+    <Button title="Open inner modal" className="button" action={() => setShowInner(true)}>
+      Open inner modal
+    </Button>
+  );
+
+  return (
+    <>
+      {showOuter && (
+        <Modal
+          body={outerBody}
+          closeFunction={() => setShowOuter(!showOuter)}
+          active={showOuter}
+          title="Outer Hitchhiker Modal"
+          size="M"
+        />
+      )}
+      {showInner && (
+        <Modal
+          body={children}
+          closeFunction={() => setShowInner(!showInner)}
+          active={showInner}
+          title="Inner Hitchhiker Modal"
+        />
+      )}
+    </>
+  );
 };

--- a/scm-ui/ui-components/src/usePortalRootElement.ts
+++ b/scm-ui/ui-components/src/usePortalRootElement.ts
@@ -44,9 +44,6 @@ const usePortalRootElement = (id: string) => {
     }
     setRootElement(element);
     return () => {
-      if (element) {
-        element.remove();
-      }
       setRootElement(undefined);
     };
   }, [id]);


### PR DESCRIPTION
## Proposed changes

Remove deletion of empty modalRoot node to allow a different modal to continue to exist

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [x] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
