### PR TITLE
Create a more flexible and typesafe id for indexed objects

### DIFF
--- a/scm-core/src/main/java/sonia/scm/search/Id.java
+++ b/scm-core/src/main/java/sonia/scm/search/Id.java
@@ -25,17 +25,17 @@
 package sonia.scm.search;
 
 import com.google.common.annotations.Beta;
-import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.ToString;
 import sonia.scm.ModelObject;
-import sonia.scm.repository.Repository;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.Optional;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * Describes the id of an indexed object.
@@ -45,114 +45,75 @@ import java.util.Optional;
 @Beta
 @ToString
 @EqualsAndHashCode
-public final class Id {
+@Getter(AccessLevel.PACKAGE)
+public final class Id<T> {
 
-  private final String value;
-  private final String repository;
+  private final Class<T> mainType;
+  private final String mainId;
+  private final Map<Class<?>, String> others;
 
-  private Id(@Nonnull String value, @Nullable String repository) {
-    this.value = value;
-    this.repository = repository;
+  private Id(Class<T> mainType, String mainId, Map<Class<?>, String> others) {
+    this.mainType = mainType;
+    this.mainId = mainId;
+    this.others = others;
   }
 
   /**
-   * Returns the string representation of the id without the repository part.
-   *
-   * @return string representation without repository.
+   * Creates a new combined id by adding a new type and value.
+   * @param type other type
+   * @param id other id
+   * @return new combined id
+   * @since 2.23.0
    */
-  public String getValue() {
-    return value;
+  public Id<T> and(Class<?> type, String id) {
+    Preconditions.checkArgument(type != null, "type is required");
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "id is required");
+    return new Id<>(
+      mainType,
+      mainId,
+      ImmutableMap.<Class<?>, String>builder()
+        .putAll(others)
+        .put(type, id)
+        .build()
+    );
   }
 
   /**
-   * Returns the repository id part of the id or an empty optional if the id does not belong to a repository.
-   * @return repository id or empty
+   * Creates a new combined id by adding a new type and value.
+   * @param type other type
+   * @param idObject object which holds id
+   * @return new combined id
+   * @since 2.23.0
    */
-  public Optional<String> getRepository() {
-    return Optional.ofNullable(repository);
-  }
-
-  /**
-   * Creates the id with the id of the given repository.
-   * @param repository repository
-   * @return id with repository id
-   */
-  public Id withRepository(@Nonnull Repository repository) {
-    checkRepository(repository);
-    return withRepository(repository.getId());
-  }
-
-  /**
-   * Creates the id with the  given repository id.
-   * @param repository repository id
-   * @return id with repository id
-   */
-  public Id withRepository(@Nonnull String repository) {
-    checkRepository(repository);
-    return new Id(value, repository);
-  }
-
-  /**
-   * Returns the string representation of the id including the repository.
-   * @return string representation
-   */
-  public String asString() {
-    if (repository != null) {
-      return value + "/" + repository;
-    }
-    return value;
+  public Id<T> and(Class<?> type, ModelObject idObject) {
+    Preconditions.checkArgument(idObject != null, "id object is required");
+    return and(type, idObject.getId());
   }
 
   /**
    * Creates a new id.
    *
-   * @param value primary value of the id
-   * @param others additional values which should be part of the id
+   * @param mainType main type of the id
+   * @param mainId main id of the id
    *
    * @return new id
    */
-  public static Id of(@Nonnull String value, String... others) {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(value), "primary value is required");
-    String idValue = value;
-    if (others.length > 0) {
-      idValue += ":" + Joiner.on(':').join(others);
-    }
-    return new Id(idValue, null);
+  public static <T> Id<T> of(Class<T> mainType, String mainId) {
+    Preconditions.checkArgument(mainType != null, "main type is required");
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(mainId), "main id is required");
+    return new Id<>(mainType, mainId, Collections.emptyMap());
   }
 
   /**
-   * Creates a new id for the given repository.
+   * Creates a new id.
    *
-   * @param repository repository
-   * @return id of repository
+   * @param mainType main type of the id
+   * @param mainIdObject object which holds the main id
+   *
+   * @return new id
    */
-  public static Id of(@Nonnull Repository repository) {
-    checkRepository(repository);
-    String id = repository.getId();
-    checkRepository(id);
-    return new Id(id, id);
-  }
-
-  /**
-   * Creates a new id for the given model object.
-   * @param object model object
-   * @param others additional values which should be part of the id
-   * @return new id from model object
-   */
-  public static Id of(@Nonnull ModelObject object, String... others) {
-    checkObject(object);
-    return of(object.getId(), others);
-  }
-
-  private static void checkRepository(Repository repository) {
-    Preconditions.checkArgument(repository != null, "repository is required");
-  }
-
-  private static void checkRepository(String repository) {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(repository), "repository id is required");
-  }
-
-  private static void checkObject(@Nonnull ModelObject object) {
-    Preconditions.checkArgument(object != null, "object is required");
+  public static <T> Id<T> of(Class<T> mainType, ModelObject mainIdObject) {
+    Preconditions.checkArgument(mainIdObject != null, "main id object is required");
+    return of(mainType, mainIdObject.getId());
   }
 }

--- a/scm-core/src/main/java/sonia/scm/search/Index.java
+++ b/scm-core/src/main/java/sonia/scm/search/Index.java
@@ -53,27 +53,27 @@ public interface Index<T>  {
    *
    * @see Indexed
    */
-  void store(Id id, String permission, T object);
+  void store(Id<T> id, String permission, T object);
 
   /**
    * Delete provides an api to delete objects from the index
    * @return delete api
    * @since 2.23.0
    */
-  Deleter delete();
+  Deleter<T> delete();
 
   /**
    * Deleter provides an api to delete object from index.
    *
    * @since 2.23.0
    */
-  interface Deleter {
+  interface Deleter<T> {
 
     /**
      * Delete the object with the given id and type from index.
      * @param id id of object
      */
-    void byId(Id id);
+    void byId(Id<T> id);
 
     /**
      * Delete all objects of the given type from index.

--- a/scm-core/src/test/java/sonia/scm/search/IdTest.java
+++ b/scm-core/src/test/java/sonia/scm/search/IdTest.java
@@ -26,6 +26,7 @@ package sonia.scm.search;
 
 import org.junit.jupiter.api.Test;
 import sonia.scm.ModelObject;
+import sonia.scm.group.Group;
 import sonia.scm.repository.Repository;
 import sonia.scm.user.User;
 
@@ -35,94 +36,95 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class IdTest {
 
   @Test
-  void shouldCreateIdFromPrimary() {
-    Id id = Id.of("one");
-    assertThat(id.getValue()).isEqualTo("one");
+  void shouldCreateSimpleId() {
+    Id<Repository> id = Id.of(Repository.class, "42");
+    assertThat(id.getMainType()).isEqualTo(Repository.class);
+    assertThat(id.getMainId()).isEqualTo("42");
+    assertThat(id.getOthers()).isEmpty();
   }
 
   @Test
-  void shouldCreateIdWithoutRepository() {
-    Id id = Id.of("one");
-    assertThat(id.getRepository()).isEmpty();
+  void shouldFailWithNullType() {
+    assertThrows(IllegalArgumentException.class, () -> Id.of(null, "42"));
   }
 
   @Test
-  void shouldFailWithoutPrimaryValue() {
-    assertThrows(IllegalArgumentException.class, () -> Id.of((String) null));
+  void shouldFailWithEmptyId() {
+    assertThrows(IllegalArgumentException.class, () -> Id.of(Repository.class, ""));
   }
 
   @Test
-  void shouldFailWithEmptyPrimaryValue() {
-    assertThrows(IllegalArgumentException.class, () -> Id.of(""));
+  void shouldFailWithNullId() {
+    assertThrows(IllegalArgumentException.class, () -> Id.of(Repository.class, (String) null));
   }
 
   @Test
-  void shouldCreateCombinedValue() {
-    Id id = Id.of("one", "two", "three");
-    assertThat(id.getValue()).isEqualTo("one:two:three");
+  void shouldFailWithNullIdObject() {
+    assertThrows(IllegalArgumentException.class, () -> Id.of(Repository.class, (ModelObject) null));
   }
 
   @Test
-  void shouldAddRepositoryId() {
-    Id id = Id.of("one").withRepository("4211");
-    assertThat(id.getRepository()).contains("4211");
-  }
-
-  @Test
-  void shouldAddRepository() {
+  void shouldCreateSimpleFromModelObject() {
     Repository repository = new Repository();
-    repository.setId("4211");
-    Id id = Id.of("one").withRepository(repository);
-    assertThat(id.getRepository()).contains("4211");
+    repository.setId("42");
+    Id<Repository> id = Id.of(Repository.class, repository);
+    assertThat(id.getMainType()).isEqualTo(Repository.class);
+    assertThat(id.getMainId()).isEqualTo("42");
+    assertThat(id.getOthers()).isEmpty();
   }
 
   @Test
-  void shouldCreateIdFromRepository() {
-    Repository repository = new Repository();
-    repository.setId("4211");
-    Id id = Id.of(repository);
-    assertThat(id.getRepository()).contains("4211");
+  void shouldCreateIdWithOneOther() {
+    Id<User> id = Id.of(User.class, "trillian").and(Group.class, "hog");
+    assertThat(id.getMainType()).isEqualTo(User.class);
+    assertThat(id.getMainId()).isEqualTo("trillian");
+    assertThat(id.getOthers()).containsEntry(Group.class, "hog");
   }
 
   @Test
-  void shouldFailWithoutRepository() {
-    Id id = Id.of("one");
-    assertThrows(IllegalArgumentException.class, () -> id.withRepository((Repository) null));
+  void shouldCreateIdWithOtherFromModelObject() {
+    Group group = new Group("xml", "hog");
+    Id<User> id = Id.of(User.class, "trillian").and(Group.class, group);
+    assertThat(id.getMainType()).isEqualTo(User.class);
+    assertThat(id.getMainId()).isEqualTo("trillian");
+    assertThat(id.getOthers()).containsEntry(Group.class, "hog");
   }
 
   @Test
-  void shouldFailWithoutRepositoryId() {
-    Id id = Id.of("one");
-    assertThrows(IllegalArgumentException.class, () -> id.withRepository((String) null));
+  void shouldCreateIdWithOthers() {
+    Id<User> id = Id.of(User.class, "trillian")
+      .and(Group.class, "hog")
+      .and(Repository.class, "heart-of-gold");
+
+    assertThat(id.getMainType()).isEqualTo(User.class);
+    assertThat(id.getMainId()).isEqualTo("trillian");
+    assertThat(id.getOthers())
+      .containsEntry(Group.class, "hog")
+      .containsEntry(Repository.class, "heart-of-gold");
   }
 
   @Test
-  void shouldFailWithEmptyRepositoryId() {
-    Id id = Id.of("one");
-    assertThrows(IllegalArgumentException.class, () -> id.withRepository((String) null));
+  void shouldFailIfOtherTypeIsNull() {
+    Id<User> id = Id.of(User.class, "trillian");
+    assertThrows(IllegalArgumentException.class, () -> id.and(null, "hog"));
   }
 
   @Test
-  void shouldCreateIdFromModelObject() {
-    Id id = Id.of(new User("trillian"));
-    assertThat(id.getValue()).isEqualTo("trillian");
+  void shouldFailIfOtherIdIsNull() {
+    Id<User> id = Id.of(User.class, "trillian");
+    assertThrows(IllegalArgumentException.class, () -> id.and(Group.class, (String) null));
   }
 
   @Test
-  void shouldFailWithoutModelObject() {
-    assertThrows(IllegalArgumentException.class, () -> Id.of((ModelObject) null));
+  void shouldFailIfOtherIdIsEmpty() {
+    Id<User> id = Id.of(User.class, "trillian");
+    assertThrows(IllegalArgumentException.class, () -> id.and(Group.class, ""));
   }
 
   @Test
-  void shouldReturnSimpleIdAsString() {
-    Id id = Id.of("one", "two");
-    assertThat(id.asString()).isEqualTo("one:two");
-  }
-
-  @Test
-  void shouldReturnIdWithRepositoryAsString() {
-    Id id = Id.of("one", "two").withRepository("4211");
-    assertThat(id.asString()).isEqualTo("one:two/4211");
+  void shouldFailIfOtherIdObjectIsNull() {
+    Id<User> id = Id.of(User.class, "trillian");
+    assertThrows(IllegalArgumentException.class, () -> id.and(Group.class, (ModelObject) null));
   }
 
 }

--- a/scm-webapp/src/main/java/sonia/scm/group/GroupIndexer.java
+++ b/scm-webapp/src/main/java/sonia/scm/group/GroupIndexer.java
@@ -74,7 +74,7 @@ public class GroupIndexer implements Indexer<Group> {
 
   @Override
   public SerializableIndexTask<Group> createDeleteTask(Group group) {
-    return index -> index.delete().byId(Id.of(group));
+    return index -> index.delete().byId(Id.of(Group.class, group));
   }
 
   @Subscribe(async = false)
@@ -83,7 +83,7 @@ public class GroupIndexer implements Indexer<Group> {
   }
 
   public static void store(Index<Group> index, Group group) {
-    index.store(Id.of(group), GroupPermissions.read(group).asShiroString(), group);
+    index.store(Id.of(Group.class, group), GroupPermissions.read(group).asShiroString(), group);
   }
 
   public static class ReIndexAll extends ReIndexAllTask<Group> {

--- a/scm-webapp/src/main/java/sonia/scm/repository/RepositoryIndexer.java
+++ b/scm-webapp/src/main/java/sonia/scm/repository/RepositoryIndexer.java
@@ -90,11 +90,17 @@ public class RepositoryIndexer implements Indexer<Repository> {
 
   @Override
   public SerializableIndexTask<Repository> createDeleteTask(Repository repository) {
-    return index -> index.delete().byRepository(repository);
+    return index -> {
+      if (Repository.class.equals(index.getDetails().getType())) {
+        index.delete().byId(Id.of(Repository.class, repository.getId()));
+      } else {
+        index.delete().byRepository(repository);
+      }
+    };
   }
 
   private static void store(Index<Repository> index, Repository repository) {
-    index.store(Id.of(repository), RepositoryPermissions.read(repository).asShiroString(), repository);
+    index.store(Id.of(Repository.class, repository), RepositoryPermissions.read(repository).asShiroString(), repository);
   }
 
   public static class ReIndexAll extends ReIndexAllTask<Repository> {

--- a/scm-webapp/src/main/java/sonia/scm/search/Ids.java
+++ b/scm-webapp/src/main/java/sonia/scm/search/Ids.java
@@ -1,0 +1,66 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.search;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+final class Ids {
+
+  private Ids() {
+  }
+
+  static Map<String,String> others(Id<?> id) {
+    Map<String,String> result = new TreeMap<>();
+
+    Map<Class<?>, String> others = id.getOthers();
+    for (Map.Entry<Class<?>, String> e : others.entrySet()) {
+      result.put(name(e.getKey()), e.getValue());
+    }
+
+    return result;
+  }
+
+  static String id(String mainId, Map<String,String> others) {
+    List<String> values = new ArrayList<>();
+    values.add(mainId);
+    values.addAll(others.values());
+    return values.stream()
+      .map(v -> v.replace(";", "\\;" ))
+      .collect(Collectors.joining(";"));
+  }
+
+  static String asString(Id<?> id) {
+    return id(id.getMainId(), others(id));
+  }
+
+  private static String name(Class<?> key) {
+    return LuceneSearchableType.createName(key, key.getAnnotation(IndexedType.class));
+  }
+
+}

--- a/scm-webapp/src/main/java/sonia/scm/search/LuceneSearchableType.java
+++ b/scm-webapp/src/main/java/sonia/scm/search/LuceneSearchableType.java
@@ -54,7 +54,7 @@ public class LuceneSearchableType implements SearchableType {
 
   public LuceneSearchableType(Class<?> type, @Nonnull IndexedType annotation, List<LuceneSearchableField> fields) {
     this.type = type;
-    this.name = createName(type, annotation);
+    this.name = Names.create(type, annotation);
     this.permission = Strings.emptyToNull(annotation.permission());
     this.fields = fields;
     this.fieldNames = fieldNames(fields);
@@ -65,18 +65,6 @@ public class LuceneSearchableType implements SearchableType {
 
   public Optional<String> getPermission() {
     return Optional.ofNullable(permission);
-  }
-
-  static String createName(Class<?> type, @Nullable IndexedType annotation) {
-    String nameFromAnnotation = null;
-    if (annotation != null) {
-      nameFromAnnotation = annotation.value();
-    }
-    if (Strings.isNullOrEmpty(nameFromAnnotation)) {
-      String simpleName = type.getSimpleName();
-      return Character.toLowerCase(simpleName.charAt(0)) + simpleName.substring(1);
-    }
-    return nameFromAnnotation;
   }
 
   private String[] fieldNames(List<LuceneSearchableField> fields) {

--- a/scm-webapp/src/main/java/sonia/scm/search/LuceneSearchableType.java
+++ b/scm-webapp/src/main/java/sonia/scm/search/LuceneSearchableType.java
@@ -28,6 +28,8 @@ import com.google.common.base.Strings;
 import lombok.Value;
 import org.apache.lucene.queryparser.flexible.standard.config.PointsConfig;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -50,9 +52,9 @@ public class LuceneSearchableType implements SearchableType {
   Map<String, PointsConfig> pointsConfig;
   TypeConverter typeConverter;
 
-  public LuceneSearchableType(Class<?> type, IndexedType annotation, List<LuceneSearchableField> fields) {
+  public LuceneSearchableType(Class<?> type, @Nonnull IndexedType annotation, List<LuceneSearchableField> fields) {
     this.type = type;
-    this.name = name(type, annotation);
+    this.name = createName(type, annotation);
     this.permission = Strings.emptyToNull(annotation.permission());
     this.fields = fields;
     this.fieldNames = fieldNames(fields);
@@ -65,8 +67,11 @@ public class LuceneSearchableType implements SearchableType {
     return Optional.ofNullable(permission);
   }
 
-  private String name(Class<?> type, IndexedType annotation) {
-    String nameFromAnnotation = annotation.value();
+  static String createName(Class<?> type, @Nullable IndexedType annotation) {
+    String nameFromAnnotation = null;
+    if (annotation != null) {
+      nameFromAnnotation = annotation.value();
+    }
     if (Strings.isNullOrEmpty(nameFromAnnotation)) {
       String simpleName = type.getSimpleName();
       return Character.toLowerCase(simpleName.charAt(0)) + simpleName.substring(1);

--- a/scm-webapp/src/main/java/sonia/scm/search/Names.java
+++ b/scm-webapp/src/main/java/sonia/scm/search/Names.java
@@ -24,43 +24,28 @@
 
 package sonia.scm.search;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-import java.util.stream.Collectors;
+import com.google.common.base.Strings;
 
-final class Ids {
+import javax.annotation.Nullable;
 
-  private Ids() {
+final class Names {
+
+  private Names() {
   }
 
-  static Map<String,String> others(Id<?> id) {
-    Map<String,String> result = new TreeMap<>();
+  static String create(Class<?> type) {
+    return create(type, type.getAnnotation(IndexedType.class));
+  }
 
-    Map<Class<?>, String> others = id.getOthers();
-    for (Map.Entry<Class<?>, String> e : others.entrySet()) {
-      result.put(name(e.getKey()), e.getValue());
+  static String create(Class<?> type, @Nullable IndexedType annotation) {
+    String nameFromAnnotation = null;
+    if (annotation != null) {
+      nameFromAnnotation = annotation.value();
     }
-
-    return result;
+    if (Strings.isNullOrEmpty(nameFromAnnotation)) {
+      String simpleName = type.getSimpleName();
+      return Character.toLowerCase(simpleName.charAt(0)) + simpleName.substring(1);
+    }
+    return nameFromAnnotation;
   }
-
-  static String id(String mainId, Map<String,String> others) {
-    List<String> values = new ArrayList<>();
-    values.add(mainId);
-    values.addAll(others.values());
-    return values.stream()
-      .map(v -> v.replace(";", "\\;" ))
-      .collect(Collectors.joining(";"));
-  }
-
-  static String asString(Id<?> id) {
-    return id(id.getMainId(), others(id));
-  }
-
-  private static String name(Class<?> key) {
-    return Names.create(key, key.getAnnotation(IndexedType.class));
-  }
-
 }

--- a/scm-webapp/src/main/java/sonia/scm/user/UserIndexer.java
+++ b/scm-webapp/src/main/java/sonia/scm/user/UserIndexer.java
@@ -74,7 +74,7 @@ public class UserIndexer implements Indexer<User> {
 
   @Override
   public SerializableIndexTask<User> createDeleteTask(User item) {
-    return index -> index.delete().byId(Id.of(item));
+    return index -> index.delete().byId(Id.of(User.class, item));
   }
 
   @Subscribe(async = false)
@@ -83,7 +83,7 @@ public class UserIndexer implements Indexer<User> {
   }
 
   private static void store(Index<User> index, User user) {
-    index.store(Id.of(user), UserPermissions.read(user).asShiroString(), user);
+    index.store(Id.of(User.class, user), UserPermissions.read(user).asShiroString(), user);
   }
 
   public static class ReIndexAll extends ReIndexAllTask<User> {

--- a/scm-webapp/src/test/java/sonia/scm/group/GroupIndexerTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/group/GroupIndexerTest.java
@@ -90,14 +90,14 @@ class GroupIndexerTest {
   void shouldCreateGroup() {
     indexer.createStoreTask(astronauts).update(index);
 
-    verify(index).store(Id.of(astronauts), GroupPermissions.read(astronauts).asShiroString(), astronauts);
+    verify(index).store(Id.of(Group.class, astronauts), GroupPermissions.read(astronauts).asShiroString(), astronauts);
   }
 
   @Test
   void shouldDeleteGroup() {
     indexer.createDeleteTask(astronauts).update(index);
 
-    verify(index.delete()).byId(Id.of(astronauts));
+    verify(index.delete()).byId(Id.of(Group.class, astronauts));
   }
 
   @Test
@@ -108,8 +108,8 @@ class GroupIndexerTest {
     reIndexAll.update(index);
 
     verify(index.delete()).all();
-    verify(index).store(Id.of(astronauts), GroupPermissions.read(astronauts).asShiroString(), astronauts);
-    verify(index).store(Id.of(planetCreators), GroupPermissions.read(planetCreators).asShiroString(), planetCreators);
+    verify(index).store(Id.of(Group.class, astronauts), GroupPermissions.read(astronauts).asShiroString(), astronauts);
+    verify(index).store(Id.of(Group.class, planetCreators), GroupPermissions.read(planetCreators).asShiroString(), planetCreators);
   }
 
   @Test
@@ -120,7 +120,7 @@ class GroupIndexerTest {
 
     verify(searchEngine.forType(Group.class)).update(captor.capture());
     captor.getValue().update(index);
-    verify(index.delete()).byId(Id.of(astronauts));
+    verify(index.delete()).byId(Id.of(Group.class, astronauts));
   }
 
 }

--- a/scm-webapp/src/test/java/sonia/scm/repository/RepositoryIndexerTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/repository/RepositoryIndexerTest.java
@@ -89,13 +89,24 @@ class RepositoryIndexerTest {
 
     indexer.createStoreTask(heartOfGold).update(index);
 
-    verify(index).store(Id.of(heartOfGold), RepositoryPermissions.read(heartOfGold).asShiroString(), heartOfGold);
+    verify(index).store(Id.of(Repository.class, heartOfGold), RepositoryPermissions.read(heartOfGold).asShiroString(), heartOfGold);
   }
 
   @Test
-  void shouldDeleteRepository() {
+  void shouldDeleteRepositoryById() {
     Repository heartOfGold = RepositoryTestData.createHeartOfGold();
 
+    when(index.getDetails().getType()).then(ic -> Repository.class);
+    indexer.createDeleteTask(heartOfGold).update(index);
+
+    verify(index.delete()).byId(Id.of(Repository.class, heartOfGold));
+  }
+
+  @Test
+  void shouldDeleteAllByRepository() {
+    Repository heartOfGold = RepositoryTestData.createHeartOfGold();
+
+    when(index.getDetails().getType()).then(ic -> String.class);
     indexer.createDeleteTask(heartOfGold).update(index);
 
     verify(index.delete()).byRepository(heartOfGold);
@@ -111,8 +122,8 @@ class RepositoryIndexerTest {
     reIndexAll.update(index);
 
     verify(index.delete()).all();
-    verify(index).store(Id.of(heartOfGold), RepositoryPermissions.read(heartOfGold).asShiroString(), heartOfGold);
-    verify(index).store(Id.of(puzzle), RepositoryPermissions.read(puzzle).asShiroString(), puzzle);
+    verify(index).store(Id.of(Repository.class, heartOfGold), RepositoryPermissions.read(heartOfGold).asShiroString(), heartOfGold);
+    verify(index).store(Id.of(Repository.class, puzzle), RepositoryPermissions.read(puzzle).asShiroString(), puzzle);
   }
 
   @Test
@@ -136,7 +147,7 @@ class RepositoryIndexerTest {
 
     verify(searchEngine.forType(Repository.class)).update(captor.capture());
     captor.getValue().update(index);
-    verify(index).store(Id.of(heartOfGold), RepositoryPermissions.read(heartOfGold).asShiroString(), heartOfGold);
+    verify(index).store(Id.of(Repository.class, heartOfGold), RepositoryPermissions.read(heartOfGold).asShiroString(), heartOfGold);
   }
 
 }

--- a/scm-webapp/src/test/java/sonia/scm/search/IdsTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/search/IdsTest.java
@@ -1,0 +1,66 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.search;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static sonia.scm.search.Ids.asString;
+
+class IdsTest {
+
+  @Test
+  void shouldUseNameFromAnnotation() {
+    Id<String> id = Id.of(String.class, "0")
+      .and(Z.class, "zzz");
+    assertThat(Ids.others(id)).containsEntry("c", "zzz");
+  }
+
+  @Test
+  void shouldEscapeSemicolon() {
+    Id<String> id = Id.of(String.class, "a;b;c");
+    assertThat(Ids.asString(id)).isEqualTo("a\\;b\\;c");
+  }
+
+  @Test
+  void shouldSortInAlphabeticalOrder() {
+    Id<String> id = Id.of(String.class, "0")
+      .and(D.class, "4")
+      .and(A.class, "1")
+      .and(B.class, "2")
+      .and(Z.class, "3");
+
+    assertThat(asString(id)).isEqualTo("0;1;2;3;4");
+  }
+
+  private static class A {}
+
+  private static class B {}
+
+  @IndexedType("c")
+  private static class Z {}
+
+  private static class D {}
+}

--- a/scm-webapp/src/test/java/sonia/scm/search/NamesTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/search/NamesTest.java
@@ -24,43 +24,25 @@
 
 package sonia.scm.search;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
 
-final class Ids {
+import static org.assertj.core.api.Assertions.assertThat;
 
-  private Ids() {
+class NamesTest {
+
+  @Test
+  void shouldUseNameFromAnnotation() {
+    assertThat(Names.create(WithAlias.class)).isEqualTo("alias");
   }
 
-  static Map<String,String> others(Id<?> id) {
-    Map<String,String> result = new TreeMap<>();
-
-    Map<Class<?>, String> others = id.getOthers();
-    for (Map.Entry<Class<?>, String> e : others.entrySet()) {
-      result.put(name(e.getKey()), e.getValue());
-    }
-
-    return result;
+  @Test
+  void shouldUseNameFromClass() {
+    assertThat(Names.create(Simple.class)).isEqualTo("simple");
   }
 
-  static String id(String mainId, Map<String,String> others) {
-    List<String> values = new ArrayList<>();
-    values.add(mainId);
-    values.addAll(others.values());
-    return values.stream()
-      .map(v -> v.replace(";", "\\;" ))
-      .collect(Collectors.joining(";"));
-  }
+  private static class Simple {}
 
-  static String asString(Id<?> id) {
-    return id(id.getMainId(), others(id));
-  }
-
-  private static String name(Class<?> key) {
-    return Names.create(key, key.getAnnotation(IndexedType.class));
-  }
+  @IndexedType("alias")
+  private static class WithAlias {}
 
 }

--- a/scm-webapp/src/test/java/sonia/scm/user/UserIndexerTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/user/UserIndexerTest.java
@@ -89,7 +89,7 @@ class UserIndexerTest {
 
     indexer.createStoreTask(trillian).update(index);
 
-    verify(index).store(Id.of(trillian), UserPermissions.read(trillian).asShiroString(), trillian);
+    verify(index).store(Id.of(User.class, trillian), UserPermissions.read(trillian).asShiroString(), trillian);
   }
 
   @Test
@@ -98,7 +98,7 @@ class UserIndexerTest {
 
     indexer.createDeleteTask(trillian).update(index);
 
-    verify(index.delete()).byId(Id.of(trillian));
+    verify(index.delete()).byId(Id.of(User.class, trillian));
   }
 
   @Test
@@ -111,8 +111,8 @@ class UserIndexerTest {
     reIndexAll.update(index);
 
     verify(index.delete()).all();
-    verify(index).store(Id.of(trillian), UserPermissions.read(trillian).asShiroString(), trillian);
-    verify(index).store(Id.of(slarti), UserPermissions.read(slarti).asShiroString(), slarti);
+    verify(index).store(Id.of(User.class, trillian), UserPermissions.read(trillian).asShiroString(), trillian);
+    verify(index).store(Id.of(User.class, slarti), UserPermissions.read(slarti).asShiroString(), slarti);
   }
 
   @Test
@@ -124,7 +124,7 @@ class UserIndexerTest {
 
     verify(searchEngine.forType(User.class)).update(captor.capture());
     captor.getValue().update(index);
-    verify(index.delete()).byId(Id.of(trillian));
+    verify(index.delete()).byId(Id.of(User.class, trillian));
   }
 
 }


### PR DESCRIPTION
## Proposed changes

Id's can now be combined with more than just a repository. It is now possible to build a more complex Id such as Comment -> Pull request -> Repository. The id's now bound to a specific type. This makes it harder to accidentally use a id within an index of the wrong type.

Changelog entry is not required, because the restructured api is not yet released.

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] New code is covered with unit tests

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
