### PR TITLE
handle resources, never left left opened file handler on windows

### DIFF
--- a/scm-core/src/main/java/sonia/scm/util/IOUtil.java
+++ b/scm-core/src/main/java/sonia/scm/util/IOUtil.java
@@ -391,20 +391,17 @@ public final class IOUtil
       }
     }
 
-    for (int i = 20; !file.delete(); i--)
+    for (int i = 20; !file.delete() && i > 0; i--)
     {
-      if (i <= 20)
-      {
-        String message = "could not delete file ".concat(file.getPath());
+      String message = "could not delete file ".concat(file.getPath());
 
-        if (silent)
-        {
-          logger.error(message);
-        }
-        else
-        {
-          throw new IOException(message);
-        }
+      if (silent)
+      {
+        logger.error(message);
+      }
+      else
+      {
+        throw new IOException(message);
       }
 
       try

--- a/scm-core/src/test/java/sonia/scm/BaseDirectoryTest.java
+++ b/scm-core/src/test/java/sonia/scm/BaseDirectoryTest.java
@@ -61,7 +61,7 @@ class BaseDirectoryTest {
     @Test
     void linux() {
       BaseDirectory directory = builder().withSystemProperty("user.home", "/tmp").create();
-      assertThat(directory.find().toString()).isEqualTo(new File("/tmp/.scm").getPath());
+      assertThat(directory.find()).isEqualTo(Paths.get("/tmp/.scm"));
     }
 
     @Test

--- a/scm-core/src/test/java/sonia/scm/BaseDirectoryTest.java
+++ b/scm-core/src/test/java/sonia/scm/BaseDirectoryTest.java
@@ -28,6 +28,8 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Properties;
 
@@ -38,19 +40,19 @@ class BaseDirectoryTest {
   @Test
   void shouldGetFromClassPathResource() {
     BaseDirectory directory = builder().withClassPathResource("/sonia/scm/basedirectory.properties").create();
-    assertThat(directory.find().toString()).isEqualTo("/tmp/scm_home");
+    assertThat(directory.find().toString()).isEqualTo(new File("/tmp/scm_home").getPath());
   }
 
   @Test
   void shouldGetFromSystemProperty() {
     BaseDirectory directory = builder().withSystemProperty(BaseDirectory.SYSTEM_PROPERTY, "/tmp/scm_home").create();
-    assertThat(directory.find().toString()).isEqualTo("/tmp/scm_home");
+    assertThat(directory.find().toString()).isEqualTo(new File("/tmp/scm_home").getPath());
   }
 
   @Test
   void shouldGetFromEnvironmentVariable() {
     BaseDirectory directory = builder().withEnvironment(BaseDirectory.ENVIRONMENT_VARIABLE, "/tmp/scm_home").create();
-    assertThat(directory.find().toString()).isEqualTo("/tmp/scm_home");
+    assertThat(directory.find().toString()).isEqualTo(new File("/tmp/scm_home").getPath());
   }
 
   @Nested
@@ -59,19 +61,19 @@ class BaseDirectoryTest {
     @Test
     void linux() {
       BaseDirectory directory = builder().withSystemProperty("user.home", "/tmp").create();
-      assertThat(directory.find().toString()).isEqualTo("/tmp/.scm");
+      assertThat(directory.find().toString()).isEqualTo(new File("/tmp/.scm").getPath());
     }
 
     @Test
     void osx() {
       BaseDirectory directory = builder().withOsx().withSystemProperty("user.home", "/tmp").create();
-      assertThat(directory.find().toString()).isEqualTo("/tmp/Library/Application Support/SCM-Manager");
+      assertThat(directory.find().toString()).isEqualTo(new File("/tmp/Library/Application Support/SCM-Manager").getPath());
     }
 
     @Test
     void windows() {
       BaseDirectory directory = builder().withWindows().withEnvironment("APPDATA", "/tmp").create();
-      assertThat(directory.find().toString()).isEqualTo("/tmp\\SCM-Manager");
+      assertThat(directory.find().toString()).isEqualTo(new File("/tmp\\SCM-Manager").getPath());
     }
 
   }

--- a/scm-core/src/test/java/sonia/scm/BaseDirectoryTest.java
+++ b/scm-core/src/test/java/sonia/scm/BaseDirectoryTest.java
@@ -46,7 +46,7 @@ class BaseDirectoryTest {
   @Test
   void shouldGetFromSystemProperty() {
     BaseDirectory directory = builder().withSystemProperty(BaseDirectory.SYSTEM_PROPERTY, "/tmp/scm_home").create();
-    assertThat(directory.find().toString()).isEqualTo(new File("/tmp/scm_home").getPath());
+    assertThat(directory.find()).isEqualTo(Paths.get("/tmp/scm_home"));
   }
 
   @Test

--- a/scm-core/src/test/java/sonia/scm/BaseDirectoryTest.java
+++ b/scm-core/src/test/java/sonia/scm/BaseDirectoryTest.java
@@ -52,7 +52,7 @@ class BaseDirectoryTest {
   @Test
   void shouldGetFromEnvironmentVariable() {
     BaseDirectory directory = builder().withEnvironment(BaseDirectory.ENVIRONMENT_VARIABLE, "/tmp/scm_home").create();
-    assertThat(directory.find().toString()).isEqualTo(new File("/tmp/scm_home").getPath());
+    assertThat(directory.find()).isEqualTo(Paths.get("/tmp/scm_home"));
   }
 
   @Nested

--- a/scm-core/src/test/java/sonia/scm/BaseDirectoryTest.java
+++ b/scm-core/src/test/java/sonia/scm/BaseDirectoryTest.java
@@ -73,7 +73,7 @@ class BaseDirectoryTest {
     @Test
     void windows() {
       BaseDirectory directory = builder().withWindows().withEnvironment("APPDATA", "/tmp").create();
-      assertThat(directory.find().toString()).isEqualTo(new File("/tmp\\SCM-Manager").getPath());
+      assertThat(directory.find()).isEqualTo(Paths.get("/tmp\\SCM-Manager"));
     }
 
   }

--- a/scm-core/src/test/java/sonia/scm/BaseDirectoryTest.java
+++ b/scm-core/src/test/java/sonia/scm/BaseDirectoryTest.java
@@ -40,7 +40,7 @@ class BaseDirectoryTest {
   @Test
   void shouldGetFromClassPathResource() {
     BaseDirectory directory = builder().withClassPathResource("/sonia/scm/basedirectory.properties").create();
-    assertThat(directory.find().toString()).isEqualTo(new File("/tmp/scm_home").getPath());
+    assertThat(directory.find()).isEqualTo(Paths.get("/tmp/scm_home"));
   }
 
   @Test

--- a/scm-core/src/test/java/sonia/scm/BaseDirectoryTest.java
+++ b/scm-core/src/test/java/sonia/scm/BaseDirectoryTest.java
@@ -67,7 +67,7 @@ class BaseDirectoryTest {
     @Test
     void osx() {
       BaseDirectory directory = builder().withOsx().withSystemProperty("user.home", "/tmp").create();
-      assertThat(directory.find().toString()).isEqualTo(new File("/tmp/Library/Application Support/SCM-Manager").getPath());
+      assertThat(directory.find()).isEqualTo(Paths.get("/tmp/Library/Application Support/SCM-Manager"));
     }
 
     @Test

--- a/scm-core/src/test/java/sonia/scm/plugin/SmpArchiveTest.java
+++ b/scm-core/src/test/java/sonia/scm/plugin/SmpArchiveTest.java
@@ -43,6 +43,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.Path;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -137,17 +138,14 @@ class SmpArchiveTest {
     return archiveFile;
   }
 
-  private XMLStreamWriter createStreamWriter(File file) throws IOException, XMLStreamException {
-    return XMLOutputFactory.newFactory().createXMLStreamWriter(new FileOutputStream(file));
-  }
-
   private void writeDescriptor(File descriptor, String name, String version) throws IOException, XMLStreamException {
     IOUtil.mkdirs(descriptor.getParentFile());
 
     XMLStreamWriter writer = null;
 
-    try {
-      writer = createStreamWriter(descriptor);
+    try (OutputStream os = new FileOutputStream(descriptor)) {
+      writer = XMLOutputFactory.newFactory().createXMLStreamWriter(os);
+
       writer.writeStartDocument();
       writer.writeStartElement("plugin");
       writer.writeStartElement("information");
@@ -157,10 +155,7 @@ class SmpArchiveTest {
       writer.writeEndElement();
       writer.writeEndElement();
       writer.writeEndDocument();
-    } finally {
-      if (writer != null) {
-        writer.close();
-      }
+      writer.close();
     }
   }
 

--- a/scm-dao-xml/src/main/java/sonia/scm/store/FileStoreExporter.java
+++ b/scm-dao-xml/src/main/java/sonia/scm/store/FileStoreExporter.java
@@ -35,6 +35,8 @@ import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -135,8 +137,8 @@ public class FileStoreExporter implements StoreExporter {
 
   private StoreType determineConfigType(Path storePath) {
     XMLStreamReader reader = null;
-    try {
-      reader = XmlStreams.createReader(storePath);
+    try (Reader inputReader = Files.newBufferedReader(storePath, StandardCharsets.UTF_8)) {
+      reader = XmlStreams.createReader(inputReader);
       reader.nextTag();
       if (
         "configuration".equals(reader.getLocalName())

--- a/scm-dao-xml/src/main/java/sonia/scm/store/JAXBConfigurationEntryStore.java
+++ b/scm-dao-xml/src/main/java/sonia/scm/store/JAXBConfigurationEntryStore.java
@@ -197,38 +197,37 @@ public class JAXBConfigurationEntryStore<V> implements ConfigurationEntryStore<V
         temp -> {
           try (Writer ioWriter = Files.newBufferedWriter(temp, StandardCharsets.UTF_8);
                IndentXMLStreamWriter writer = XmlStreams.createWriter(ioWriter)) {
-              writer.writeStartDocument();
+            writer.writeStartDocument();
 
-              // configuration start
-              writer.writeStartElement(TAG_CONFIGURATION);
-              writer.writeAttribute("type", "config-entry");
+            // configuration start
+            writer.writeStartElement(TAG_CONFIGURATION);
+            writer.writeAttribute("type", "config-entry");
 
-              for (Entry<String, V> e : entries.entrySet()) {
+            for (Entry<String, V> e : entries.entrySet()) {
 
-                // entry start
-                writer.writeStartElement(TAG_ENTRY);
+              // entry start
+              writer.writeStartElement(TAG_ENTRY);
 
-                // key start
-                writer.writeStartElement(TAG_KEY);
-                writer.writeCharacters(e.getKey());
+              // key start
+              writer.writeStartElement(TAG_KEY);
+              writer.writeCharacters(e.getKey());
 
-                // key end
-                writer.writeEndElement();
-
-                // value
-                JAXBElement<V> je = new JAXBElement<>(QName.valueOf(TAG_VALUE), type,
-                        e.getValue());
-
-                m.marshal(je, writer);
-
-                // entry end
-                writer.writeEndElement();
-              }
-
-              // configuration end
+              // key end
               writer.writeEndElement();
-              writer.writeEndDocument();
+
+              // value
+              JAXBElement<V> je = new JAXBElement<>(QName.valueOf(TAG_VALUE), type,
+                      e.getValue());
+
+              m.marshal(je, writer);
+
+              // entry end
+              writer.writeEndElement();
             }
+
+            // configuration end
+            writer.writeEndElement();
+            writer.writeEndDocument();
           }
         },
         file.toPath()

--- a/scm-dao-xml/src/main/java/sonia/scm/store/JAXBConfigurationEntryStore.java
+++ b/scm-dao-xml/src/main/java/sonia/scm/store/JAXBConfigurationEntryStore.java
@@ -195,8 +195,8 @@ public class JAXBConfigurationEntryStore<V> implements ConfigurationEntryStore<V
 
       CopyOnWrite.withTemporaryFile(
         temp -> {
-          try (Writer ioWriter = Files.newBufferedWriter(temp, StandardCharsets.UTF_8)) {
-            try (IndentXMLStreamWriter writer = XmlStreams.createWriter(ioWriter)) {
+          try (Writer ioWriter = Files.newBufferedWriter(temp, StandardCharsets.UTF_8);
+               IndentXMLStreamWriter writer = XmlStreams.createWriter(ioWriter)) {
               writer.writeStartDocument();
 
               // configuration start

--- a/scm-dao-xml/src/main/java/sonia/scm/xml/XmlStreams.java
+++ b/scm-dao-xml/src/main/java/sonia/scm/xml/XmlStreams.java
@@ -32,13 +32,8 @@ import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
-import java.io.File;
-import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 public final class XmlStreams {
 
@@ -67,31 +62,13 @@ public final class XmlStreams {
     }
   }
 
-  public static XMLStreamReader createReader(Path path) throws IOException, XMLStreamException {
-    return createReader(Files.newBufferedReader(path, StandardCharsets.UTF_8));
-  }
-
-  public static XMLStreamReader createReader(File file) throws IOException, XMLStreamException {
-    return createReader(file.toPath());
-  }
-
-  private static XMLStreamReader createReader(Reader reader) throws XMLStreamException {
+  public static XMLStreamReader createReader(Reader reader) throws XMLStreamException {
     XMLInputFactory factory = XMLInputFactory.newInstance();
     factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
     return factory.createXMLStreamReader(reader);
   }
 
-
-  public static IndentXMLStreamWriter createWriter(Path path) throws IOException, XMLStreamException {
-    return createWriter(Files.newBufferedWriter(path, StandardCharsets.UTF_8));
-  }
-
-  public static IndentXMLStreamWriter createWriter(File file) throws IOException, XMLStreamException {
-    return createWriter(file.toPath());
-  }
-
-  private static IndentXMLStreamWriter createWriter(Writer writer) throws XMLStreamException {
+  public static IndentXMLStreamWriter createWriter(Writer writer) throws XMLStreamException {
     return new IndentXMLStreamWriter(XMLOutputFactory.newFactory().createXMLStreamWriter(writer));
   }
-
 }

--- a/scm-webapp/src/main/java/sonia/scm/importexport/RepositoryImportStep.java
+++ b/scm-webapp/src/main/java/sonia/scm/importexport/RepositoryImportStep.java
@@ -93,8 +93,8 @@ class RepositoryImportStep implements ImportStep {
   private void importFromTemporaryPath(ImportState state, Path path) {
     LOG.debug("Importing repository from temporary location in work dir");
     state.getLogger().step("importing repository from temporary location");
-    try {
-      unbundleRepository(state, Files.newInputStream(path));
+    try (InputStream is = Files.newInputStream(path)) {
+      unbundleRepository(state, is);
     } catch (IOException e) {
       throw new ImportFailedException(
         entity(state.getRepository()).build(),

--- a/scm-webapp/src/test/java/sonia/scm/update/repository/CopyMigrationStrategyTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/update/repository/CopyMigrationStrategyTest.java
@@ -91,14 +91,8 @@ class CopyMigrationStrategyTest {
   }
 
   private void assertDirectoriesEqual(Path targetDataDir, Path originalDataDir) {
-    Stream<Path> list = null;
-    try {
-      list = Files.list(originalDataDir);
-    } catch (IOException e) {
-      fail("could not read original directory", e);
-    }
-    list.forEach(
-      original -> {
+    try (Stream<Path> list = Files.list(originalDataDir)) {
+      list.forEach(original -> {
         Path expectedTarget = targetDataDir.resolve(original.getFileName());
         assertThat(expectedTarget).exists();
         if (Files.isDirectory(original)) {
@@ -106,7 +100,9 @@ class CopyMigrationStrategyTest {
         } else {
           assertThat(expectedTarget).hasSameContentAs(original);
         }
-      }
-    );
+      });
+    } catch (IOException e) {
+      fail("could not read original directory", e);
+    }
   }
 }


### PR DESCRIPTION
On windows unit tests are failing because junit checks if all @TempDir directries are empty and can be deleted after test run.
But due to opened file handles (not closed resource streams) Windows keeps files, which are "in use".
Linux is less strict in this area.
Additionally I want highlight that XMLStreamReaderImpl/XMLStreamWriterImpl from apache.xerces library (in OpenJDK11 at least) which are picked at runtime as xml parser implementation - they don't close associated resources.
BTW, I thing that relying on some runtime (sometimes - unpredictable) dependencies - is bad practice, but this it up to separate topic.
Additional fix: in IOUtil is file is locked (due to permissions or opened handle) - it will undlessly try-and-retry to delete it until end of the world, on windows.