### PR TITLE
Add extension points for source tree

### DIFF
--- a/gradle/changelog/ep_history_download.yaml
+++ b/gradle/changelog/ep_history_download.yaml
@@ -1,0 +1,2 @@
+- type: Added
+  description: Extension points for source tree ([#1816](https://github.com/scm-manager/scm-manager/pull/1816))

--- a/scm-ui/ui-extensions/src/ExtensionPoint.test.tsx
+++ b/scm-ui/ui-extensions/src/ExtensionPoint.test.tsx
@@ -188,7 +188,7 @@ describe("ExtensionPoint test", () => {
     };
 
     mockedBinder.hasExtension.mockReturnValue(true);
-    mockedBinder.getExtension.mockReturnValue(<Label name="One" />);
+    mockedBinder.getExtension.mockReturnValue(Label);
 
     const rendered = mount(<ExtensionPoint name="something.special" props={{ name: "Two" }} />);
     expect(rendered.text()).toBe("Extension Two");
@@ -258,6 +258,25 @@ describe("ExtensionPoint test", () => {
       </ExtensionPoint>
     );
     const text = rendered.text();
-    expect(text).toEqual("Outer -> Inner -> Children");;
+    expect(text).toEqual("Outer -> Inner -> Children");
+  });
+
+  it("should render children of non fc", () => {
+    const nonfc = (
+      <div>
+        <label>Non fc with children</label>
+      </div>
+    );
+
+    mockedBinder.hasExtension.mockReturnValue(true);
+    mockedBinder.getExtension.mockReturnValue(nonfc);
+
+    const rendered = mount(
+      <ExtensionPoint name="something.special">
+        <p>Children</p>
+      </ExtensionPoint>
+    );
+    const text = rendered.text();
+    expect(text).toEqual("Non fc with children");
   });
 });

