### PR TITLE
Fix disabled local proxy configuration being used over global config

### DIFF
--- a/gradle/changelog/disabled_local_proxy_config.yaml
+++ b/gradle/changelog/disabled_local_proxy_config.yaml
@@ -1,0 +1,2 @@
+- type: Fixed
+  description: Fix disabled local proxy configuration being used over global config ([#1780](https://github.com/scm-manager/scm-manager/pull/1780))

--- a/scm-core/src/main/java/sonia/scm/net/HttpURLConnectionFactory.java
+++ b/scm-core/src/main/java/sonia/scm/net/HttpURLConnectionFactory.java
@@ -129,7 +129,7 @@ public final class HttpURLConnectionFactory {
       // because we are not able to remove the authentication from thread local
       ThreadLocalAuthenticator.clear();
 
-      ProxyConfiguration proxyConfiguration = options.getProxyConfiguration().orElse(globalProxyConfiguration);
+      ProxyConfiguration proxyConfiguration = options.getProxyConfiguration().filter(ProxyConfiguration::isEnabled).orElse(globalProxyConfiguration);
       if (isProxyEnabled(proxyConfiguration, url)) {
         return openProxyConnection(proxyConfiguration, url);
       }

--- a/scm-core/src/test/java/sonia/scm/net/HttpURLConnectionFactoryTest.java
+++ b/scm-core/src/test/java/sonia/scm/net/HttpURLConnectionFactoryTest.java
@@ -181,6 +181,22 @@ class HttpURLConnectionFactoryTest {
     }
 
     @Test
+    void shouldUseGlobalProxyConfigurationIfLocalOneIsDisabled() throws IOException {
+      configuration.setProxyServer("proxy.hitchhiker.com");
+      configuration.setProxyPort(3128);
+      configuration.setEnableProxy(true);
+
+      ScmConfiguration localProxyConf = new ScmConfiguration();
+      localProxyConf.setEnableProxy(false);
+      localProxyConf.setProxyServer("prox.hitchhiker.net");
+      localProxyConf.setProxyPort(3127);
+
+      connectionFactory.create(new URL("https://hitchhiker.org"), new HttpConnectionOptions().withProxyConfiguration(new GlobalProxyConfiguration(localProxyConf)));
+
+      assertUsedProxy("proxy.hitchhiker.com", 3128);
+    }
+
+    @Test
     void shouldCreateProxyConnection() throws IOException {
       configuration.setEnableProxy(true);
       configuration.setProxyServer("proxy.hitchhiker.com");
@@ -340,7 +356,6 @@ class HttpURLConnectionFactoryTest {
 
       return captor.getValue();
     }
-
 
     private void assertUsedProxy(String host, int port) {
       assertThat(usedProxy).isNotNull();

--- a/scm-plugins/scm-svn-plugin/src/main/java/sonia/scm/repository/spi/SvnMirrorCommand.java
+++ b/scm-plugins/scm-svn-plugin/src/main/java/sonia/scm/repository/spi/SvnMirrorCommand.java
@@ -147,7 +147,7 @@ public class SvnMirrorCommand extends AbstractSvnCommand implements MirrorComman
       }
     };
     checkAndApplyProxyConfiguration(
-      authManager, mirrorCommandRequest.getProxyConfiguration().orElse(globalProxyConfiguration), url
+      authManager, mirrorCommandRequest.getProxyConfiguration().filter(ProxyConfiguration::isEnabled).orElse(globalProxyConfiguration), url
     );
     return authManager;
   }

--- a/scm-plugins/scm-svn-plugin/src/test/java/sonia/scm/repository/spi/SvnMirrorCommandTest.java
+++ b/scm-plugins/scm-svn-plugin/src/test/java/sonia/scm/repository/spi/SvnMirrorCommandTest.java
@@ -53,6 +53,7 @@ import java.util.function.Consumer;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static sonia.scm.repository.api.MirrorCommandResult.ResultType.OK;
@@ -220,8 +221,8 @@ public class SvnMirrorCommandTest extends AbstractSvnCommandTestBase {
   private ProxyConfiguration createDisabledProxyConfiguration() {
     ProxyConfiguration configuration = mock(ProxyConfiguration.class);
     when(configuration.isEnabled()).thenReturn(false);
-    when(configuration.getHost()).thenReturn("proxy.hitchhiker.com");
-    when(configuration.getPort()).thenReturn(3128);
+    lenient().when(configuration.getHost()).thenReturn("proxy.hitchhiker.com");
+    lenient().when(configuration.getPort()).thenReturn(3128);
     return configuration;
   }
 

--- a/scm-plugins/scm-svn-plugin/src/test/java/sonia/scm/repository/spi/SvnMirrorCommandTest.java
+++ b/scm-plugins/scm-svn-plugin/src/test/java/sonia/scm/repository/spi/SvnMirrorCommandTest.java
@@ -197,9 +197,29 @@ public class SvnMirrorCommandTest extends AbstractSvnCommandTestBase {
     assertThat(authenticationManager.getProxyPasswordValue()).isNull();
   }
 
+  @Test
+  public void shouldNotApplyDisabledLocalProxySettings() throws SVNException {
+    MirrorCommandRequest request = new MirrorCommandRequest();
+    request.setProxyConfiguration(createDisabledProxyConfiguration());
+
+    BasicAuthenticationManager authenticationManager = createAuthenticationManager(request);
+    assertThat(authenticationManager.getProxyHost()).isNull();
+    assertThat(authenticationManager.getProxyPort()).isZero();
+    assertThat(authenticationManager.getProxyUserName()).isNull();
+    assertThat(authenticationManager.getProxyPasswordValue()).isNull();
+  }
+
   private ProxyConfiguration createProxyConfiguration() {
     ProxyConfiguration configuration = mock(ProxyConfiguration.class);
     when(configuration.isEnabled()).thenReturn(true);
+    when(configuration.getHost()).thenReturn("proxy.hitchhiker.com");
+    when(configuration.getPort()).thenReturn(3128);
+    return configuration;
+  }
+
+  private ProxyConfiguration createDisabledProxyConfiguration() {
+    ProxyConfiguration configuration = mock(ProxyConfiguration.class);
+    when(configuration.isEnabled()).thenReturn(false);
     when(configuration.getHost()).thenReturn("proxy.hitchhiker.com");
     when(configuration.getPort()).thenReturn(3128);
     return configuration;


### PR DESCRIPTION
## Proposed changes

The original proxy configuration implementation only used the global configuration if the local proxy configuration was not provided (i.e. `null`). This PR adds the corner case where a local configuration is provided, but `disabled`. In this case, the global proxy configuration will be used as a fallback as well.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
