### PR TITLE
Fetch clone modal data on first opening.

### DIFF
--- a/gradle/changelog/clone_modal_fetch.yaml
+++ b/gradle/changelog/clone_modal_fetch.yaml
@@ -1,0 +1,2 @@
+- type: Fixed
+  description: Fetch clone modal data on first opening ([#1784](https://github.com/scm-manager/scm-manager/pull/1784))

--- a/scm-ui/ui-components/src/repos/RepositoryEntry.tsx
+++ b/scm-ui/ui-components/src/repos/RepositoryEntry.tsx
@@ -81,21 +81,23 @@ const RepositoryEntry: FC<Props> = ({ repository, baseDate }) => {
 
   const createContentRight = () => (
     <ContentRightContainer>
-      <Modal
-        size="L"
-        active={openCloneModal}
-        title={t("overview.clone")}
-        body={
-          <ExtensionPoint
-            name="repos.repository-details.information"
-            renderAll={true}
-            props={{
-              repository,
-            }}
-          />
-        }
-        closeFunction={() => setOpenCloneModal(false)}
-      />
+      {openCloneModal && (
+        <Modal
+          size="L"
+          active={openCloneModal}
+          title={t("overview.clone")}
+          body={
+            <ExtensionPoint
+              name="repos.repository-details.information"
+              renderAll={true}
+              props={{
+                repository,
+              }}
+            />
+          }
+          closeFunction={() => setOpenCloneModal(false)}
+        />
+      )}
       <QuickActionbar>
         <QuickAction
           name="download"


### PR DESCRIPTION
## Proposed changes
Get the data of the clone modal the first time it is opened. This way, we display a loading spinner for a fraction of a second when the modal is first opened. But we also prevent fetching a lot of data that is probably not needed. 

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
