### PR TITLE
Fix display of ellipsis if search fragment matches content start or end

### DIFF
--- a/gradle/changelog/search_ellipsis.yaml
+++ b/gradle/changelog/search_ellipsis.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Do not display ellipsis if search result matches start or end of content ([#1896](https://github.com/scm-manager/scm-manager/pull/1896))

--- a/scm-core/src/main/java/sonia/scm/search/Hit.java
+++ b/scm-core/src/main/java/sonia/scm/search/Hit.java
@@ -81,7 +81,7 @@ public class Hit {
   @Getter
   @AllArgsConstructor(access = AccessLevel.PRIVATE)
   public abstract static class Field {
-    boolean highlighted;
+    private final boolean highlighted;
   }
 
   /**
@@ -89,7 +89,7 @@ public class Hit {
    */
   @Getter
   public static class ValueField extends Field {
-    Object value;
+    private final Object value;
 
     public ValueField(Object value) {
       super(false);
@@ -102,28 +102,28 @@ public class Hit {
    */
   @Getter
   public static class HighlightedField extends Field {
-    String[] fragments;
+    private final String[] fragments;
 
     /**
      * @since 2.28.0
      */
-    boolean matchesContentStart;
+    private final boolean matchesContentStart;
 
     /**
      * @since 2.28.0
      */
-    boolean matchesContentEnd;
+    private final boolean matchesContentEnd;
 
     public HighlightedField(String[] fragments) {
-      super(true);
-      this.fragments = fragments;
+      this(fragments, false, false);
     }
 
     /**
      * @since 2.28.0
      */
     public HighlightedField(String[] fragments, boolean matchesContentStart, boolean matchesContentEnd) {
-      this(fragments);
+      super(true);
+      this.fragments = fragments;
       this.matchesContentStart = matchesContentStart;
       this.matchesContentEnd = matchesContentEnd;
     }

--- a/scm-core/src/main/java/sonia/scm/search/Hit.java
+++ b/scm-core/src/main/java/sonia/scm/search/Hit.java
@@ -104,9 +104,28 @@ public class Hit {
   public static class HighlightedField extends Field {
     String[] fragments;
 
+    /**
+     * @since 2.28.0
+     */
+    boolean matchesContentStart;
+
+    /**
+     * @since 2.28.0
+     */
+    boolean matchesContentEnd;
+
     public HighlightedField(String[] fragments) {
       super(true);
       this.fragments = fragments;
+    }
+
+    /**
+     * @since 2.28.0
+     */
+    public HighlightedField(String[] fragments, boolean matchesContentStart, boolean matchesContentEnd) {
+      this(fragments);
+      this.matchesContentStart = matchesContentStart;
+      this.matchesContentEnd = matchesContentEnd;
     }
   }
 

--- a/scm-ui/ui-components/src/__resources__/ContentSearchHit.ts
+++ b/scm-ui/ui-components/src/__resources__/ContentSearchHit.ts
@@ -33,7 +33,9 @@ export const javaHit: Hit = {
         "import org.slf4j.LoggerFactory;\n\nimport java.util.Date;\nimport java.util.HashMap;\nimport java.util.Map;\nimport java.util.concurrent.TimeUnit;\n\n/**\n * Jwt implementation of {@link <|[[--AccessTokenBuilder--]]|>}.\n * \n * @author Sebastian Sdorra\n * @since 2.0.0\n */\npublic final class <|[[--JwtAccessTokenBuilder--]]|> implements <|[[--AccessTokenBuilder--]]|> {\n\n  /**\n   * the logger for <|[[--JwtAccessTokenBuilder--]]|>\n   */\n  private static final Logger LOG = LoggerFactory.getLogger(<|[[--JwtAccessTokenBuilder.class--]]|>);\n  \n  private final KeyGenerator keyGenerator; \n  private final SecureKeyResolver keyResolver; \n  \n  private String subject;\n  private String issuer;\n",
         "  private final Map<String,Object> custom = Maps.newHashMap();\n  \n  <|[[--JwtAccessTokenBuilder--]]|>(KeyGenerator keyGenerator, SecureKeyResolver keyResolver)  {\n    this.keyGenerator = keyGenerator;\n    this.keyResolver = keyResolver;\n  }\n\n  @Override\n  public <|[[--JwtAccessTokenBuilder--]]|> subject(String subject) {\n",
         '  public <|[[--JwtAccessTokenBuilder--]]|> custom(String key, Object value) {\n    Preconditions.checkArgument(!Strings.isNullOrEmpty(key), "null or empty value not allowed");\n    Preconditions.checkArgument(value != null, "null or empty value not allowed");\n'
-      ]
+      ],
+      matchesContentStart: false,
+      matchesContentEnd: false
     }
   },
   _links: {}
@@ -46,7 +48,9 @@ export const bashHit: Hit = {
       highlighted: true,
       fragments: [
         '# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\n# SOFTWARE.\n#\n\n<|[[--getent--]]|> group scm >/dev/null || groupadd -r scm\n<|[[--getent--]]|> passwd scm >/dev/null || \\\n    useradd -r -g scm -M \\\n    -s /sbin/nologin -d /var/lib/scm \\\n    -c "user for the scm-server process" scm\nexit 0\n\n'
-      ]
+      ],
+      matchesContentStart: false,
+      matchesContentEnd: true
     }
   },
   _links: {}
@@ -60,7 +64,9 @@ export const markdownHit: Hit = {
       fragments: [
         "---\ntitle: SCM-Manager v2 Test <|[[--Cases--]]|>\n---\n\nDescribes the expected behaviour for SCMM v2 REST Resources using manual tests.\n\nThe following states general test <|[[--cases--]]|> per HTTP Method and en expected return code as well as exemplary curl calls.\nResource-specifics are stated \n\n## Test <|[[--Cases--]]|>\n\n### GET\n\n- Collection Resource (e.g. `/users`)\n    - Without parameters -> 200\n    - Parameters\n        - `?pageSize=1` -> Only one embedded element, pageTotal reflects the correct number of pages, `last` link points to last page.\n        - `?pageSize=1&page=1` -> `next` link points to page 0 ; `prev` link points to page 2\n        - `?sortBy=admin` -> Sorted by `admin` field of embedded objects\n        - `?sortBy=admin&desc=true` -> Invert sorting\n- Individual Resource (e.g. `/users/scmadmin`)\n    - Exists  -> 200\n",
         "\n### DELETE\n\n- existing -> 204\n- not existing -> 204\n- without permission -> 401\n\n## Exemplary calls & Resource specific test <|[[--cases--]]|>\n\nIn order to extend those tests to other Resources, have a look at the rest docs. Note that the Content Type is specific to each resource as well.\n"
-      ]
+      ],
+      matchesContentStart: true,
+      matchesContentEnd: false
     }
   },
   _links: {}

--- a/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
+++ b/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
@@ -90029,8 +90029,6 @@ exports[`Storyshots TextHitField Bash SyntaxHighlighting 1`] = `
 exit 0
 
 
-  ...
-
 </pre>
 `;
 
@@ -90202,8 +90200,6 @@ public final class
 
 exports[`Storyshots TextHitField Markdown SyntaxHighlighting 1`] = `
 <pre>
-  ...
-
   ---
 title: SCM-Manager v2 Test 
   <mark>
@@ -90238,8 +90234,6 @@ Resource-specifics are stated
         - \`?sortBy=admin&desc=true\` -&gt; Invert sorting
 - Individual Resource (e.g. \`/users/scmadmin\`)
     - Exists  -&gt; 200
-
-  ...
 
   
 ### DELETE
@@ -90285,8 +90279,6 @@ exports[`Storyshots TextHitField Unknown SyntaxHighlighting 1`] = `
     -c "user for the scm-server process" scm
 exit 0
 
-
-  ...
 
 </pre>
 `;

--- a/scm-ui/ui-components/src/search/TextHitField.tsx
+++ b/scm-ui/ui-components/src/search/TextHitField.tsx
@@ -39,13 +39,13 @@ const HighlightedTextField: FC<HighlightedTextFieldProps> = ({ field, syntaxHigh
     <>
       {field.fragments.map((fragment, i) => (
         <React.Fragment key={fragment}>
-          {separator}
+          {field.matchesContentStart ? null : separator}
           {syntaxHighlightingLanguage ? (
             <SyntaxHighlightedFragment value={fragment} language={syntaxHighlightingLanguage} />
           ) : (
             <HighlightedFragment value={fragment} />
           )}
-          {i + 1 >= field.fragments.length ? separator : null}
+          {i + 1 >= field.fragments.length && !field.matchesContentEnd ? separator : null}
         </React.Fragment>
       ))}
     </>

--- a/scm-ui/ui-scripts/src/webpack.config.js
+++ b/scm-ui/ui-scripts/src/webpack.config.js
@@ -140,6 +140,7 @@ module.exports = [
         }
       },
       historyApiFallback: true,
+      host: "127.0.0.1",
       port: 3000,
       hot: true,
       devMiddleware: {

--- a/scm-webapp/src/main/java/sonia/scm/search/ContentFragment.java
+++ b/scm-webapp/src/main/java/sonia/scm/search/ContentFragment.java
@@ -28,9 +28,9 @@ import lombok.Getter;
 
 @Getter
 public class ContentFragment {
-  String fragment;
-  boolean matchesContentStart;
-  boolean matchesContentEnd;
+  private final String fragment;
+  private final boolean matchesContentStart;
+  private final boolean matchesContentEnd;
 
   ContentFragment(String fragment) {
     this(fragment, false, false);

--- a/scm-webapp/src/main/java/sonia/scm/search/ContentFragment.java
+++ b/scm-webapp/src/main/java/sonia/scm/search/ContentFragment.java
@@ -22,47 +22,23 @@
  * SOFTWARE.
  */
 
-import { HalRepresentation, HalRepresentationWithEmbedded, PagedCollection } from "./hal";
-import { Repository } from "./Repositories";
+package sonia.scm.search;
 
-export type ValueHitField = {
-  highlighted: false;
-  value: unknown;
-};
+import lombok.Getter;
 
-export type HighlightedHitField = {
-  highlighted: true;
-  fragments: string[];
-  matchesContentStart: boolean;
-  matchesContentEnd: boolean;
-};
+@Getter
+public class ContentFragment {
+  String fragment;
+  boolean matchesContentStart;
+  boolean matchesContentEnd;
 
-export type HitField = ValueHitField | HighlightedHitField;
+  ContentFragment(String fragment) {
+    this(fragment, false, false);
+  }
 
-export type EmbeddedRepository = {
-  repository?: Repository;
-};
-
-export type Hit = HalRepresentationWithEmbedded<EmbeddedRepository> & {
-  score: number;
-  fields: { [name: string]: HitField };
-};
-
-export type HitEmbedded = {
-  hits: Hit[];
-};
-
-export type QueryResult = PagedCollection<HitEmbedded> & {
-  type: string;
-  totalHits: number;
-};
-
-export type SearchableField = {
-  name: string;
-  type: string;
-};
-
-export type SearchableType = HalRepresentation & {
-  name: string;
-  fields: SearchableField[];
-};
+  ContentFragment(String fragment, boolean matchesContentStart, boolean matchesContentEnd) {
+    this.fragment = fragment;
+    this.matchesContentStart = matchesContentStart;
+    this.matchesContentEnd = matchesContentEnd;
+  }
+}

--- a/scm-webapp/src/main/java/sonia/scm/search/QueryResultFactory.java
+++ b/scm-webapp/src/main/java/sonia/scm/search/QueryResultFactory.java
@@ -34,6 +34,7 @@ import org.apache.lucene.search.highlight.InvalidTokenOffsetsException;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -75,9 +76,11 @@ public class QueryResultFactory {
     Object value = field.value(document);
     if (value != null) {
       if (highlighter.isHighlightable(field)) {
-        String[] fragments = createFragments(field, value.toString());
+        ContentFragment[] fragments = createFragments(field, value.toString());
         if (fragments.length > 0) {
-          return of(new Hit.HighlightedField(fragments));
+          boolean firstFragmentMatchesContentStart = fragments[0].matchesContentStart;
+          boolean lastFragmentMatchesContentEnd = fragments[fragments.length - 1].matchesContentEnd;
+          return of(new Hit.HighlightedField(Arrays.stream(fragments).map(f -> f.fragment).toArray(String[]::new), firstFragmentMatchesContentStart, lastFragmentMatchesContentEnd));
         }
       }
       return of(new Hit.ValueField(value));
@@ -85,7 +88,7 @@ public class QueryResultFactory {
     return empty();
   }
 
-  private String[] createFragments(LuceneSearchableField field, String value) throws InvalidTokenOffsetsException, IOException {
+  private ContentFragment[] createFragments(LuceneSearchableField field, String value) throws InvalidTokenOffsetsException, IOException {
     return highlighter.highlight(field.getName(), field.getAnalyzer(), value);
   }
 

--- a/scm-webapp/src/main/java/sonia/scm/search/QueryResultFactory.java
+++ b/scm-webapp/src/main/java/sonia/scm/search/QueryResultFactory.java
@@ -78,9 +78,9 @@ public class QueryResultFactory {
       if (highlighter.isHighlightable(field)) {
         ContentFragment[] fragments = createFragments(field, value.toString());
         if (fragments.length > 0) {
-          boolean firstFragmentMatchesContentStart = fragments[0].matchesContentStart;
-          boolean lastFragmentMatchesContentEnd = fragments[fragments.length - 1].matchesContentEnd;
-          return of(new Hit.HighlightedField(Arrays.stream(fragments).map(f -> f.fragment).toArray(String[]::new), firstFragmentMatchesContentStart, lastFragmentMatchesContentEnd));
+          boolean firstFragmentMatchesContentStart = fragments[0].isMatchesContentStart();
+          boolean lastFragmentMatchesContentEnd = fragments[fragments.length - 1].isMatchesContentEnd();
+          return of(new Hit.HighlightedField(Arrays.stream(fragments).map(ContentFragment::getFragment).toArray(String[]::new), firstFragmentMatchesContentStart, lastFragmentMatchesContentEnd));
         }
       }
       return of(new Hit.ValueField(value));

--- a/scm-webapp/src/test/java/sonia/scm/search/LuceneHighlighterTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/search/LuceneHighlighterTest.java
@@ -56,43 +56,47 @@ class LuceneHighlighterTest {
     String content = content("content");
 
     LuceneHighlighter highlighter = new LuceneHighlighter(analyzer, query);
-    String[] snippets = highlighter.highlight("content", Indexed.Analyzer.DEFAULT, content);
+    ContentFragment[] contentFragments = highlighter.highlight("content", Indexed.Analyzer.DEFAULT, content);
 
-    assertThat(snippets).hasSize(1).allSatisfy(
-      snippet -> assertThat(snippet).contains("<|[[--Golgafrinchan--]]|>")
+    assertThat(contentFragments).hasSize(1).allSatisfy(
+      contentFragment -> assertThat(contentFragment.fragment).contains("<|[[--Golgafrinchan--]]|>")
     );
   }
 
   @Test
   void shouldHighlightCodeAndKeepLines() throws IOException, InvalidTokenOffsetsException {
-    String[] snippets = highlightCode("GameOfLife.java", "die");
+    ContentFragment[] contentFragments = highlightCode("GameOfLife.java", "die");
 
-    assertThat(snippets).hasSize(1).allSatisfy(
-      snippet -> assertThat(snippet.split("\n")).contains(
-        "\t\t\t\tint neighbors= getNeighbors(above, same, below);",
-        "\t\t\t\tif(neighbors < 2 || neighbors > 3){",
-        "\t\t\t\t\tnewGen[row]+= \"_\";//<2 or >3 neighbors -> <|[[--die--]]|>",
-        "\t\t\t\t}else if(neighbors == 3){",
-        "\t\t\t\t\tnewGen[row]+= \"#\";//3 neighbors -> spawn/live"
-      )
+    assertThat(contentFragments).hasSize(1).allSatisfy(
+      contentFragment -> {
+        assertThat(contentFragment.fragment.split("\n")).contains(
+          "\t\t\t\tint neighbors= getNeighbors(above, same, below);",
+          "\t\t\t\tif(neighbors < 2 || neighbors > 3){",
+          "\t\t\t\t\tnewGen[row]+= \"_\";//<2 or >3 neighbors -> <|[[--die--]]|>",
+          "\t\t\t\t}else if(neighbors == 3){",
+          "\t\t\t\t\tnewGen[row]+= \"#\";//3 neighbors -> spawn/live"
+        );
+        assertThat(contentFragment.matchesContentStart).isFalse();
+        assertThat(contentFragment.matchesContentEnd).isFalse();
+      }
     );
   }
 
   @Test
   void shouldNotStartHighlightedFragmentWithLineBreak() throws IOException, InvalidTokenOffsetsException {
-    String[] snippets = highlightCode("GameOfLife.java", "die");
+    ContentFragment[] contentFragments = highlightCode("GameOfLife.java", "die");
 
-    assertThat(snippets).hasSize(1).allSatisfy(
-      snippet -> assertThat(snippet).doesNotStartWith("\n")
+    assertThat(contentFragments).hasSize(1).allSatisfy(
+      contentFragment -> assertThat(contentFragment.fragment).doesNotStartWith("\n")
     );
   }
 
   @Test
   void shouldHighlightCodeInTsx() throws IOException, InvalidTokenOffsetsException {
-    String[] snippets = highlightCode("Button.tsx", "inherit");
+    ContentFragment[] contentFragments = highlightCode("Button.tsx", "inherit");
 
-    assertThat(snippets).hasSize(1).allSatisfy(
-      snippet -> assertThat(snippet.split("\n")).contains(
+    assertThat(contentFragments).hasSize(1).allSatisfy(
+      contentFragment -> assertThat(contentFragment.fragment.split("\n")).contains(
         "}) => {",
         "  const renderIcon = () => {",
         "    return <>{icon ? <Icon name={icon} color=\"<|[[--inherit--]]|>\" className=\"is-medium pr-1\" /> : null}</>;",
@@ -103,16 +107,20 @@ class LuceneHighlighterTest {
 
   @Test
   void shouldHighlightFirstCodeLine() throws InvalidTokenOffsetsException, IOException {
-    String[] snippets = highlightCode("GameOfLife.java", "gameoflife");
+    ContentFragment[] contentFragments = highlightCode("GameOfLife.java", "gameoflife");
 
-    assertThat(snippets).hasSize(1);
+    assertThat(contentFragments).hasSize(1);
+    assertThat(contentFragments[0].matchesContentStart).isTrue();
+    assertThat(contentFragments[0].matchesContentEnd).isFalse();
   }
 
   @Test
   void shouldHighlightLastCodeLine() throws InvalidTokenOffsetsException, IOException {
-    String[] snippets = highlightCode("Button.tsx", "default");
+    ContentFragment[] contentFragments = highlightCode("Button.tsx", "default");
 
-    assertThat(snippets).hasSize(1);
+    assertThat(contentFragments).hasSize(1);
+    assertThat(contentFragments[0].matchesContentStart).isFalse();
+    assertThat(contentFragments[0].matchesContentEnd).isTrue();
   }
 
   @Nested
@@ -154,7 +162,7 @@ class LuceneHighlighterTest {
 
   }
 
-  private String[] highlightCode(String resource, String search) throws IOException, InvalidTokenOffsetsException {
+  private ContentFragment[] highlightCode(String resource, String search) throws IOException, InvalidTokenOffsetsException {
     NonNaturalLanguageAnalyzer analyzer = new NonNaturalLanguageAnalyzer();
     Query query = new TermQuery(new Term("content", search));
 

--- a/scm-webapp/src/test/java/sonia/scm/search/LuceneHighlighterTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/search/LuceneHighlighterTest.java
@@ -59,7 +59,7 @@ class LuceneHighlighterTest {
     ContentFragment[] contentFragments = highlighter.highlight("content", Indexed.Analyzer.DEFAULT, content);
 
     assertThat(contentFragments).hasSize(1).allSatisfy(
-      contentFragment -> assertThat(contentFragment.fragment).contains("<|[[--Golgafrinchan--]]|>")
+      contentFragment -> assertThat(contentFragment.getFragment()).contains("<|[[--Golgafrinchan--]]|>")
     );
   }
 
@@ -69,15 +69,15 @@ class LuceneHighlighterTest {
 
     assertThat(contentFragments).hasSize(1).allSatisfy(
       contentFragment -> {
-        assertThat(contentFragment.fragment.split("\n")).contains(
+        assertThat(contentFragment.getFragment().split("\n")).contains(
           "\t\t\t\tint neighbors= getNeighbors(above, same, below);",
           "\t\t\t\tif(neighbors < 2 || neighbors > 3){",
           "\t\t\t\t\tnewGen[row]+= \"_\";//<2 or >3 neighbors -> <|[[--die--]]|>",
           "\t\t\t\t}else if(neighbors == 3){",
           "\t\t\t\t\tnewGen[row]+= \"#\";//3 neighbors -> spawn/live"
         );
-        assertThat(contentFragment.matchesContentStart).isFalse();
-        assertThat(contentFragment.matchesContentEnd).isFalse();
+        assertThat(contentFragment.isMatchesContentEnd()).isFalse();
+        assertThat(contentFragment.isMatchesContentEnd()).isFalse();
       }
     );
   }
@@ -87,7 +87,7 @@ class LuceneHighlighterTest {
     ContentFragment[] contentFragments = highlightCode("GameOfLife.java", "die");
 
     assertThat(contentFragments).hasSize(1).allSatisfy(
-      contentFragment -> assertThat(contentFragment.fragment).doesNotStartWith("\n")
+      contentFragment -> assertThat(contentFragment.getFragment()).doesNotStartWith("\n")
     );
   }
 
@@ -96,7 +96,7 @@ class LuceneHighlighterTest {
     ContentFragment[] contentFragments = highlightCode("Button.tsx", "inherit");
 
     assertThat(contentFragments).hasSize(1).allSatisfy(
-      contentFragment -> assertThat(contentFragment.fragment.split("\n")).contains(
+      contentFragment -> assertThat(contentFragment.getFragment().split("\n")).contains(
         "}) => {",
         "  const renderIcon = () => {",
         "    return <>{icon ? <Icon name={icon} color=\"<|[[--inherit--]]|>\" className=\"is-medium pr-1\" /> : null}</>;",
@@ -110,8 +110,8 @@ class LuceneHighlighterTest {
     ContentFragment[] contentFragments = highlightCode("GameOfLife.java", "gameoflife");
 
     assertThat(contentFragments).hasSize(1);
-    assertThat(contentFragments[0].matchesContentStart).isTrue();
-    assertThat(contentFragments[0].matchesContentEnd).isFalse();
+    assertThat(contentFragments[0].isMatchesContentStart()).isTrue();
+    assertThat(contentFragments[0].isMatchesContentEnd()).isFalse();
   }
 
   @Test
@@ -119,8 +119,8 @@ class LuceneHighlighterTest {
     ContentFragment[] contentFragments = highlightCode("Button.tsx", "default");
 
     assertThat(contentFragments).hasSize(1);
-    assertThat(contentFragments[0].matchesContentStart).isFalse();
-    assertThat(contentFragments[0].matchesContentEnd).isTrue();
+    assertThat(contentFragments[0].isMatchesContentStart()).isFalse();
+    assertThat(contentFragments[0].isMatchesContentEnd()).isTrue();
   }
 
   @Nested


### PR DESCRIPTION
## Proposed changes

Display ellipsis as an indicator that there is more content before or behind a search result fragment only if there really is more content.

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] New code is covered with unit tests
- [X] New ui components are tested inside the storybook (module ui-components only) 
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
