### PR TITLE
fix redundant git repo closing

### DIFF
--- a/gradle/changelog/redundant_git_repo_closing.yaml
+++ b/gradle/changelog/redundant_git_repo_closing.yaml
@@ -1,0 +1,2 @@
+- type: Fixed
+  description: redundant git repo closing in some commands ([#1789](https://github.com/scm-manager/scm-manager/pull/1789))

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitContext.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitContext.java
@@ -24,6 +24,7 @@
 
 package sonia.scm.repository.spi;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sonia.scm.api.v2.resources.GitRepositoryConfigStoreProvider;
@@ -117,6 +118,11 @@ public class GitContext implements Closeable, RepositoryProvider
 
   void setConfig(GitRepositoryConfig newConfig) {
     storeProvider.get(repository).set(newConfig);
+  }
+
+  @VisibleForTesting
+  void setGitRepository(org.eclipse.jgit.lib.Repository gitRepository) {
+    this.gitRepository = gitRepository;
   }
 
   GitConfig getGlobalConfig() {

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitLogCommand.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitLogCommand.java
@@ -91,6 +91,7 @@ public class GitLogCommand extends AbstractGitCommand implements LogCommand
    * @return
    */
   @Override
+  @SuppressWarnings("java:S2093")
   public Changeset getChangeset(String revision, LogCommandRequest request)
   {
     if (logger.isDebugEnabled())
@@ -147,7 +148,6 @@ public class GitLogCommand extends AbstractGitCommand implements LogCommand
     {
       IOUtil.close(converter);
       GitUtil.release(revWalk);
-      GitUtil.close(gr);
     }
 
     return changeset;
@@ -176,13 +176,13 @@ public class GitLogCommand extends AbstractGitCommand implements LogCommand
    * @throws IOException
    */
   @Override
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings("java:S2093")
   public ChangesetPagingResult getChangesets(LogCommandRequest request) {
-    try (org.eclipse.jgit.lib.Repository gitRepository = open()) {
+    try {
       if (Strings.isNullOrEmpty(request.getBranch())) {
         request.setBranch(context.getConfig().getDefaultBranch());
       }
-      return new GitLogComputer(this.repository.getId(), gitRepository, converterFactory).compute(request);
+      return new GitLogComputer(this.repository.getId(), open(), converterFactory).compute(request);
     } catch (IOException e) {
       throw new InternalRepositoryException(repository, "could not create change log", e);
     }

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitModificationsCommand.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitModificationsCommand.java
@@ -62,6 +62,7 @@ public class GitModificationsCommand extends AbstractGitCommand implements Modif
   }
 
   @Override
+  @SuppressWarnings("java:S2093")
   public Modifications getModifications(String baseRevision, String revision) {
     org.eclipse.jgit.lib.Repository gitRepository = null;
     RevWalk revWalk = null;
@@ -84,7 +85,6 @@ public class GitModificationsCommand extends AbstractGitCommand implements Modif
       throw new InternalRepositoryException(entity(repository), "could not open repository", ex);
     } finally {
       GitUtil.release(revWalk);
-      GitUtil.close(gitRepository);
     }
     return null;
   }

--- a/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/AbstractRemoteCommandTestBase.java
+++ b/scm-plugins/scm-git-plugin/src/test/java/sonia/scm/repository/spi/AbstractRemoteCommandTestBase.java
@@ -50,8 +50,8 @@ import java.io.File;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 //~--- JDK imports ------------------------------------------------------------
 
@@ -83,9 +83,9 @@ public class AbstractRemoteCommandTestBase {
     eventFactory = mock(GitRepositoryHookEventFactory.class);
 
     handler = mock(GitRepositoryHandler.class);
-    when(handler.getDirectory(incomingRepository.getId())).thenReturn(
+    lenient().when(handler.getDirectory(incomingRepository.getId())).thenReturn(
       incomingDirectory);
-    when(handler.getDirectory(outgoingRepository.getId())).thenReturn(
+    lenient().when(handler.getDirectory(outgoingRepository.getId())).thenReturn(
       outgoingDirectory);
   }
 


### PR DESCRIPTION
## Proposed changes

Both the GitLogCommand and the GitModificationsCommand incorrectly closed the underlying git repository. This caused the git repository to be opened once but closed twice, which in turn flooded the logs with avoidable warnings and affected performance. The redundant closing of the git repo has been removed from both commands.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
