### PR TITLE
Fix bugs in svn and source tree for folders with a % in the name

### DIFF
--- a/gradle/changelog/percentage_in_path.yaml
+++ b/gradle/changelog/percentage_in_path.yaml
@@ -1,0 +1,2 @@
+- type: Fixed
+  description: Bugs in svn and source tree for folders with a % in the name ([#1817](https://github.com/scm-manager/scm-manager/issues/1817) and [#1818](https://github.com/scm-manager/scm-manager/pull/1818))

--- a/scm-plugins/scm-svn-plugin/build.gradle
+++ b/scm-plugins/scm-svn-plugin/build.gradle
@@ -27,7 +27,7 @@ plugins {
   id 'org.scm-manager.smp' version '0.8.5'
 }
 
-def svnkitVersion = '1.10.1-scm2'
+def svnkitVersion = '1.10.3-scm1'
 
 dependencies {
   implementation("sonia.svnkit:svnkit:${svnkitVersion}") {

--- a/scm-ui/ui-components/src/Breadcrumb.tsx
+++ b/scm-ui/ui-components/src/Breadcrumb.tsx
@@ -128,7 +128,7 @@ const Breadcrumb: FC<Props> = ({
     if (path) {
       const paths = path.split("/");
       return paths.map((pathFragment, index) => {
-        let currPath = paths.slice(0, index + 1).join("/");
+        let currPath = paths.slice(0, index + 1).map(encodeURIComponent).join("/");
         if (!currPath.endsWith("/")) {
           currPath = currPath + "/";
         }

--- a/scm-ui/ui-webapp/src/repos/sources/components/content/FileLink.test.ts
+++ b/scm-ui/ui-webapp/src/repos/sources/components/content/FileLink.test.ts
@@ -22,7 +22,8 @@
  * SOFTWARE.
  */
 
-import { createRelativeLink, createFolderLink } from "./FileLink";
+import { createRelativeLink, createFolderLink, encodePart } from "./FileLink";
+import { createLocation } from "history";
 import { File } from "@scm-manager/ui-types";
 
 describe("create relative link tests", () => {
@@ -47,8 +48,8 @@ describe("create folder link tests", () => {
       revision: "1a",
       _links: {},
       _embedded: {
-        children: []
-      }
+        children: [],
+      },
     };
   }
 
@@ -60,5 +61,21 @@ describe("create folder link tests", () => {
 
   it("should return base url if the directory path is empty", () => {
     expect(createFolderLink("src", dir(""))).toBe("src/");
+  });
+
+  it("should encode folder names with percent", () => {
+    expect(createFolderLink("src", dir("a%20b"))).toBe("src/a%2520b");
+  });
+});
+
+describe("link should keep encoded percentages", () => {
+  it("history should create a location with encoded pathname", () => {
+    // For version 4.x of history we have to double encode uri components with a '%',
+    // because of the following issue https://github.com/remix-run/history/issues/505
+    // The issue is fixed with 5.x, but react-router-dom seams not to work with 5.x.
+    // So we have to stick with 4.x and the double encoding, until react-router-dom uses version 5.x.
+    // This test is mainly to remind us to remove the double encoding after update to 5.x.
+    const location = createLocation(encodePart("a%20b"));
+    expect(location.pathname).toBe("a%2520b");
   });
 });

--- a/scm-ui/ui-webapp/src/repos/sources/components/content/FileLink.test.ts
+++ b/scm-ui/ui-webapp/src/repos/sources/components/content/FileLink.test.ts
@@ -63,8 +63,8 @@ describe("create folder link tests", () => {
     expect(createFolderLink("src", dir(""))).toBe("src/");
   });
 
-  it("should encode folder names with percent", () => {
-    expect(createFolderLink("src", dir("a%20b"))).toBe("src/a%2520b");
+  it("should double encode folder names with percent", () => {
+    expect(createFolderLink("src", dir("a%20b"))).toBe("src/a%252520b/");
   });
 });
 

--- a/scm-ui/ui-webapp/src/repos/sources/components/content/FileLink.tsx
+++ b/scm-ui/ui-webapp/src/repos/sources/components/content/FileLink.tsx
@@ -46,6 +46,14 @@ const isLocalRepository = (repositoryUrl: string) => {
   return host === window.location.hostname;
 };
 
+export const encodePart = (part: string) => {
+  const encoded = encodeURIComponent(part);
+  if (part.includes("%")) {
+    return encodeURIComponent(encoded);
+  }
+  return encoded;
+};
+
 export const createRelativeLink = (repositoryUrl: string) => {
   const paths = repositoryUrl.split("/");
   return "/" + paths.slice(3).join("/");
@@ -54,7 +62,7 @@ export const createRelativeLink = (repositoryUrl: string) => {
 export const createFolderLink = (base: string, file: File) => {
   let link = base;
   if (file.path) {
-    let path = file.path.split("/").map(encodeURIComponent).join("/");
+    let path = file.path.split("/").map(encodePart).join("/");
     if (path.startsWith("/")) {
       path = path.substring(1);
     }


### PR DESCRIPTION
## Proposed changes

Update svnkit to version 1.10.3-scm1 to fix svn the encoding issue in svn dav protocol.

- https://github.com/scm-manager/svnkit-patches/blob/master/master/svnkit-dav.path-info-decoding
- https://github.com/scm-manager/svn-server-spec/commit/a8e4a8f6a1aae05123a4b567f8c1a0263a5be19c

This change will also fix problems in  the source tree for folders with a % in the name.

Fixes #1817 

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] New code is covered with unit tests
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
