### PR TITLE
Fix deletion of repositories from search index

### DIFF
--- a/gradle/changelog/repository_index.yaml
+++ b/gradle/changelog/repository_index.yaml
@@ -1,0 +1,2 @@
+- type: Fixed
+  description: Deletion of repositories from search index ([#1813](https://github.com/scm-manager/scm-manager/pull/1813))

--- a/scm-webapp/src/main/java/sonia/scm/repository/RepositoryIndexer.java
+++ b/scm-webapp/src/main/java/sonia/scm/repository/RepositoryIndexer.java
@@ -43,7 +43,7 @@ import javax.inject.Singleton;
 public class RepositoryIndexer implements Indexer<Repository> {
 
   @VisibleForTesting
-  static final int VERSION = 3;
+  static final int VERSION = 4;
 
   private final SearchEngine searchEngine;
 
@@ -92,7 +92,7 @@ public class RepositoryIndexer implements Indexer<Repository> {
   public SerializableIndexTask<Repository> createDeleteTask(Repository repository) {
     return index -> {
       if (Repository.class.equals(index.getDetails().getType())) {
-        index.delete().byId(Id.of(Repository.class, repository.getId()));
+        index.delete().byId(id(repository));
       } else {
         index.delete().by(Repository.class, repository).execute();
       }
@@ -101,9 +101,14 @@ public class RepositoryIndexer implements Indexer<Repository> {
 
   private static void store(Index<Repository> index, Repository repository) {
     index.store(
-      Id.of(Repository.class, repository).and(repository),
+      id(repository),
       RepositoryPermissions.read(repository).asShiroString(),
-      repository);
+      repository
+    );
+  }
+
+  private static Id<Repository> id(Repository repository) {
+    return Id.of(Repository.class, repository).and(repository);
   }
 
   public static class ReIndexAll extends ReIndexAllTask<Repository> {

--- a/scm-webapp/src/test/java/sonia/scm/repository/RepositoryIndexerTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/repository/RepositoryIndexerTest.java
@@ -97,7 +97,7 @@ class RepositoryIndexerTest {
     when(index.getDetails().getType()).then(ic -> Repository.class);
     indexer.createDeleteTask(heartOfGold).update(index);
 
-    verify(index.delete()).byId(Id.of(Repository.class, heartOfGold));
+    verify(index.delete()).byId(Id.of(Repository.class, heartOfGold).and(heartOfGold));
   }
 
   @Test


### PR DESCRIPTION
## Proposed changes

The search id for the deletion of repositories are missing the additional repository field.

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] New code is covered with unit tests
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
