### PR TITLE
Clear external group cache on explicit logout

### DIFF
--- a/gradle/changelog/clear_external_group_cache.yaml
+++ b/gradle/changelog/clear_external_group_cache.yaml
@@ -1,0 +1,2 @@
+- type: Changed
+  description: Clear external group cache on explicit user logout ([#1819](https://github.com/scm-manager/scm-manager/pull/1819))

--- a/scm-core/src/main/java/sonia/scm/security/LogoutEvent.java
+++ b/scm-core/src/main/java/sonia/scm/security/LogoutEvent.java
@@ -1,0 +1,42 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.security;
+
+import lombok.Value;
+import org.apache.shiro.subject.PrincipalCollection;
+import sonia.scm.event.Event;
+
+/**
+ * Event is fired whenever a user explicitly logs out.
+ * The event is not fired if a session expires or a token is blacklisted,
+ * the event is only fired if the user calls the rest method for the logout.
+ *
+ * @since 2.14.0
+ */
+@Value
+@Event
+public class LogoutEvent {
+  PrincipalCollection principal;
+}

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/AuthenticationResource.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/AuthenticationResource.java
@@ -24,6 +24,7 @@
 
 package sonia.scm.api.v2.resources;
 
+import com.github.legman.EventBus;
 import com.google.inject.Inject;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -40,6 +41,7 @@ import io.swagger.v3.oas.annotations.security.SecuritySchemes;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.subject.PrincipalCollection;
 import org.apache.shiro.subject.Subject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,6 +51,7 @@ import sonia.scm.security.AccessTokenBuilder;
 import sonia.scm.security.AccessTokenBuilderFactory;
 import sonia.scm.security.AccessTokenCookieIssuer;
 import sonia.scm.security.AllowAnonymousAccess;
+import sonia.scm.security.LogoutEvent;
 import sonia.scm.security.Scope;
 import sonia.scm.security.Tokens;
 import sonia.scm.web.VndMediaType;
@@ -86,7 +89,6 @@ import java.util.Optional;
   @Tag(name = "Authentication", description = "Authentication related endpoints")
 })
 @Path(AuthenticationResource.PATH)
