### PR TITLE
Use SLF4J for javahg internal logs

### DIFF
--- a/gradle/changelog/hg_logger.yaml
+++ b/gradle/changelog/hg_logger.yaml
@@ -1,0 +1,2 @@
+- type: Fixed
+  description: Use correct logger for mercurial internal commands ([#1804](https://github.com/scm-manager/scm-manager/pull/1804))

--- a/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/log/HgLoggerFactoryBinder.java
+++ b/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/log/HgLoggerFactoryBinder.java
@@ -1,0 +1,45 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.log;
+
+import com.aragost.javahg.log.LoggerFactory;
+import sonia.scm.plugin.Extension;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+@Extension
+public class HgLoggerFactoryBinder implements ServletContextListener {
+  @Override
+  public void contextInitialized(ServletContextEvent servletContextEvent) {
+    // Set our own LoggerFactory to prevent usage of javahg fallback JULLogger
+    System.setProperty(LoggerFactory.class.getName(), HgLoggerFactory.class.getName());
+  }
+
+  @Override
+  public void contextDestroyed(ServletContextEvent servletContextEvent) {
+    // Do nothing
+  }
+}


### PR DESCRIPTION
## Proposed changes

Use own logger for mercurial internal commands. This prevents log overflow by javahg's JULLogger.

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [x] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [x] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [x] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [x] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
