### PR TITLE
Add delete store method for configuration store

### DIFF
--- a/gradle/changelog/delete_config_store.yaml
+++ b/gradle/changelog/delete_config_store.yaml
@@ -1,4 +1,4 @@
 - type: Added
   description: Add method to delete whole configuration store ([#1814](https://github.com/scm-manager/scm-manager/pull/1814))
-- type: Changed
+- type: Added
   description: Move DangerZone styling to ui-components (([#1814](https://github.com/scm-manager/scm-manager/pull/1814)))

--- a/gradle/changelog/delete_config_store.yaml
+++ b/gradle/changelog/delete_config_store.yaml
@@ -1,0 +1,2 @@
+- type: Added
+  description: Add method to delete whole configuration store ([#1814](https://github.com/scm-manager/scm-manager/pull/1814))

--- a/gradle/changelog/delete_config_store.yaml
+++ b/gradle/changelog/delete_config_store.yaml
@@ -1,2 +1,4 @@
 - type: Added
   description: Add method to delete whole configuration store ([#1814](https://github.com/scm-manager/scm-manager/pull/1814))
+- type: Changed
+  description: Move DangerZone styling to ui-components (([#1814](https://github.com/scm-manager/scm-manager/pull/1814)))

--- a/scm-core/src/main/java/sonia/scm/store/AbstractStore.java
+++ b/scm-core/src/main/java/sonia/scm/store/AbstractStore.java
@@ -67,7 +67,7 @@ public abstract class AbstractStore<T> implements ConfigurationStore<T> {
   @Override
   public void delete() {
     if (readOnly.getAsBoolean()) {
-      throw new StoreReadOnlyException(storeObject);
+      throw new StoreReadOnlyException();
     }
     deleteObject();
     this.storeObject = null;

--- a/scm-core/src/main/java/sonia/scm/store/AbstractStore.java
+++ b/scm-core/src/main/java/sonia/scm/store/AbstractStore.java
@@ -29,10 +29,9 @@ import java.util.function.BooleanSupplier;
 /**
  * Base class for {@link ConfigurationStore}.
  *
+ * @param <T> type of store objects
  * @author Sebastian Sdorra
  * @since 1.16
- *
- * @param <T> type of store objects
  */
 public abstract class AbstractStore<T> implements ConfigurationStore<T> {
 
@@ -64,9 +63,18 @@ public abstract class AbstractStore<T> implements ConfigurationStore<T> {
     this.storeObject = object;
   }
 
+
+  @Override
+  public void delete() {
+    if (readOnly.getAsBoolean()) {
+      throw new StoreReadOnlyException(storeObject);
+    }
+    deleteObject();
+    this.storeObject = null;
+  }
+
   /**
    * Read the stored object.
-   *
    *
    * @return stored object
    */
@@ -75,8 +83,14 @@ public abstract class AbstractStore<T> implements ConfigurationStore<T> {
   /**
    * Write object to the store.
    *
-   *
    * @param object object to write
    */
   protected abstract void writeObject(T object);
+
+  /**
+   * Deletes store object.
+   *
+   * @since 2.24.0
+   */
+  protected abstract void deleteObject();
 }

--- a/scm-core/src/main/java/sonia/scm/store/ConfigurationStore.java
+++ b/scm-core/src/main/java/sonia/scm/store/ConfigurationStore.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.store;
 
 import java.util.Optional;
@@ -32,16 +32,13 @@ import static java.util.Optional.ofNullable;
  * ConfigurationStore for configuration objects. <strong>Note:</strong> the default
  * implementation use JAXB to marshall the configuration objects.
  *
- * @author Sebastian Sdorra
- *
  * @param <T> type of the configuration objects
+ * @author Sebastian Sdorra
  */
-public interface ConfigurationStore<T>
-{
+public interface ConfigurationStore<T> {
 
   /**
    * Returns the configuration object from store.
-   *
    *
    * @return configuration object from store
    */
@@ -50,20 +47,24 @@ public interface ConfigurationStore<T>
   /**
    * Returns the configuration object from store.
    *
-   *
    * @return configuration object from store
    */
   default Optional<T> getOptional() {
     return ofNullable(get());
   }
 
-  //~--- set methods ----------------------------------------------------------
-
   /**
    * Stores the given configuration object to the store.
-   *
    *
    * @param object configuration object to store
    */
   void set(T object);
+
+  /**
+   * Deletes the configuration.
+   * @since 2.24.0
+   */
+  default void delete() {
+    throw new StoreException("Delete operation is not implemented by the store");
+  }
 }

--- a/scm-core/src/main/java/sonia/scm/store/StoreReadOnlyException.java
+++ b/scm-core/src/main/java/sonia/scm/store/StoreReadOnlyException.java
@@ -46,6 +46,11 @@ public class StoreReadOnlyException extends ExceptionWithContext {
     LOG.error(getMessage());
   }
 
+  public StoreReadOnlyException() {
+    super(noContext(), "Store is read only, could not delete store");
+    LOG.error(getMessage());
+  }
+
     @Override
     public String getCode () {
       return CODE;

--- a/scm-dao-xml/src/main/java/sonia/scm/store/JAXBConfigurationStore.java
+++ b/scm-dao-xml/src/main/java/sonia/scm/store/JAXBConfigurationStore.java
@@ -28,6 +28,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.function.BooleanSupplier;
 
 /**
@@ -64,7 +66,6 @@ public class JAXBConfigurationStore<T> extends AbstractStore<T> {
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   protected T readObject() {
     LOG.debug("load {} from store {}", type, configFile);
 
@@ -81,5 +82,15 @@ public class JAXBConfigurationStore<T> extends AbstractStore<T> {
       temp -> context.marshal(object, temp.toFile()),
       configFile.toPath()
     );
+  }
+
+  @Override
+  protected void deleteObject() {
+    LOG.debug("deletes {}", configFile.getPath());
+    try {
+      Files.deleteIfExists(configFile.toPath());
+    } catch (IOException e) {
+      throw new StoreException("Failed to delete store object " + configFile.getPath(), e);
+    }
   }
 }

--- a/scm-dao-xml/src/main/java/sonia/scm/store/JAXBConfigurationStore.java
+++ b/scm-dao-xml/src/main/java/sonia/scm/store/JAXBConfigurationStore.java
@@ -26,10 +26,10 @@ package sonia.scm.store;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import sonia.scm.util.IOUtil;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.function.BooleanSupplier;
 
 /**
@@ -88,7 +88,7 @@ public class JAXBConfigurationStore<T> extends AbstractStore<T> {
   protected void deleteObject() {
     LOG.debug("deletes {}", configFile.getPath());
     try {
-      Files.deleteIfExists(configFile.toPath());
+      IOUtil.delete(configFile);
     } catch (IOException e) {
       throw new StoreException("Failed to delete store object " + configFile.getPath(), e);
     }

--- a/scm-dao-xml/src/test/java/sonia/scm/store/JAXBConfigurationStoreTest.java
+++ b/scm-dao-xml/src/test/java/sonia/scm/store/JAXBConfigurationStoreTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import sonia.scm.repository.Repository;
 import sonia.scm.repository.RepositoryReadOnlyChecker;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
@@ -44,15 +45,13 @@ public class JAXBConfigurationStoreTest extends StoreTestBase {
   private final RepositoryReadOnlyChecker readOnlyChecker = mock(RepositoryReadOnlyChecker.class);
 
   @Override
-  protected ConfigurationStoreFactory createStoreFactory()
-  {
+  protected ConfigurationStoreFactory createStoreFactory() {
     return new JAXBConfigurationStoreFactory(contextProvider, repositoryLocationResolver, readOnlyChecker);
   }
 
 
   @Test
-  public void shouldStoreAndLoadInRepository()
-  {
+  public void shouldStoreAndLoadInRepository() {
     Repository repository = new Repository("id", "git", "ns", "n");
     ConfigurationStore<StoreObject> store = createStoreFactory()
       .withType(StoreObject.class)
@@ -69,8 +68,7 @@ public class JAXBConfigurationStoreTest extends StoreTestBase {
 
 
   @Test
-  public void shouldNotWriteArchivedRepository()
-  {
+  public void shouldNotWriteArchivedRepository() {
     Repository repository = new Repository("id", "git", "ns", "n");
     when(readOnlyChecker.isReadOnly("id")).thenReturn(true);
     ConfigurationStore<StoreObject> store = createStoreFactory()
@@ -81,5 +79,39 @@ public class JAXBConfigurationStoreTest extends StoreTestBase {
 
     StoreObject storeObject = new StoreObject("value");
     assertThrows(RuntimeException.class, () -> store.set(storeObject));
+  }
+
+  @Test
+  public void shouldDeleteConfigStore() {
+    Repository repository = new Repository("id", "git", "ns", "n");
+    ConfigurationStore<StoreObject> store = createStoreFactory()
+      .withType(StoreObject.class)
+      .withName("test")
+      .forRepository(repository)
+      .build();
+
+    store.set(new StoreObject("value"));
+    StoreObject storeObject = store.get();
+
+    assertThat(storeObject).isNotNull();
+    assertThat(storeObject.getValue()).isEqualTo("value");
+
+    store.delete();
+    storeObject = store.get();
+
+    assertThat(storeObject).isNull();
+  }
+
+  @Test
+  public void shouldNotDeleteStoreForArchivedRepository() {
+    Repository repository = new Repository("id", "git", "ns", "n");
+    when(readOnlyChecker.isReadOnly("id")).thenReturn(true);
+    ConfigurationStore<StoreObject> store = createStoreFactory()
+      .withType(StoreObject.class)
+      .withName("test")
+      .forRepository(repository)
+      .build();
+
+    assertThrows(RuntimeException.class, store::delete);
   }
 }

--- a/scm-ui/ui-components/src/DangerZone.tsx
+++ b/scm-ui/ui-components/src/DangerZone.tsx
@@ -22,37 +22,28 @@
  * SOFTWARE.
  */
 
-import React, { FC } from "react";
-import { Repository, Tag } from "@scm-manager/ui-types";
-import { DangerZone, Subtitle } from "@scm-manager/ui-components";
-import { useTranslation } from "react-i18next";
-import DeleteTag from "./DeleteTag";
+import styled from "styled-components";
 
-type Props = {
-  repository: Repository;
-  tag: Tag;
-};
+export const DangerZone = styled.div`
+  border: 1px solid #ff6a88;
+  border-radius: 5px;
 
-const TagDangerZone: FC<Props> = ({ repository, tag }) => {
-  const [t] = useTranslation("repos");
+  > .level {
+    flex-flow: wrap;
 
-  const dangerZone = [];
+    .level-left {
+      max-width: 100%;
+    }
 
-  if (tag?._links?.delete) {
-    dangerZone.push(<DeleteTag repository={repository} tag={tag} key={dangerZone.length} />);
+    .level-right {
+      margin-top: 0.75rem;
+    }
   }
 
-  if (dangerZone.length === 0) {
-    return null;
+  > *:not(:last-child) {
+    padding-bottom: 1.5rem;
+    border-bottom: solid 2px whitesmoke;
   }
+`;
 
-  return (
-    <>
-      <hr />
-      <Subtitle subtitle={t("tag.dangerZone")} />
-      <DangerZone className="px-4 py-5">{dangerZone}</DangerZone>
-    </>
-  );
-};
-
-export default TagDangerZone;
+export default DangerZone;

--- a/scm-ui/ui-components/src/index.ts
+++ b/scm-ui/ui-components/src/index.ts
@@ -57,6 +57,7 @@ export { default as Paginator } from "./Paginator";
 export { default as LinkPaginator } from "./LinkPaginator";
 export { default as StatePaginator } from "./StatePaginator";
 
+export { default as DangerZone } from "./DangerZone";
 export { default as FileSize } from "./FileSize";
 export { default as ProtectedRoute } from "./ProtectedRoute";
 export { default as Help } from "./Help";

--- a/scm-ui/ui-webapp/src/repos/branches/containers/BranchDangerZone.tsx
+++ b/scm-ui/ui-webapp/src/repos/branches/containers/BranchDangerZone.tsx
@@ -24,9 +24,8 @@
 
 import React, { FC } from "react";
 import { Branch, Repository } from "@scm-manager/ui-types";
-import { Subtitle } from "@scm-manager/ui-components";
+import { DangerZone, Subtitle } from "@scm-manager/ui-components";
 import { useTranslation } from "react-i18next";
-import { DangerZoneContainer } from "../../containers/RepositoryDangerZone";
 import DeleteBranch from "./DeleteBranch";
 
 type Props = {
@@ -51,7 +50,7 @@ const BranchDangerZone: FC<Props> = ({ repository, branch }) => {
     <>
       <hr />
       <Subtitle subtitle={t("branch.dangerZone")} />
-      <DangerZoneContainer className="px-4 py-5">{dangerZone}</DangerZoneContainer>
+      <DangerZone className="px-4 py-5">{dangerZone}</DangerZone>
     </>
   );
 };

--- a/scm-ui/ui-webapp/src/repos/containers/RepositoryDangerZone.tsx
+++ b/scm-ui/ui-webapp/src/repos/containers/RepositoryDangerZone.tsx
@@ -23,9 +23,8 @@
  */
 import React, { FC } from "react";
 import { useTranslation } from "react-i18next";
-import styled from "styled-components";
 import { Repository } from "@scm-manager/ui-types";
-import { Subtitle } from "@scm-manager/ui-components";
+import { DangerZone, Subtitle } from "@scm-manager/ui-components";
 import RenameRepository from "./RenameRepository";
 import DeleteRepo from "./DeleteRepo";
 import ArchiveRepo from "./ArchiveRepo";
@@ -34,28 +33,6 @@ import UnarchiveRepo from "./UnarchiveRepo";
 type Props = {
   repository: Repository;
 };
-
-export const DangerZoneContainer = styled.div`
-  border: 1px solid #ff6a88;
-  border-radius: 5px;
-
-  > .level {
-    flex-flow: wrap;
-
-    .level-left {
-      max-width: 100%;
-    }
-
-    .level-right {
-      margin-top: 0.75rem;
-    }
-  }
-
-  > *:not(:last-child) {
-    padding-bottom: 1.5rem;
-    border-bottom: solid 2px whitesmoke;
-  }
-`;
 
 const RepositoryDangerZone: FC<Props> = ({ repository }) => {
   const [t] = useTranslation("repos");
@@ -81,7 +58,7 @@ const RepositoryDangerZone: FC<Props> = ({ repository }) => {
     <>
       <hr />
       <Subtitle subtitle={t("repositoryForm.dangerZone")} />
-      <DangerZoneContainer className="px-4 py-5">{dangerZone}</DangerZoneContainer>
+      <DangerZone className="px-4 py-5">{dangerZone}</DangerZone>
     </>
   );
 };


### PR DESCRIPTION
## Proposed changes

Add method to delete configuration store completely.

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