-@AllowAnonymousAccess
 public class AuthenticationResource {
 
   private static final Logger LOG = LoggerFactory.getLogger(AuthenticationResource.class);
@@ -99,17 +101,19 @@ public class AuthenticationResource {
   private final Counter loginAttemptsCounter;
   private final Counter loginFailedCounter;
   private final Counter logoutCounter;
+  private final EventBus eventBus;
 
   @Inject(optional = true)
   private LogoutRedirection logoutRedirection;
 
   @Inject
-  public AuthenticationResource(AccessTokenBuilderFactory tokenBuilderFactory, AccessTokenCookieIssuer cookieIssuer, MeterRegistry meterRegistry) {
+  public AuthenticationResource(AccessTokenBuilderFactory tokenBuilderFactory, AccessTokenCookieIssuer cookieIssuer, MeterRegistry meterRegistry, EventBus eventBus) {
     this.tokenBuilderFactory = tokenBuilderFactory;
     this.cookieIssuer = cookieIssuer;
     this.loginAttemptsCounter = AuthenticationMetrics.loginAttempts(meterRegistry, AUTH_METRIC_TYPE);
     this.loginFailedCounter = AuthenticationMetrics.loginFailed(meterRegistry, AUTH_METRIC_TYPE);
     this.logoutCounter = AuthenticationMetrics.logout(meterRegistry, AUTH_METRIC_TYPE);
+    this.eventBus = eventBus;
   }
 
   @POST
@@ -134,6 +138,7 @@ public class AuthenticationResource {
       schema = @Schema(implementation = ErrorDto.class)
     )
   )
+  @AllowAnonymousAccess
   public Response authenticateViaForm(
     @Context HttpServletRequest request,
     @Context HttpServletResponse response,
@@ -174,6 +179,7 @@ public class AuthenticationResource {
       schema = @Schema(implementation = ErrorDto.class)
     )
   )
+  @AllowAnonymousAccess
   public Response authenticateViaJSONBody(
     @Context HttpServletRequest request,
     @Context HttpServletResponse response,
@@ -238,7 +244,14 @@ public class AuthenticationResource {
   public Response logout(@Context HttpServletRequest request, @Context HttpServletResponse response) {
     logoutCounter.increment();
 
-    SecurityUtils.getSubject().logout();
+    Subject subject = SecurityUtils.getSubject();
+
+    PrincipalCollection principals = subject.getPrincipals();
+
+    subject.logout();
+
+    eventBus.post(new LogoutEvent(principals));
+
     // remove authentication cookie
     cookieIssuer.invalidate(request, response);
 

--- a/scm-webapp/src/main/java/sonia/scm/group/DefaultGroupCollector.java
+++ b/scm-webapp/src/main/java/sonia/scm/group/DefaultGroupCollector.java
@@ -25,12 +25,14 @@
 package sonia.scm.group;
 
 import com.cronutils.utils.VisibleForTesting;
+import com.github.legman.Subscribe;
 import com.google.common.collect.ImmutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sonia.scm.cache.Cache;
 import sonia.scm.cache.CacheManager;
 import sonia.scm.security.Authentications;
+import sonia.scm.security.LogoutEvent;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -76,6 +78,12 @@ public class DefaultGroupCollector implements GroupCollector {
     Set<String> groups = builder.build();
     LOG.debug("collected following groups for principal {}: {}", principal, groups);
     return groups;
+  }
+
+  @Subscribe(async = false)
+  public void clearCacheOn(LogoutEvent event) {
+    String principal = event.getPrincipal().getPrimaryPrincipal().toString();
+    cache.remove(principal);
   }
 
   private void appendInternalGroups(String principal, ImmutableSet.Builder<String> builder) {

--- a/scm-webapp/src/main/java/sonia/scm/security/SecurityRequests.java
+++ b/scm-webapp/src/main/java/sonia/scm/security/SecurityRequests.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.security;
 
 import javax.servlet.http.HttpServletRequest;
@@ -41,7 +41,11 @@ public final class SecurityRequests {
 
   public static boolean isAuthenticationRequest(HttpServletRequest request) {
     String uri = request.getRequestURI().substring(request.getContextPath().length());
-    return isAuthenticationRequest(uri);
+    return isAuthenticationRequest(uri) && !isLogoutMethod(request);
+  }
+
+  private static boolean isLogoutMethod(HttpServletRequest request) {
+    return "DELETE".equals(request.getMethod());
   }
 
   public static boolean isAuthenticationRequest(String uri) {

--- a/scm-webapp/src/test/java/sonia/scm/group/DefaultGroupCollectorTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/group/DefaultGroupCollectorTest.java
@@ -26,6 +26,7 @@ package sonia.scm.group;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import org.apache.shiro.subject.SimplePrincipalCollection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -36,6 +37,7 @@ import sonia.scm.SCMContext;
 import sonia.scm.cache.MapCache;
 import sonia.scm.cache.MapCacheManager;
 import sonia.scm.security.Authentications;
+import sonia.scm.security.LogoutEvent;
 
 import java.util.HashSet;
 import java.util.List;
@@ -96,6 +98,17 @@ class DefaultGroupCollectorTest {
     assertThat(groups).containsOnly("_authenticated", "awesome", "incredible");
 
     verify(groupResolver, never()).resolve("trillian");
+  }
+
+  @Test
+  void shouldClearCacheOnLogout() {
+    MapCache<String, Set<String>> cache = mapCacheManager.getCache(DefaultGroupCollector.CACHE_NAME);
+    cache.put("trillian", ImmutableSet.of("awesome", "incredible"));
+
+    SimplePrincipalCollection principal = new SimplePrincipalCollection("trillian", "Test");
+    collector.clearCacheOn(new LogoutEvent(principal));
+
+    assertThat(cache.get("trillian")).isNull();
   }
 
   @Test

--- a/scm-webapp/src/test/java/sonia/scm/security/SecurityRequestsTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/security/SecurityRequestsTest.java
@@ -21,41 +21,51 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.security;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.servlet.http.HttpServletRequest;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 /**
  * Created by masuewer on 04.07.18.
  */
-@RunWith(MockitoJUnitRunner.class)
-public class SecurityRequestsTest {
+@ExtendWith(MockitoExtension.class)
+class SecurityRequestsTest {
 
   @Mock
   private HttpServletRequest request;
 
   @Test
-  public void testIsAuthenticationRequestWithContextPath() {
+  void shouldReturnTrueWithContextPath() {
     when(request.getRequestURI()).thenReturn("/scm/api/auth/access_token");
     when(request.getContextPath()).thenReturn("/scm");
 
-    assertTrue(SecurityRequests.isAuthenticationRequest(request));
+    assertThat(SecurityRequests.isAuthenticationRequest(request)).isTrue();
   }
 
   @Test
-  public void testIsAuthenticationRequest() throws Exception {
-    assertTrue(SecurityRequests.isAuthenticationRequest("/api/auth/access_token"));
-    assertTrue(SecurityRequests.isAuthenticationRequest("/api/v2/auth/access_token"));
-    assertFalse(SecurityRequests.isAuthenticationRequest("/api/repositories"));
-    assertFalse(SecurityRequests.isAuthenticationRequest("/api/v2/repositories"));
+  void shouldDetectAuthenticationResource() {
+    assertThat(SecurityRequests.isAuthenticationRequest("/api/auth/access_token")).isTrue();
+    assertThat(SecurityRequests.isAuthenticationRequest("/api/v2/auth/access_token")).isTrue();
+    assertThat(SecurityRequests.isAuthenticationRequest("/api/repositories")).isFalse();
+    assertThat(SecurityRequests.isAuthenticationRequest("/api/v2/repositories")).isFalse();
   }
+
+  @Test
+  void shouldReturnFalseForLogout() {
+    when(request.getRequestURI()).thenReturn("/scm/api/auth/access_token");
+    when(request.getContextPath()).thenReturn("/scm");
+    when(request.getMethod()).thenReturn("DELETE");
+
+    assertThat(SecurityRequests.isAuthenticationRequest(request)).isFalse();
+  }
+
 }


### PR DESCRIPTION
## Proposed changes

Clears the external group cache whenever a user gets logged out by the logout rest method.

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] New code is covered with unit tests
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
