### PR TITLE
Prevent multiple instances of working copy pool

### DIFF
--- a/gradle/changelog/single_working_copy_pool.yaml
+++ b/gradle/changelog/single_working_copy_pool.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Prevent multiple working copy pools ([#1797](https://github.com/scm-manager/scm-manager/issues/1797))

--- a/scm-core/src/main/java/sonia/scm/repository/work/SimpleCachingWorkingCopyPool.java
+++ b/scm-core/src/main/java/sonia/scm/repository/work/SimpleCachingWorkingCopyPool.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import sonia.scm.util.IOUtil;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.io.File;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -81,6 +82,7 @@ import static java.util.Optional.of;
  *   <li>Wait for a cached directory on parallel requests</li>
  * </ul>
  */
+@Singleton
 public class SimpleCachingWorkingCopyPool implements WorkingCopyPool {
 
   public static final int DEFAULT_WORKING_COPY_POOL_SIZE = 5;


### PR DESCRIPTION
## Proposed changes

The working copy pool has to be a singleton, because
otherwise there could be multiple instances with their
own caches and therefore no reuse and maybe more relevant
working directories that will never be deleted.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
