### PR TITLE
Fix search highlighting conflict with jsx code

### DIFF
--- a/gradle/changelog/hightlight_jsx_conflict.yaml
+++ b/gradle/changelog/hightlight_jsx_conflict.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Search highlighting in jsx ([#1886](https://github.com/scm-manager/scm-manager/pull/1886))

--- a/scm-ui/ui-components/src/search/HighlightedFragment.tsx
+++ b/scm-ui/ui-components/src/search/HighlightedFragment.tsx
@@ -24,6 +24,9 @@
 
 import React, { FC } from "react";
 
+const PRE_TAG = "<|[[--";
+const POST_TAG = "--]]|>";
+
 type Props = {
   value: string;
 };
@@ -33,14 +36,14 @@ const HighlightedFragment: FC<Props> = ({ value }) => {
 
   const result = [];
   while (content.length > 0) {
-    const start = content.indexOf("<>");
-    const end = content.indexOf("</>");
+    const start = content.indexOf(PRE_TAG);
+    const end = content.indexOf(POST_TAG);
     if (start >= 0 && end > 0) {
       if (start > 0) {
         result.push(content.substring(0, start));
       }
-      result.push(<strong>{content.substring(start + 2, end)}</strong>);
-      content = content.substring(end + 3);
+      result.push(<strong>{content.substring(start + PRE_TAG.length, end)}</strong>);
+      content = content.substring(end + POST_TAG.length);
     } else {
       result.push(content);
       break;

--- a/scm-webapp/src/main/java/sonia/scm/search/LuceneHighlighter.java
+++ b/scm-webapp/src/main/java/sonia/scm/search/LuceneHighlighter.java
@@ -55,7 +55,6 @@ public final class LuceneHighlighter {
       fragments = keepWholeLine(value, fragments);
     }
     return Arrays.stream(fragments)
-      .map(fragment -> fragment.replace(PRE_TAG, "<>").replace(POST_TAG, "</>"))
       .toArray(String[]::new);
   }
 

--- a/scm-webapp/src/test/java/sonia/scm/search/LuceneHighlighterTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/search/LuceneHighlighterTest.java
@@ -52,7 +52,7 @@ class LuceneHighlighterTest {
     String[] snippets = highlighter.highlight("content", Indexed.Analyzer.DEFAULT, content);
 
     assertThat(snippets).hasSize(1).allSatisfy(
-      snippet -> assertThat(snippet).contains("<>Golgafrinchan</>")
+      snippet -> assertThat(snippet).contains("<|[[--Golgafrinchan--]]|>")
     );
   }
 
@@ -64,7 +64,7 @@ class LuceneHighlighterTest {
       snippet -> assertThat(snippet.split("\n")).contains(
         "\t\t\t\tint neighbors= getNeighbors(above, same, below);",
         "\t\t\t\tif(neighbors < 2 || neighbors > 3){",
-        "\t\t\t\t\tnewGen[row]+= \"_\";//<2 or >3 neighbors -> <>die</>",
+        "\t\t\t\t\tnewGen[row]+= \"_\";//<2 or >3 neighbors -> <|[[--die--]]|>",
         "\t\t\t\t}else if(neighbors == 3){",
         "\t\t\t\t\tnewGen[row]+= \"#\";//3 neighbors -> spawn/live"
       )
@@ -79,7 +79,7 @@ class LuceneHighlighterTest {
       snippet -> assertThat(snippet.split("\n")).contains(
         "}) => {",
         "  const renderIcon = () => {",
-        "    return <>{icon ? <Icon name={icon} color=\"<>inherit</>\" className=\"is-medium pr-1\" /> : null}</>;",
+        "    return <>{icon ? <Icon name={icon} color=\"<|[[--inherit--]]|>\" className=\"is-medium pr-1\" /> : null}</>;",
         "  };"
       )
     );

--- a/scm-webapp/src/test/java/sonia/scm/search/LuceneQueryBuilderTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/search/LuceneQueryBuilderTest.java
@@ -499,7 +499,7 @@ class LuceneQueryBuilderTest {
 
     JsonNode displayName = fields.get("displayName");
     assertThat(displayName.get("highlighted").asBoolean()).isTrue();
-    assertThat(displayName.get("fragments").get(0).asText()).contains("<>Arthur</>");
+    assertThat(displayName.get("fragments").get(0).asText()).contains("<|[[--Arthur--]]|>");
   }
 
   @Test


### PR DESCRIPTION
## Proposed changes

Replaces "<>", "</>" highlighting marks with "<|[[--" and "--]]|>" to avoid conflicts when highlighting jsx code.

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] New code is covered with unit tests
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
