### PR TITLE
Replace backslash in Modify Command

### DIFF
--- a/gradle/changelog/modify_command_backslash_replacement.yaml
+++ b/gradle/changelog/modify_command_backslash_replacement.yaml
@@ -1,0 +1,2 @@
+- type: changed
+  description: Replace backslash in ModifyCommand ([#1866](https://github.com/scm-manager/scm-manager/pull/1866))

--- a/scm-core/src/main/java/sonia/scm/repository/spi/ModifyCommandRequest.java
+++ b/scm-core/src/main/java/sonia/scm/repository/spi/ModifyCommandRequest.java
@@ -139,7 +139,7 @@ public class ModifyCommandRequest implements Resetable, Validateable, CommandWit
     }
 
     public DeleteFileRequest(String path, boolean recursive) {
-      this.path = path;
+      this.path = sanitizePath(path);
       this.recursive = recursive;
     }
 
@@ -179,7 +179,7 @@ public class ModifyCommandRequest implements Resetable, Validateable, CommandWit
 
     public CreateFileRequest(String path, File content, boolean overwrite) {
       super(content);
-      this.path = path;
+      this.path = sanitizePath(path);
       this.overwrite = overwrite;
     }
 
@@ -196,7 +196,7 @@ public class ModifyCommandRequest implements Resetable, Validateable, CommandWit
 
     public ModifyFileRequest(String path, File content) {
       super(content);
-      this.path = path;
+      this.path = sanitizePath(path);
     }
 
     @Override
@@ -215,13 +215,17 @@ public class ModifyCommandRequest implements Resetable, Validateable, CommandWit
     private final String toPath;
 
     public MoveRequest(String fromPath, String toPath) {
-      this.toPath = toPath;
-      this.fromPath = fromPath;
+      this.toPath = sanitizePath(toPath);
+      this.fromPath = sanitizePath(fromPath);
     }
 
     @Override
     public void execute(ModifyCommand.Worker worker) throws IOException {
       worker.move(fromPath, toPath);
     }
+  }
+
+  private static String sanitizePath(String path) {
+    return path.trim().replace("\\", "/");
   }
 }

--- a/scm-core/src/test/java/sonia/scm/repository/spi/ModifyCommandRequestTest.java
+++ b/scm-core/src/test/java/sonia/scm/repository/spi/ModifyCommandRequestTest.java
@@ -1,0 +1,85 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.repository.spi;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sonia.scm.repository.spi.ModifyCommandRequest.CreateFileRequest;
+import sonia.scm.repository.spi.ModifyCommandRequest.DeleteFileRequest;
+import sonia.scm.repository.spi.ModifyCommandRequest.ModifyFileRequest;
+import sonia.scm.repository.spi.ModifyCommandRequest.MoveRequest;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ModifyCommandRequestTest {
+
+  @Mock
+  private ModifyCommand.Worker worker;
+
+  @Test
+  void shouldReplaceBackslashInDelete() throws IOException {
+    DeleteFileRequest deleteFileRequest = new DeleteFileRequest("path\\with\\backslash", false);
+
+    deleteFileRequest.execute(worker);
+
+    verify(worker).delete("path/with/backslash", false);
+  }
+
+  @Test
+  void shouldReplaceBackslashInCreate(@TempDir Path temp) throws IOException {
+    CreateFileRequest createFileRequest = new CreateFileRequest("path\\with\\backslash", temp.toFile(), false);
+
+    createFileRequest.execute(worker);
+
+    verify(worker).create("path/with/backslash", temp.toFile(), false);
+  }
+
+  @Test
+  void shouldReplaceBackslashInModify(@TempDir Path temp) throws IOException {
+    ModifyFileRequest modifyFileRequest = new ModifyFileRequest("path\\with\\backslash", temp.toFile());
+
+    modifyFileRequest.execute(worker);
+
+    verify(worker).modify("path/with/backslash", temp.toFile());
+  }
+
+  @Test
+  void shouldReplaceBackslashInMove() throws IOException {
+    MoveRequest moveRequest = new MoveRequest("from\\path", "path\\with\\backslash");
+
+    moveRequest.execute(worker);
+
+    verify(worker).move("from/path", "path/with/backslash");
+  }
+}


### PR DESCRIPTION
## Proposed changes

Replaces all backslashes (`\`) in any paths used in
the modify command with forward slashes (`/`) to avoid
unexpected behaviour for Windows users used to backslashes.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
