### PR TITLE
Fix concurrent modification in SVN modify command

### DIFF
--- a/gradle/changelog/concurrent_modification.yaml
+++ b/gradle/changelog/concurrent_modification.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Concurrent modification error in SVN modify command ([#1849](https://github.com/scm-manager/scm-manager/pull/1849))

--- a/scm-plugins/scm-svn-plugin/src/main/java/sonia/scm/repository/spi/SvnModifyCommand.java
+++ b/scm-plugins/scm-svn-plugin/src/main/java/sonia/scm/repository/spi/SvnModifyCommand.java
@@ -82,7 +82,7 @@ public class SvnModifyCommand implements ModifyCommand {
 
   private String getCurrentRevision(SVNClientManager clientManager, WorkingCopy<File, File> workingCopy) {
     try {
-      return Integer.toString(clientManager.getStatusClient().doStatus(workingCopy.getWorkingRepository(), false).getRevision().getID());
+      return Long.toString(clientManager.getStatusClient().doStatus(workingCopy.getWorkingRepository(), false).getRevision().getNumber());
     } catch (SVNException e) {
       throw new InternalRepositoryException(entity(repository), "Could not read status of working repository", e);
     }

--- a/scm-plugins/scm-svn-plugin/src/test/java/sonia/scm/repository/spi/SvnModifyCommandTest.java
+++ b/scm-plugins/scm-svn-plugin/src/test/java/sonia/scm/repository/spi/SvnModifyCommandTest.java
@@ -185,7 +185,7 @@ public class SvnModifyCommandTest extends AbstractSvnCommandTestBase {
     request.addRequest(new ModifyCommandRequest.CreateFileRequest("Test123", testfile, false));
     request.setCommitMessage("this should not pass");
     request.setAuthor(new Person("Arthur Dent", "dent@hitchhiker.com"));
-    request.setExpectedRevision("10");
+    request.setExpectedRevision("5");
 
     svnModifyCommand.execute(request);
 


### PR DESCRIPTION
## Proposed changes

The current revision has been computed in a wrong way in the SVN modify command, leading to wrong concurrent modification errors. This fixes this error.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