--- a/scm-ui/ui-extensions/src/ExtensionPoint.tsx
+++ b/scm-ui/ui-extensions/src/ExtensionPoint.tsx
@@ -38,6 +38,7 @@ type Props = {
 const createInstance = (Component: any, props: object, key?: number) => {
   const instanceProps = {
     ...props,
+    ...(Component.props || {}),
     key,
   };
   if (React.isValidElement(Component)) {

--- a/scm-ui/ui-extensions/src/extensionPoints.ts
+++ b/scm-ui/ui-extensions/src/extensionPoints.ts
@@ -92,11 +92,12 @@ export type ReposSourcesTreeWrapperProps = {
 
 export type ReposSourcesTreeWrapperExtension = ExtensionPointDefinition<"repos.source.tree.wrapper", ReposSourcesTreeWrapperProps>;
 
-export type ReposSourcesTreeRowRightProps = {
+export type ReposSourcesTreeRowProps = {
   file: File;
 };
 
-export type ReposSourcesTreeRowRightExtension = ExtensionPointDefinition<"repos.sources.tree.row.right", ReposSourcesTreeWrapperProps>;
+export type ReposSourcesTreeRowRightExtension = ExtensionPointDefinition<"repos.sources.tree.row.right", ReposSourcesTreeRowProps>;
+export type ReposSourcesTreeRowAfterExtension = ExtensionPointDefinition<"repos.sources.tree.row.after", ReposSourcesTreeRowProps>;
 
 export type PrimaryNavigationLoginButtonProps = {
   links: Links;

--- a/scm-ui/ui-extensions/src/extensionPoints.ts
+++ b/scm-ui/ui-extensions/src/extensionPoints.ts
@@ -85,6 +85,7 @@ export type ReposSourcesEmptyActionbar = ExtensionPointDefinition<
 >;
 
 export type ReposSourcesTreeWrapperProps = {
+  repository: Repository;
   directory: File;
   baseUrl: string;
   revision: string;

--- a/scm-ui/ui-extensions/src/extensionPoints.ts
+++ b/scm-ui/ui-extensions/src/extensionPoints.ts
@@ -90,14 +90,23 @@ export type ReposSourcesTreeWrapperProps = {
   revision: string;
 };
 
-export type ReposSourcesTreeWrapperExtension = ExtensionPointDefinition<"repos.source.tree.wrapper", ReposSourcesTreeWrapperProps>;
+export type ReposSourcesTreeWrapperExtension = ExtensionPointDefinition<
+  "repos.source.tree.wrapper",
+  React.ComponentType<ReposSourcesTreeWrapperProps>
+>;
 
 export type ReposSourcesTreeRowProps = {
   file: File;
 };
 
-export type ReposSourcesTreeRowRightExtension = ExtensionPointDefinition<"repos.sources.tree.row.right", ReposSourcesTreeRowProps>;
-export type ReposSourcesTreeRowAfterExtension = ExtensionPointDefinition<"repos.sources.tree.row.after", ReposSourcesTreeRowProps>;
+export type ReposSourcesTreeRowRightExtension = ExtensionPointDefinition<
+  "repos.sources.tree.row.right",
+  React.ComponentType<ReposSourcesTreeRowProps>
+>;
+export type ReposSourcesTreeRowAfterExtension = ExtensionPointDefinition<
+  "repos.sources.tree.row.after",
+  React.ComponentType<ReposSourcesTreeRowProps>
+>;
 
 export type PrimaryNavigationLoginButtonProps = {
   links: Links;

--- a/scm-ui/ui-extensions/src/extensionPoints.ts
+++ b/scm-ui/ui-extensions/src/extensionPoints.ts
@@ -90,7 +90,13 @@ export type ReposSourcesTreeWrapperProps = {
   revision: string;
 };
 
-export type ReposSourcesTreeWrapperExtension = ExtensionPointDefinition<"repos.sources.tree.row.right", ReposSourcesTreeWrapperProps>;
+export type ReposSourcesTreeWrapperExtension = ExtensionPointDefinition<"repos.source.tree.wrapper", ReposSourcesTreeWrapperProps>;
+
+export type ReposSourcesTreeRowRightProps = {
+  file: File;
+};
+
+export type ReposSourcesTreeRowRightExtension = ExtensionPointDefinition<"repos.sources.tree.row.right", ReposSourcesTreeWrapperProps>;
 
 export type PrimaryNavigationLoginButtonProps = {
   links: Links;

--- a/scm-ui/ui-extensions/src/extensionPoints.ts
+++ b/scm-ui/ui-extensions/src/extensionPoints.ts
@@ -24,6 +24,7 @@
 
 import React from "react";
 import {
+  File,
   Branch,
   IndexResources,
   Links,
@@ -82,6 +83,14 @@ export type ReposSourcesEmptyActionbar = ExtensionPointDefinition<
   "repos.sources.empty.actionbar",
   ReposSourcesEmptyActionbarExtension
 >;
+
+export type ReposSourcesTreeWrapperProps = {
+  directory: File;
+  baseUrl: string;
+  revision: string;
+};
+
+export type ReposSourcesTreeWrapperExtension = ExtensionPointDefinition<"repos.sources.tree.row.right", ReposSourcesTreeWrapperProps>;
 
 export type PrimaryNavigationLoginButtonProps = {
   links: Links;

--- a/scm-ui/ui-webapp/src/repos/sources/components/FileTree.tsx
+++ b/scm-ui/ui-webapp/src/repos/sources/components/FileTree.tsx
@@ -26,13 +26,14 @@ import React, { FC } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { binder, ExtensionPoint } from "@scm-manager/ui-extensions";
-import { File } from "@scm-manager/ui-types";
+import { File, Repository } from "@scm-manager/ui-types";
 import FileTreeLeaf from "./FileTreeLeaf";
 import TruncatedNotification from "./TruncatedNotification";
 import { isRootPath } from "../utils/files";
 import { extensionPoints } from "@scm-manager/ui-extensions";
 
 type Props = {
+  repository: Repository;
   directory: File;
   baseUrl: string;
   revision: string;
@@ -56,7 +57,7 @@ export function findParent(path: string) {
   return "";
 }
 
-const FileTree: FC<Props> = ({ directory, baseUrl, revision, fetchNextPage, isFetchingNextPage }) => {
+const FileTree: FC<Props> = ({ repository, directory, baseUrl, revision, fetchNextPage, isFetchingNextPage }) => {
   const [t] = useTranslation("repos");
   const { path } = directory;
   const files: File[] = [];
@@ -79,6 +80,7 @@ const FileTree: FC<Props> = ({ directory, baseUrl, revision, fetchNextPage, isFe
   const baseUrlWithRevision = baseUrl + "/" + encodeURIComponent(revision);
 
   const extProps: extensionPoints.ReposSourcesTreeWrapperProps = {
+    repository,
     directory,
     baseUrl,
     revision,

--- a/scm-ui/ui-webapp/src/repos/sources/components/FileTree.tsx
+++ b/scm-ui/ui-webapp/src/repos/sources/components/FileTree.tsx
@@ -25,12 +25,12 @@
 import React, { FC } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
-import { binder } from "@scm-manager/ui-extensions";
+import { binder, ExtensionPoint } from "@scm-manager/ui-extensions";
 import { File } from "@scm-manager/ui-types";
-import { Notification } from "@scm-manager/ui-components";
 import FileTreeLeaf from "./FileTreeLeaf";
 import TruncatedNotification from "./TruncatedNotification";
-import {isRootPath} from "../utils/files";
+import { isRootPath } from "../utils/files";
+import { extensionPoints } from "@scm-manager/ui-extensions";
 
 type Props = {
   directory: File;
@@ -69,8 +69,8 @@ const FileTree: FC<Props> = ({ directory, baseUrl, revision, fetchNextPage, isFe
       revision,
       _links: {},
       _embedded: {
-        children: []
-      }
+        children: [],
+      },
     });
   }
 
@@ -78,30 +78,38 @@ const FileTree: FC<Props> = ({ directory, baseUrl, revision, fetchNextPage, isFe
 
   const baseUrlWithRevision = baseUrl + "/" + encodeURIComponent(revision);
 
+  const extProps: extensionPoints.ReposSourcesTreeWrapperProps = {
+    directory,
+    baseUrl,
+    revision,
+  };
+
   return (
     <div className="panel-block">
-      <table className="table table-hover table-sm is-fullwidth">
-        <thead>
-          <tr>
-            <FixedWidthTh />
-            <th>{t("sources.fileTree.name")}</th>
-            <th className="is-hidden-mobile">{t("sources.fileTree.length")}</th>
-            <th className="is-hidden-mobile">{t("sources.fileTree.commitDate")}</th>
-            <th className="is-hidden-touch">{t("sources.fileTree.description")}</th>
-            {binder.hasExtension("repos.sources.tree.row.right") && <th className="is-hidden-mobile" />}
-          </tr>
-        </thead>
-        <tbody>
-          {files.map((file: File) => (
-            <FileTreeLeaf key={file.name} file={file} baseUrl={baseUrlWithRevision} />
-          ))}
-        </tbody>
-      </table>
-      <TruncatedNotification
-        directory={directory}
-        fetchNextPage={fetchNextPage}
-        isFetchingNextPage={isFetchingNextPage}
-      />
+      <ExtensionPoint name="repos.source.tree.wrapper" props={extProps} renderAll={true} wrapper={true}>
+        <table className="table table-hover table-sm is-fullwidth">
+          <thead>
+            <tr>
+              <FixedWidthTh />
+              <th>{t("sources.fileTree.name")}</th>
+              <th className="is-hidden-mobile">{t("sources.fileTree.length")}</th>
+              <th className="is-hidden-mobile">{t("sources.fileTree.commitDate")}</th>
+              <th className="is-hidden-touch">{t("sources.fileTree.description")}</th>
+              {binder.hasExtension("repos.sources.tree.row.right") && <th className="is-hidden-mobile" />}
+            </tr>
+          </thead>
+          <tbody>
+            {files.map((file: File) => (
+              <FileTreeLeaf key={file.name} file={file} baseUrl={baseUrlWithRevision} />
+            ))}
+          </tbody>
+        </table>
+        <TruncatedNotification
+          directory={directory}
+          fetchNextPage={fetchNextPage}
+          isFetchingNextPage={isFetchingNextPage}
+        />
+      </ExtensionPoint>
     </div>
   );
 };

--- a/scm-ui/ui-webapp/src/repos/sources/components/FileTreeLeaf.tsx
+++ b/scm-ui/ui-webapp/src/repos/sources/components/FileTreeLeaf.tsx
@@ -88,29 +88,38 @@ class FileTreeLeaf extends React.Component<Props> {
     const renderFileSize = (file: File) => <FileSize bytes={file?.length ? file.length : 0} />;
     const renderCommitDate = (file: File) => <DateFromNow date={file.commitDate} />;
 
-    const extProps: extensionPoints.ReposSourcesTreeRowRightProps = {
+    const extProps: extensionPoints.ReposSourcesTreeRowProps = {
       file,
     };
 
     return (
-      <tr>
-        <td>{this.createFileIcon(file)}</td>
-        <MinWidthTd className="is-word-break">{this.createFileName(file)}</MinWidthTd>
-        <NoWrapTd className="is-hidden-mobile">
-          {file.directory ? "" : this.contentIfPresent(file, "length", renderFileSize)}
-        </NoWrapTd>
-        <td className="is-hidden-mobile">{this.contentIfPresent(file, "commitDate", renderCommitDate)}</td>
-        <MinWidthTd className={classNames("is-word-break", "is-hidden-touch")}>
-          {this.contentIfPresent(file, "description", (file) => file.description)}
-        </MinWidthTd>
-        {binder.hasExtension("repos.sources.tree.row.right") && (
-          <td className="is-hidden-mobile">
-            {!file.directory && (
-              <ExtensionPoint name="repos.sources.tree.row.right" props={extProps} renderAll={true} />
-            )}
-          </td>
-        )}
-      </tr>
+      <>
+        <tr>
+          <td>{this.createFileIcon(file)}</td>
+          <MinWidthTd className="is-word-break">{this.createFileName(file)}</MinWidthTd>
+          <NoWrapTd className="is-hidden-mobile">
+            {file.directory ? "" : this.contentIfPresent(file, "length", renderFileSize)}
+          </NoWrapTd>
+          <td className="is-hidden-mobile">{this.contentIfPresent(file, "commitDate", renderCommitDate)}</td>
+          <MinWidthTd className={classNames("is-word-break", "is-hidden-touch")}>
+            {this.contentIfPresent(file, "description", (file) => file.description)}
+          </MinWidthTd>
+          {binder.hasExtension("repos.sources.tree.row.right") && (
+            <td className="is-hidden-mobile">
+              {!file.directory && (
+                <ExtensionPoint name="repos.sources.tree.row.right" props={extProps} renderAll={true} />
+              )}
+            </td>
+          )}
+        </tr>
+        {binder.hasExtension("repos.sources.tree.row.after") ? (
+          <tr>
+            <td colSpan={0}>
+              <ExtensionPoint name="repos.sources.tree.row.after" props={extProps} renderAll={true} />
+            </td>
+          </tr>
+        ) : null}
+      </>
     );
   }
 }

--- a/scm-ui/ui-webapp/src/repos/sources/components/FileTreeLeaf.tsx
+++ b/scm-ui/ui-webapp/src/repos/sources/components/FileTreeLeaf.tsx
@@ -25,7 +25,7 @@ import * as React from "react";
 import { WithTranslation, withTranslation } from "react-i18next";
 import classNames from "classnames";
 import styled from "styled-components";
-import { binder, ExtensionPoint } from "@scm-manager/ui-extensions";
+import { binder, ExtensionPoint, extensionPoints } from "@scm-manager/ui-extensions";
 import { File } from "@scm-manager/ui-types";
 import { DateFromNow, FileSize, Tooltip, Icon } from "@scm-manager/ui-components";
 import FileIcon from "./FileIcon";
@@ -88,6 +88,10 @@ class FileTreeLeaf extends React.Component<Props> {
     const renderFileSize = (file: File) => <FileSize bytes={file?.length ? file.length : 0} />;
     const renderCommitDate = (file: File) => <DateFromNow date={file.commitDate} />;
 
+    const extProps: extensionPoints.ReposSourcesTreeRowRightProps = {
+      file,
+    };
+
     return (
       <tr>
         <td>{this.createFileIcon(file)}</td>
@@ -97,18 +101,12 @@ class FileTreeLeaf extends React.Component<Props> {
         </NoWrapTd>
         <td className="is-hidden-mobile">{this.contentIfPresent(file, "commitDate", renderCommitDate)}</td>
         <MinWidthTd className={classNames("is-word-break", "is-hidden-touch")}>
-          {this.contentIfPresent(file, "description", file => file.description)}
+          {this.contentIfPresent(file, "description", (file) => file.description)}
         </MinWidthTd>
         {binder.hasExtension("repos.sources.tree.row.right") && (
           <td className="is-hidden-mobile">
             {!file.directory && (
-              <ExtensionPoint
-                name="repos.sources.tree.row.right"
-                props={{
-                  file
-                }}
-                renderAll={true}
-              />
+              <ExtensionPoint name="repos.sources.tree.row.right" props={extProps} renderAll={true} />
             )}
           </td>
         )}

--- a/scm-ui/ui-webapp/src/repos/sources/components/FileTreeLeaf.tsx
+++ b/scm-ui/ui-webapp/src/repos/sources/components/FileTreeLeaf.tsx
@@ -112,13 +112,7 @@ class FileTreeLeaf extends React.Component<Props> {
             </td>
           )}
         </tr>
-        {binder.hasExtension("repos.sources.tree.row.after") ? (
-          <tr>
-            <td colSpan={0}>
-              <ExtensionPoint name="repos.sources.tree.row.after" props={extProps} renderAll={true} />
-            </td>
-          </tr>
-        ) : null}
+        <ExtensionPoint name="repos.sources.tree.row.after" props={extProps} renderAll={true} />
       </>
     );
   }

--- a/scm-ui/ui-webapp/src/repos/sources/components/FileTreeLeaf.tsx
+++ b/scm-ui/ui-webapp/src/repos/sources/components/FileTreeLeaf.tsx
@@ -44,6 +44,14 @@ const NoWrapTd = styled.td`
   white-space: nowrap;
 `;
 
+const ExtensionTd = styled.td`
+  white-space: nowrap;
+
+  > *:not(:last-child) {
+    margin-right: 0.5rem;
+  }
+`;
+
 class FileTreeLeaf extends React.Component<Props> {
   createFileIcon = (file: File) => {
     return (
@@ -105,11 +113,11 @@ class FileTreeLeaf extends React.Component<Props> {
             {this.contentIfPresent(file, "description", (file) => file.description)}
           </MinWidthTd>
           {binder.hasExtension("repos.sources.tree.row.right") && (
-            <td className="is-hidden-mobile">
+            <ExtensionTd className="is-hidden-mobile">
               {!file.directory && (
                 <ExtensionPoint name="repos.sources.tree.row.right" props={extProps} renderAll={true} />
               )}
-            </td>
+            </ExtensionTd>
           )}
         </tr>
         <ExtensionPoint name="repos.sources.tree.row.after" props={extProps} renderAll={true} />

--- a/scm-ui/ui-webapp/src/repos/sources/containers/Sources.tsx
+++ b/scm-ui/ui-webapp/src/repos/sources/containers/Sources.tsx
@@ -149,6 +149,7 @@ const Sources: FC<Props> = ({ repository, branches, selectedBranch, baseUrl }) =
       } else {
         body = (
           <FileTree
+            repository={repository}
             directory={file}
             revision={revision || file.revision}
             baseUrl={baseUrl + "/sources"}


### PR DESCRIPTION
## Proposed changes

This change will add an extension point which allows to wrap the source tree. This is required in order to use a context provider e.g. to capture a selected file. Another extension point allows to add a row between the row of a file.
In order to implement the extension points ui-extensions has now a wrapper property and passes the children of an extension point to implementing extension.

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] New code is covered with unit tests
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
