### PR TITLE
Fix missing encoding of useBranch hook

### DIFF
--- a/gradle/changelog/usebranch_encoding.yaml
+++ b/gradle/changelog/usebranch_encoding.yaml
@@ -1,0 +1,2 @@
+- type: Fixed
+  description: Missing encoding of useBranch api ([#1798](https://github.com/scm-manager/scm-manager/pull/1798))

--- a/scm-ui/ui-api/src/branches.test.ts
+++ b/scm-ui/ui-api/src/branches.test.ts
@@ -51,6 +51,16 @@ describe("Test branches hooks", () => {
     },
   };
 
+  const feature: Branch = {
+    name: "feature/something-special",
+    revision: "42",
+    _links: {
+      delete: {
+        href: "/hog/branches/feature%2Fsomething-special",
+      },
+    },
+  };
+
   const branches: BranchCollection = {
     _embedded: {
       branches: [develop],
@@ -101,10 +111,10 @@ describe("Test branches hooks", () => {
   });
 
   describe("useBranch tests", () => {
-    const fetchBranch = async () => {
-      fetchMock.getOnce("/api/v2/hog/branches/develop", develop);
+    const fetchBranch = async (name: string, branch: Branch) => {
+      fetchMock.getOnce("/api/v2/hog/branches/" + encodeURIComponent(name), branch);
 
-      const { result, waitFor } = renderHook(() => useBranch(repository, "develop"), {
+      const { result, waitFor } = renderHook(() => useBranch(repository, name), {
         wrapper: createWrapper(undefined, queryClient),
       });
 
@@ -118,8 +128,13 @@ describe("Test branches hooks", () => {
     };
 
     it("should return branch", async () => {
-      const branch = await fetchBranch();
+      const branch = await fetchBranch("develop", develop);
       expect(branch).toEqual(develop);
+    });
+
+    it("should escape branch name", async () => {
+      const branch = await fetchBranch("feature/something-special", feature);
+      expect(branch).toEqual(feature);
     });
   });
 

--- a/scm-ui/ui-api/src/branches.ts
+++ b/scm-ui/ui-api/src/branches.ts
@@ -43,7 +43,7 @@ export const useBranches = (repository: Repository): ApiResult<BranchCollection>
 export const useBranch = (repository: Repository, name: string): ApiResult<Branch> => {
   const link = requiredLink(repository, "branches");
   return useQuery<Branch, Error>(branchQueryKey(repository, name), () =>
-    apiClient.get(concat(link, name)).then((response) => response.json())
+    apiClient.get(concat(link, encodeURIComponent(name))).then((response) => response.json())
   );
 };
 

--- a/scm-ui/ui-webapp/src/repos/branches/containers/BranchRoot.tsx
+++ b/scm-ui/ui-webapp/src/repos/branches/containers/BranchRoot.tsx
@@ -39,7 +39,7 @@ type Params = {
 
 const BranchRoot: FC<Props> = ({ repository }) => {
   const match = useRouteMatch<Params>();
-  const { isLoading, error, data: branch } = useBranch(repository, match.params.branch);
+  const { isLoading, error, data: branch } = useBranch(repository, decodeURIComponent(match.params.branch));
   const location = useLocation();
 
   if (isLoading) {


### PR DESCRIPTION
## Proposed changes

The useBranch hook does not encode the branch name before creating the url. This has not lead to an error, because the BranchRoot component has used the hook with an already encoded branch name.
But this is not the expected behaviour a user of the api should not be forced to remember that the branch name must be encoded. The new behaviour is that the useBranch hook encodes the branch name and the BranchRoot component now decodes the name before it is used with the hook.

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] New code is covered with unit tests
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
