### PR TITLE
Fix broken login page if login info response could not be parsed

### DIFF
--- a/gradle/changelog/broken_login_page.yaml
+++ b/gradle/changelog/broken_login_page.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Broken login page if login info response could not be parsed ([#1791](https://github.com/scm-manager/scm-manager/issues/1791) and [#1795](https://github.com/scm-manager/scm-manager/pull/1795))

--- a/scm-ui/ui-webapp/src/components/LoginInfo.tsx
+++ b/scm-ui/ui-webapp/src/components/LoginInfo.tsx
@@ -39,21 +39,54 @@ type State = {
   loading?: boolean;
 };
 
+type NoOpErrorBoundaryProps = {};
+
+type NoOpErrorBoundaryState = {
+  error?: Error;
+};
+
+class NoOpErrorBoundary extends React.Component<NoOpErrorBoundaryProps, NoOpErrorBoundaryState> {
+  constructor(props: NoOpErrorBoundaryProps) {
+    super(props);
+    this.state = {};
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  componentDidCatch(error: Error) {
+    // eslint-disable-next-line no-console
+    if (console && console.error) {
+      // eslint-disable-next-line no-console
+      console.error("failed to render login info", error);
+    }
+  }
+
+  render() {
+    if (this.state.error) {
+      return null;
+    }
+
+    return this.props.children;
+  }
+}
+
 class LoginInfo extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
-      loading: !!props.loginInfoLink
+      loading: !!props.loginInfoLink,
     };
   }
 
   fetchLoginInfo = (url: string) => {
     return fetch(url)
-      .then(response => response.json())
-      .then(info => {
+      .then((response) => response.json())
+      .then((info) => {
         this.setState({
           info,
-          loading: false
+          loading: false,
         });
       });
   };
@@ -74,16 +107,18 @@ class LoginInfo extends React.Component<Props, State> {
     }
     this.timeout(1000, this.fetchLoginInfo(loginInfoLink)).catch(() => {
       this.setState({
-        loading: false
+        loading: false,
       });
     });
   }
 
   createInfoPanel = (info: LoginInfoResponse) => (
-    <div className="column is-7 is-offset-1 is-paddingless">
-      <InfoBox item={info.feature} type="feature" />
-      <InfoBox item={info.plugin} type="plugin" />
-    </div>
+    <NoOpErrorBoundary>
+      <div className="column is-7 is-offset-1 is-paddingless">
+        <InfoBox item={info.feature} type="feature" />
+        <InfoBox item={info.plugin} type="plugin" />
+      </div>
+    </NoOpErrorBoundary>
   );
 
   render() {


### PR DESCRIPTION
## Proposed changes

The login page shows an error which hides the login form if the server response could not be parsed or if some json elements are missing. The change will catch such errors and log them to the console of the browser.

Fixes #1791

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
