### PR TITLE
Add recursive deletion in modify command

### DIFF
--- a/scm-core/src/main/java/sonia/scm/repository/api/ModifyCommandBuilder.java
+++ b/scm-core/src/main/java/sonia/scm/repository/api/ModifyCommandBuilder.java
@@ -120,7 +120,11 @@ public class ModifyCommandBuilder {
    * @return This builder instance.
    */
   public ModifyCommandBuilder deleteFile(String path) {
-    request.addRequest(new ModifyCommandRequest.DeleteFileRequest(path));
+    return this.deleteFile(path, false);
+  }
+
+  public ModifyCommandBuilder deleteFile(String path, boolean recursive) {
+    request.addRequest(new ModifyCommandRequest.DeleteFileRequest(path, recursive));
     return this;
   }
 

--- a/scm-core/src/main/java/sonia/scm/repository/spi/ModifyCommand.java
+++ b/scm-core/src/main/java/sonia/scm/repository/spi/ModifyCommand.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.repository.spi;
 
 import java.io.File;
@@ -32,7 +32,7 @@ public interface ModifyCommand {
   String execute(ModifyCommandRequest request);
 
   interface Worker {
-    void delete(String toBeDeleted) throws IOException;
+    void delete(String toBeDeleted, boolean recursive) throws IOException;
 
     void create(String toBeCreated, File file, boolean overwrite) throws IOException;
 

--- a/scm-core/src/main/java/sonia/scm/repository/spi/ModifyCommandRequest.java
+++ b/scm-core/src/main/java/sonia/scm/repository/spi/ModifyCommandRequest.java
@@ -128,14 +128,24 @@ public class ModifyCommandRequest implements Resetable, Validateable, CommandWit
 
   public static class DeleteFileRequest implements PartialRequest {
     private final String path;
+    private final boolean recursive;
 
+    /**
+     * @deprecated This is kept for compatibility, only. Use {@link #DeleteFileRequest(String, boolean)} instead.
+     */
+    @Deprecated
     public DeleteFileRequest(String path) {
+      this(path, false);
+    }
+
+    public DeleteFileRequest(String path, boolean recursive) {
       this.path = path;
+      this.recursive = recursive;
     }
 
     @Override
     public void execute(ModifyCommand.Worker worker) throws IOException {
-      worker.delete(path);
+      worker.delete(path, recursive);
     }
   }
 

--- a/scm-core/src/main/java/sonia/scm/repository/spi/ModifyWorkerHelper.java
+++ b/scm-core/src/main/java/sonia/scm/repository/spi/ModifyWorkerHelper.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sonia.scm.ContextEntry;
 import sonia.scm.repository.Repository;
+import sonia.scm.util.IOUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -52,12 +53,16 @@ public interface ModifyWorkerHelper extends ModifyCommand.Worker {
   Logger LOG = LoggerFactory.getLogger(ModifyWorkerHelper.class);
 
   @Override
-  default void delete(String toBeDeleted) throws IOException {
+  default void delete(String toBeDeleted, boolean recursive) throws IOException {
     Path fileToBeDeleted = getTargetFile(toBeDeleted);
-    try {
-      Files.delete(fileToBeDeleted);
-    } catch (NoSuchFileException e) {
-      throw notFound(createFileContext(toBeDeleted));
+    if (recursive) {
+      IOUtil.delete(fileToBeDeleted.toFile());
+    } else {
+      try {
+        Files.delete(fileToBeDeleted);
+      } catch (NoSuchFileException e) {
+        throw notFound(createFileContext(toBeDeleted));
+      }
     }
     doScmDelete(toBeDeleted);
   }

--- a/scm-core/src/test/java/sonia/scm/repository/api/ModifyCommandBuilderTest.java
+++ b/scm-core/src/test/java/sonia/scm/repository/api/ModifyCommandBuilderTest.java
@@ -157,7 +157,16 @@ class ModifyCommandBuilderTest {
         .deleteFile("toBeDeleted")
         .execute();
 
-      verify(worker).delete("toBeDeleted");
+      verify(worker).delete("toBeDeleted", false);
+    }
+
+    @Test
+    void shouldExecuteRecursiveDelete() throws IOException {
+      initCommand()
+        .deleteFile("toBeDeleted", true)
+        .execute();
+
+      verify(worker).delete("toBeDeleted", true);
     }
 
     @Test

--- a/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/spi/HgModifyCommandTest.java
+++ b/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/spi/HgModifyCommandTest.java
@@ -65,13 +65,27 @@ public class HgModifyCommandTest extends AbstractHgCommandTestBase {
   @Test
   public void shouldRemoveFiles() {
     ModifyCommandRequest request = new ModifyCommandRequest();
-    request.addRequest(new ModifyCommandRequest.DeleteFileRequest("a.txt"));
+    request.addRequest(new ModifyCommandRequest.DeleteFileRequest("a.txt", false));
     request.setCommitMessage("this is great");
     request.setAuthor(new Person("Arthur Dent", "dent@hitchhiker.com"));
 
     String result = hgModifyCommand.execute(request);
 
     assertThat(cmdContext.open().tip().getNode()).isEqualTo(result);
+    assertThat(cmdContext.open().tip().getDeletedFiles().size()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldRemoveDirectoriesRecursively() {
+    ModifyCommandRequest request = new ModifyCommandRequest();
+    request.addRequest(new ModifyCommandRequest.DeleteFileRequest("c", true));
+    request.setCommitMessage("this is great");
+    request.setAuthor(new Person("Arthur Dent", "dent@hitchhiker.com"));
+
+    String result = hgModifyCommand.execute(request);
+
+    assertThat(cmdContext.open().tip().getNode()).isEqualTo(result);
+    assertThat(cmdContext.open().tip().getDeletedFiles().size()).isEqualTo(2);
   }
 
   @Test

--- a/scm-plugins/scm-svn-plugin/src/test/java/sonia/scm/repository/spi/SvnModifyCommandTest.java
+++ b/scm-plugins/scm-svn-plugin/src/test/java/sonia/scm/repository/spi/SvnModifyCommandTest.java
@@ -77,7 +77,7 @@ public class SvnModifyCommandTest extends AbstractSvnCommandTestBase {
   @Test
   public void shouldRemoveFiles() {
     ModifyCommandRequest request = new ModifyCommandRequest();
-    request.addRequest(new ModifyCommandRequest.DeleteFileRequest("a.txt"));
+    request.addRequest(new ModifyCommandRequest.DeleteFileRequest("a.txt", false));
     request.setCommitMessage("this is great");
     request.setAuthor(new Person("Arthur Dent", "dent@hitchhiker.com"));
 
@@ -85,6 +85,19 @@ public class SvnModifyCommandTest extends AbstractSvnCommandTestBase {
     WorkingCopy<File, File> workingCopy = workingCopyFactory.createWorkingCopy(context, null);
     assertThat(new File(workingCopy.getWorkingRepository().getAbsolutePath() + "/a.txt")).doesNotExist();
     assertThat(new File(workingCopy.getWorkingRepository().getAbsolutePath() + "/c")).exists();
+  }
+
+  @Test
+  public void shouldRemoveDirectory() {
+    ModifyCommandRequest request = new ModifyCommandRequest();
+    request.addRequest(new ModifyCommandRequest.DeleteFileRequest("c", true));
+    request.setCommitMessage("this is great");
+    request.setAuthor(new Person("Arthur Dent", "dent@hitchhiker.com"));
+
+    svnModifyCommand.execute(request);
+    WorkingCopy<File, File> workingCopy = workingCopyFactory.createWorkingCopy(context, null);
+    assertThat(new File(workingCopy.getWorkingRepository().getAbsolutePath() + "/a.txt")).exists();
+    assertThat(new File(workingCopy.getWorkingRepository().getAbsolutePath() + "/c")).doesNotExist();
   }
 
   @Test


### PR DESCRIPTION
## Proposed changes

Adds a method in the `ModifyCommand` to delete not only files, but also directories recursively.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] New code is covered with unit tests
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
