### PR TITLE
Fix read/pull permission checks

### DIFF
--- a/gradle/changelog/read_permission.yaml
+++ b/gradle/changelog/read_permission.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: The permission 'repository:read' can only read metadata, no sources ([#1897](https://github.com/scm-manager/scm-manager/pull/1897))

--- a/scm-plugins/scm-git-plugin/src/main/js/RepositoryConfig.tsx
+++ b/scm-plugins/scm-git-plugin/src/main/js/RepositoryConfig.tsx
@@ -73,25 +73,28 @@ class RepositoryConfig extends React.Component<Props, State> {
 
   componentDidMount() {
     const { repository } = this.props;
-    this.setState({
-      loadingBranches: true,
-    });
     const branchesLink = repository._links.branches as Link;
-    apiClient
-      .get(branchesLink.href)
-      .then((response) => response.json())
-      .then((payload) => payload._embedded.branches)
-      .then((branches) =>
-        this.setState({
-          branches,
-          loadingBranches: false,
-        })
-      )
-      .catch((error) =>
-        this.setState({
-          error,
-        })
-      );
+    if (branchesLink) {
+      apiClient
+        .get(branchesLink.href)
+        .then((response) => response.json())
+        .then((payload) => payload._embedded.branches)
+        .then((branches) =>
+          this.setState({
+            branches,
+            loadingBranches: false,
+          })
+        )
+        .catch((error) =>
+          this.setState({
+            error,
+          })
+        );
+    } else {
+      this.setState({
+        loadingBranches: false,
+      });
+    }
 
     const configurationLink = repository._links.configuration as Link;
     this.setState({

--- a/scm-ui/ui-webapp/src/repos/containers/RepositoryRoot.tsx
+++ b/scm-ui/ui-webapp/src/repos/containers/RepositoryRoot.tsx
@@ -118,8 +118,10 @@ const RepositoryRoot = () => {
   let redirectedUrl;
   if (redirectUrlFactory) {
     redirectedUrl = url + redirectUrlFactory(props);
-  } else {
+  } else if (repository._links.sources) {
     redirectedUrl = url + "/code/sources/";
+  } else {
+    redirectedUrl = url + "/info";
   }
 
   const fileControlFactoryFactory: (changeset: Changeset) => FileControlFactory = changeset => file => {

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/AnnotateResource.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/AnnotateResource.java
@@ -29,6 +29,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import sonia.scm.repository.NamespaceAndName;
+import sonia.scm.repository.RepositoryPermissions;
 import sonia.scm.repository.api.RepositoryService;
 import sonia.scm.repository.api.RepositoryServiceFactory;
 import sonia.scm.web.VndMediaType;
@@ -89,6 +90,7 @@ public class AnnotateResource {
   ) throws IOException {
     NamespaceAndName namespaceAndName = new NamespaceAndName(namespace, name);
     try (RepositoryService repositoryService = serviceFactory.create(namespaceAndName)) {
+      RepositoryPermissions.pull(repositoryService.getRepository()).check();
       return mapper.map(repositoryService.getBlameCommand().setRevision(revision).getBlameResult(path), namespaceAndName, revision, path);
     }
   }

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/BranchDetailsResource.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/BranchDetailsResource.java
@@ -34,6 +34,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.hibernate.validator.constraints.Length;
 import sonia.scm.NotFoundException;
 import sonia.scm.repository.NamespaceAndName;
+import sonia.scm.repository.RepositoryPermissions;
 import sonia.scm.repository.api.BranchDetailsCommandBuilder;
 import sonia.scm.repository.api.BranchDetailsCommandResult;
 import sonia.scm.repository.api.CommandNotSupportedException;
@@ -116,6 +117,7 @@ public class BranchDetailsResource {
     @Length(min = 1, max = 100) @Pattern(regexp = VALID_BRANCH_NAMES) @PathParam("branch") String branchName
   ) {
     try (RepositoryService service = serviceFactory.create(new NamespaceAndName(namespace, name))) {
+      RepositoryPermissions.pull(service.getRepository()).check();
       BranchDetailsCommandResult result = service.getBranchDetailsCommand().execute(branchName);
       BranchDetailsDto dto = mapper.map(service.getRepository(), branchName, result.getDetails());
       return Response.ok(dto).build();
@@ -169,6 +171,7 @@ public class BranchDetailsResource {
     @QueryParam("branches") List<@Length(min = 1, max = 100) @Pattern(regexp = VALID_BRANCH_NAMES) String> branches
   ) {
     try (RepositoryService service = serviceFactory.create(new NamespaceAndName(namespace, name))) {
+      RepositoryPermissions.pull(service.getRepository()).check();
       List<BranchDetailsDto> dtos = getBranchDetailsDtos(service, decodeBranchNames(branches));
       Links links = Links.linkingTo().self(resourceLinks.branchDetailsCollection().self(namespace, name)).build();
       Embedded embedded = Embedded.embeddedBuilder().with("branchDetails", dtos).build();

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/BranchRootResource.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/BranchRootResource.java
@@ -131,6 +131,7 @@ public class BranchRootResource {
   ) throws IOException {
     NamespaceAndName namespaceAndName = new NamespaceAndName(namespace, name);
     try (RepositoryService repositoryService = serviceFactory.create(namespaceAndName)) {
+      RepositoryPermissions.pull(repositoryService.getRepository()).check();
       Branches branches = repositoryService.getBranchesCommand().getBranches();
       return branches.getBranches()
         .stream()
@@ -180,6 +181,7 @@ public class BranchRootResource {
                           @DefaultValue("0") @QueryParam("page") int page,
                           @DefaultValue("10") @QueryParam("pageSize") int pageSize) throws IOException {
     try (RepositoryService repositoryService = serviceFactory.create(new NamespaceAndName(namespace, name))) {
+      RepositoryPermissions.pull(repositoryService.getRepository()).check();
       if (!branchExists(branchName, repositoryService)) {
         throw notFound(entity(Branch.class, branchName).in(Repository.class, namespace + "/" + name));
       }
@@ -330,6 +332,7 @@ public class BranchRootResource {
     @PathParam("name") String name
   ) throws IOException {
     try (RepositoryService repositoryService = serviceFactory.create(new NamespaceAndName(namespace, name))) {
+      RepositoryPermissions.pull(repositoryService.getRepository()).check();
       Branches branches = repositoryService.getBranchesCommand().getBranches();
       return Response.ok(branchCollectionToDtoMapper.map(repositoryService.getRepository(), branches.getBranches())).build();
     } catch (CommandNotSupportedException ex) {

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/ChangesetRootResource.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/ChangesetRootResource.java
@@ -101,7 +101,7 @@ public class ChangesetRootResource {
                          @DefaultValue("10") @QueryParam("pageSize") int pageSize) throws IOException {
     try (RepositoryService repositoryService = serviceFactory.create(new NamespaceAndName(namespace, name))) {
       Repository repository = repositoryService.getRepository();
-      RepositoryPermissions.read(repository).check();
+      RepositoryPermissions.pull(repository).check();
       ChangesetPagingResult changesets = new PagedLogCommandBuilder(repositoryService)
         .page(page)
         .pageSize(pageSize)
@@ -151,7 +151,7 @@ public class ChangesetRootResource {
   public Response get(@PathParam("namespace") String namespace, @PathParam("name") String name, @PathParam("id") String id) throws IOException {
     try (RepositoryService repositoryService = serviceFactory.create(new NamespaceAndName(namespace, name))) {
       Repository repository = repositoryService.getRepository();
-      RepositoryPermissions.read(repository).check();
+      RepositoryPermissions.pull(repository).check();
       Changeset changeset = repositoryService.getLogCommand().getChangeset(id);
       if (changeset == null) {
         throw notFound(entity(Changeset.class, id).in(repository));

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/ContentResource.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/ContentResource.java
@@ -35,6 +35,7 @@ import sonia.scm.NotFoundException;
 import sonia.scm.io.ContentType;
 import sonia.scm.io.ContentTypeResolver;
 import sonia.scm.repository.NamespaceAndName;
+import sonia.scm.repository.RepositoryPermissions;
 import sonia.scm.repository.api.RepositoryService;
 import sonia.scm.repository.api.RepositoryServiceFactory;
 import sonia.scm.util.IOUtil;
@@ -121,6 +122,7 @@ public class ContentResource {
     @QueryParam("end") Integer end) {
     StreamingOutput stream = createStreamingOutput(namespace, name, revision, path, start, end);
     try (RepositoryService repositoryService = serviceFactory.create(new NamespaceAndName(namespace, name))) {
+      RepositoryPermissions.pull(repositoryService.getRepository()).check();
       Response.ResponseBuilder responseBuilder = Response.ok(stream);
       return createContentHeader(namespace, name, revision, path, repositoryService, responseBuilder);
     } catch (NotFoundException e) {
@@ -188,6 +190,7 @@ public class ContentResource {
     ))
   public Response metadata(@PathParam("namespace") String namespace, @PathParam("name") String name, @PathParam("revision") String revision, @PathParam("path") String path) {
     try (RepositoryService repositoryService = serviceFactory.create(new NamespaceAndName(namespace, name))) {
+      RepositoryPermissions.pull(repositoryService.getRepository()).check();
       Response.ResponseBuilder responseBuilder = Response.ok();
       return createContentHeader(namespace, name, revision, path, repositoryService, responseBuilder);
     } catch (NotFoundException e) {

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/DiffRootResource.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/DiffRootResource.java
@@ -30,6 +30,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import sonia.scm.NotFoundException;
 import sonia.scm.repository.NamespaceAndName;
+import sonia.scm.repository.RepositoryPermissions;
 import sonia.scm.repository.api.DiffCommandBuilder;
 import sonia.scm.repository.api.DiffFormat;
 import sonia.scm.repository.api.DiffResult;
@@ -103,6 +104,7 @@ public class DiffRootResource {
     HttpUtil.checkForCRLFInjection(revision);
     DiffFormat diffFormat = DiffFormat.valueOf(format);
     try (RepositoryService repositoryService = serviceFactory.create(new NamespaceAndName(namespace, name))) {
+      RepositoryPermissions.pull(repositoryService.getRepository()).check();
       DiffCommandBuilder.OutputStreamConsumer outputStreamConsumer = repositoryService.getDiffCommand()
         .setRevision(revision)
         .setFormat(diffFormat)
@@ -150,6 +152,7 @@ public class DiffRootResource {
                                  @QueryParam("offset") @Min(0) Integer offset) throws IOException {
     HttpUtil.checkForCRLFInjection(revision);
     try (RepositoryService repositoryService = serviceFactory.create(new NamespaceAndName(namespace, name))) {
+      RepositoryPermissions.pull(repositoryService.getRepository()).check();
       DiffResult diffResult = repositoryService.getDiffResultCommand()
         .setRevision(revision)
         .setLimit(limit)

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/FileHistoryRootResource.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/FileHistoryRootResource.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.api.v2.resources;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,6 +34,7 @@ import sonia.scm.repository.Changeset;
 import sonia.scm.repository.ChangesetPagingResult;
 import sonia.scm.repository.NamespaceAndName;
 import sonia.scm.repository.Repository;
+import sonia.scm.repository.RepositoryPermissions;
 import sonia.scm.repository.api.RepositoryService;
 import sonia.scm.repository.api.RepositoryServiceFactory;
 import sonia.scm.web.VndMediaType;
@@ -114,6 +115,7 @@ public class FileHistoryRootResource {
     try (RepositoryService repositoryService = serviceFactory.create(namespaceAndName)) {
       log.info("Get changesets of the file {} and revision {}", path, revision);
       Repository repository = repositoryService.getRepository();
+      RepositoryPermissions.pull(repository).check();
       ChangesetPagingResult changesets = new PagedLogCommandBuilder(repositoryService)
         .page(page)
         .pageSize(pageSize)

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/IncomingRootResource.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/IncomingRootResource.java
@@ -143,7 +143,7 @@ public class IncomingRootResource {
                                      @DefaultValue("10") @QueryParam("pageSize") int pageSize) throws IOException {
     try (RepositoryService repositoryService = serviceFactory.create(new NamespaceAndName(namespace, name))) {
       Repository repository = repositoryService.getRepository();
-      RepositoryPermissions.read(repository).check();
+      RepositoryPermissions.pull(repository).check();
       ChangesetPagingResult changesets = new PagedLogCommandBuilder(repositoryService)
         .page(page)
         .pageSize(pageSize)
@@ -199,6 +199,7 @@ public class IncomingRootResource {
     HttpUtil.checkForCRLFInjection(target);
     DiffFormat diffFormat = DiffFormat.valueOf(format);
     try (RepositoryService repositoryService = serviceFactory.create(new NamespaceAndName(namespace, name))) {
+      RepositoryPermissions.pull(repositoryService.getRepository()).check();
       DiffCommandBuilder.OutputStreamConsumer outputStreamConsumer = repositoryService.getDiffCommand()
         .setRevision(source)
         .setAncestorChangeset(target)
@@ -249,6 +250,7 @@ public class IncomingRootResource {
     HttpUtil.checkForCRLFInjection(source);
     HttpUtil.checkForCRLFInjection(target);
     try (RepositoryService repositoryService = serviceFactory.create(new NamespaceAndName(namespace, name))) {
+      RepositoryPermissions.pull(repositoryService.getRepository()).check();
       DiffResult diffResult = repositoryService.getDiffResultCommand()
         .setRevision(source)
         .setAncestorChangeset(target)

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/ModificationsRootResource.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/ModificationsRootResource.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.api.v2.resources;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,6 +30,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import sonia.scm.repository.Modifications;
 import sonia.scm.repository.NamespaceAndName;
+import sonia.scm.repository.RepositoryPermissions;
 import sonia.scm.repository.api.RepositoryService;
 import sonia.scm.repository.api.RepositoryServiceFactory;
 import sonia.scm.web.VndMediaType;
@@ -81,6 +82,7 @@ public class ModificationsRootResource {
   @ApiResponse(responseCode = "500", description = "internal server error")
   public Response get(@PathParam("namespace") String namespace, @PathParam("name") String name, @PathParam("revision") String revision) throws IOException {
     try (RepositoryService repositoryService = serviceFactory.create(new NamespaceAndName(namespace, name))) {
+      RepositoryPermissions.pull(repositoryService.getRepository()).check();
       Modifications modifications = repositoryService.getModificationsCommand()
         .revision(revision)
         .getModifications();

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/RepositoryToRepositoryDtoMapper.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/RepositoryToRepositoryDtoMapper.java
@@ -134,34 +134,34 @@ public abstract class RepositoryToRepositoryDtoMapper extends BaseMapper<Reposit
           .map(this::createProtocolLink)
           .collect(toList());
         linksBuilder.array(protocolLinks);
-      }
 
-      if (repositoryService.isSupported(Command.BUNDLE) && RepositoryPermissions.export(repository).isPermitted()) {
-        linksBuilder.single(link("export", resourceLinks.repository().export(repository.getNamespace(), repository.getName(), repository.getType())));
-        linksBuilder.single(link("fullExport", resourceLinks.repository().fullExport(repository.getNamespace(), repository.getName(), repository.getType())));
-        linksBuilder.single(link("exportInfo", resourceLinks.repository().exportInfo(repository.getNamespace(), repository.getName())));
-      }
-
-      if (repositoryService.isSupported(Command.TAGS)) {
-        linksBuilder.single(link("tags", resourceLinks.tag().all(repository.getNamespace(), repository.getName())));
-      }
-      if (repositoryService.isSupported(Command.BRANCHES)) {
-        linksBuilder.single(link("branches", resourceLinks.branchCollection().self(repository.getNamespace(), repository.getName())));
-      }
-      if (repositoryService.isSupported(Command.BRANCH_DETAILS)) {
-        linksBuilder.single(link("branchDetailsCollection", resourceLinks.branchDetailsCollection().self(repository.getNamespace(), repository.getName())));
-      }
-      if (repositoryService.isSupported(Feature.INCOMING_REVISION)) {
-        linksBuilder.single(link("incomingChangesets", resourceLinks.incoming().changesets(repository.getNamespace(), repository.getName())));
-        linksBuilder.single(link("incomingDiff", resourceLinks.incoming().diff(repository.getNamespace(), repository.getName())));
-        if (repositoryService.isSupported(Command.DIFF_RESULT)) {
-          linksBuilder.single(link("incomingDiffParsed", resourceLinks.incoming().diffParsed(repository.getNamespace(), repository.getName())));
+        if (repositoryService.isSupported(Command.BUNDLE) && RepositoryPermissions.export(repository).isPermitted()) {
+          linksBuilder.single(link("export", resourceLinks.repository().export(repository.getNamespace(), repository.getName(), repository.getType())));
+          linksBuilder.single(link("fullExport", resourceLinks.repository().fullExport(repository.getNamespace(), repository.getName(), repository.getType())));
+          linksBuilder.single(link("exportInfo", resourceLinks.repository().exportInfo(repository.getNamespace(), repository.getName())));
         }
+
+        if (repositoryService.isSupported(Command.TAGS)) {
+          linksBuilder.single(link("tags", resourceLinks.tag().all(repository.getNamespace(), repository.getName())));
+        }
+        if (repositoryService.isSupported(Command.BRANCHES)) {
+          linksBuilder.single(link("branches", resourceLinks.branchCollection().self(repository.getNamespace(), repository.getName())));
+        }
+        if (repositoryService.isSupported(Command.BRANCH_DETAILS)) {
+          linksBuilder.single(link("branchDetailsCollection", resourceLinks.branchDetailsCollection().self(repository.getNamespace(), repository.getName())));
+        }
+        if (repositoryService.isSupported(Feature.INCOMING_REVISION)) {
+          linksBuilder.single(link("incomingChangesets", resourceLinks.incoming().changesets(repository.getNamespace(), repository.getName())));
+          linksBuilder.single(link("incomingDiff", resourceLinks.incoming().diff(repository.getNamespace(), repository.getName())));
+          if (repositoryService.isSupported(Command.DIFF_RESULT)) {
+            linksBuilder.single(link("incomingDiffParsed", resourceLinks.incoming().diffParsed(repository.getNamespace(), repository.getName())));
+          }
+        }
+        linksBuilder.single(link("changesets", resourceLinks.changeset().all(repository.getNamespace(), repository.getName())));
+        linksBuilder.single(link("sources", resourceLinks.source().selfWithoutRevision(repository.getNamespace(), repository.getName())));
+        linksBuilder.single(link("paths", resourceLinks.repository().paths(repository.getNamespace(), repository.getName())));
       }
     }
-    linksBuilder.single(link("changesets", resourceLinks.changeset().all(repository.getNamespace(), repository.getName())));
-    linksBuilder.single(link("sources", resourceLinks.source().selfWithoutRevision(repository.getNamespace(), repository.getName())));
-    linksBuilder.single(link("paths", resourceLinks.repository().paths(repository.getNamespace(), repository.getName())));
     if (RepositoryPermissions.healthCheck(repository).isPermitted() && !healthCheckService.checkRunning(repository)) {
       linksBuilder.single(link("runHealthCheck", resourceLinks.repository().runHealthCheck(repository.getNamespace(), repository.getName())));
     }

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/SourceRootResource.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/SourceRootResource.java
@@ -27,6 +27,7 @@ package sonia.scm.api.v2.resources;
 import io.swagger.v3.oas.annotations.Operation;
 import sonia.scm.repository.BrowserResult;
 import sonia.scm.repository.NamespaceAndName;
+import sonia.scm.repository.RepositoryPermissions;
 import sonia.scm.repository.api.BrowseCommandBuilder;
 import sonia.scm.repository.api.RepositoryService;
 import sonia.scm.repository.api.RepositoryServiceFactory;
@@ -83,6 +84,7 @@ public class SourceRootResource {
   private FileObjectDto getSource(String namespace, String repoName, String path, String revision, int offset) throws IOException {
     NamespaceAndName namespaceAndName = new NamespaceAndName(namespace, repoName);
     try (RepositoryService repositoryService = serviceFactory.create(namespaceAndName)) {
+      RepositoryPermissions.pull(repositoryService.getRepository()).check();
       BrowseCommandBuilder browseCommand = repositoryService.getBrowseCommand();
       browseCommand.setPath(path);
       browseCommand.setOffset(offset);

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/TagRootResource.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/TagRootResource.java
@@ -262,7 +262,7 @@ public class TagRootResource {
 
   private Tags getTags(RepositoryService repositoryService) throws IOException {
     Repository repository = repositoryService.getRepository();
-    RepositoryPermissions.read(repository).check();
+    RepositoryPermissions.pull(repository).check();
     return repositoryService.getTagsCommand().getTags();
   }
 

--- a/scm-webapp/src/main/java/sonia/scm/repository/RepositoryPathCollector.java
+++ b/scm-webapp/src/main/java/sonia/scm/repository/RepositoryPathCollector.java
@@ -52,6 +52,7 @@ public class RepositoryPathCollector {
 
   private BrowserResult browse(NamespaceAndName repository, String revision) throws IOException {
     try (RepositoryService repositoryService = serviceFactory.create(repository)) {
+      RepositoryPermissions.pull(repositoryService.getRepository()).check();
       return repositoryService.getBrowseCommand()
         .setDisableSubRepositoryDetection(true)
         .setDisableLastCommit(true)

--- a/scm-webapp/src/test/java/sonia/scm/api/v2/resources/SourceRootResourceTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/api/v2/resources/SourceRootResourceTest.java
@@ -24,19 +24,22 @@
 
 package sonia.scm.api.v2.resources;
 
-import com.google.inject.util.Providers;
+import org.github.sdorra.jse.ShiroExtension;
+import org.github.sdorra.jse.SubjectAware;
 import org.jboss.resteasy.mock.MockHttpRequest;
 import org.jboss.resteasy.mock.MockHttpResponse;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mapstruct.factory.Mappers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import sonia.scm.NotFoundException;
 import sonia.scm.repository.BrowserResult;
 import sonia.scm.repository.FileObject;
 import sonia.scm.repository.NamespaceAndName;
+import sonia.scm.repository.Repository;
 import sonia.scm.repository.api.BrowseCommandBuilder;
 import sonia.scm.repository.api.RepositoryService;
 import sonia.scm.repository.api.RepositoryServiceFactory;
@@ -50,8 +53,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(MockitoJUnitRunner.Silent.class)
-public class SourceRootResourceTest extends RepositoryTestBase {
+@ExtendWith(ShiroExtension.class)
+@ExtendWith(MockitoExtension.class)
+class SourceRootResourceTest extends RepositoryTestBase {
 
   private RestDispatcher dispatcher = new RestDispatcher();
   private final URI baseUri = URI.create("/");
@@ -66,64 +70,89 @@ public class SourceRootResourceTest extends RepositoryTestBase {
 
   private BrowserResultToFileObjectDtoMapper browserResultToFileObjectDtoMapper;
 
+  private final MockHttpResponse response = new MockHttpResponse();
 
-  @Before
+  @BeforeEach
   public void prepareEnvironment() {
     browserResultToFileObjectDtoMapper = Mappers.getMapper(BrowserResultToFileObjectDtoMapper.class);
     browserResultToFileObjectDtoMapper.setResourceLinks(resourceLinks);
-    when(serviceFactory.create(new NamespaceAndName("space", "repo"))).thenReturn(service);
-    when(service.getBrowseCommand()).thenReturn(browseCommandBuilder);
 
     sourceRootResource = new SourceRootResource(serviceFactory, browserResultToFileObjectDtoMapper);
     dispatcher.addSingletonResource(getRepositoryRootResource());
   }
 
-  @Test
-  public void shouldReturnSources() throws URISyntaxException, IOException {
-    BrowserResult result = createBrowserResult();
-    when(browseCommandBuilder.getBrowserResult()).thenReturn(result);
-    MockHttpRequest request = MockHttpRequest.get("/" + RepositoryRootResource.REPOSITORIES_PATH_V2 + "space/repo/sources");
-    MockHttpResponse response = new MockHttpResponse();
+  @Nested
+  class ForRepository {
 
-    dispatcher.invoke(request, response);
-    assertThat(response.getStatus()).isEqualTo(200);
-    System.out.println(response.getContentAsString());
-    assertThat(response.getContentAsString()).contains("\"revision\":\"revision\"");
-    assertThat(response.getContentAsString()).contains("\"children\":");
+    @BeforeEach
+    void initRepository() {
+      when(serviceFactory.create(new NamespaceAndName("space", "repo"))).thenReturn(service);
+      when(service.getRepository()).thenReturn(new Repository("42", "git", "hitchhiker", "hog"));
+    }
+
+    @Nested
+    @SubjectAware(value = "dent", permissions = "repository:pull:42")
+    class WithPermission {
+
+      @BeforeEach
+      void initCommand() {
+        when(service.getBrowseCommand()).thenReturn(browseCommandBuilder);
+      }
+
+      @Test
+      void shouldReturnSources() throws URISyntaxException, IOException {
+        BrowserResult result = createBrowserResult();
+        when(browseCommandBuilder.getBrowserResult()).thenReturn(result);
+        MockHttpRequest request = MockHttpRequest.get("/" + RepositoryRootResource.REPOSITORIES_PATH_V2 + "space/repo/sources");
+
+        dispatcher.invoke(request, response);
+        assertThat(response.getStatus()).isEqualTo(200);
+        System.out.println(response.getContentAsString());
+        assertThat(response.getContentAsString()).contains("\"revision\":\"revision\"");
+        assertThat(response.getContentAsString()).contains("\"children\":");
+      }
+
+      @Test
+      void shouldGetResultForSingleFile() throws URISyntaxException, IOException {
+        FileObject fileObject = new FileObject();
+        fileObject.setName("File Object!");
+        fileObject.setPath("/");
+        BrowserResult browserResult = new BrowserResult("revision", fileObject);
+
+        when(browseCommandBuilder.getBrowserResult()).thenReturn(browserResult);
+        MockHttpRequest request = MockHttpRequest.get("/" + RepositoryRootResource.REPOSITORIES_PATH_V2 + "space/repo/sources/revision/fileabc");
+
+        dispatcher.invoke(request, response);
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getContentAsString()).contains("\"revision\":\"revision\"");
+      }
+    }
+
+    @Test
+    @SubjectAware(value = "dent", permissions = "repository:read:42")
+    void shouldFailWithoutPermission() throws URISyntaxException {
+      MockHttpRequest request = MockHttpRequest.get("/" + RepositoryRootResource.REPOSITORIES_PATH_V2 + "space/repo/sources/revision/fileabc");
+
+      dispatcher.invoke(request, response);
+
+      assertThat(response.getStatus()).isEqualTo(403);
+    }
   }
 
   @Test
-  public void shouldReturn404IfRepoNotFound() throws URISyntaxException {
+  void shouldReturn404IfRepoNotFound() throws URISyntaxException {
     when(serviceFactory.create(new NamespaceAndName("idont", "exist"))).thenThrow(new NotFoundException("Test", "a"));
     MockHttpRequest request = MockHttpRequest.get("/" + RepositoryRootResource.REPOSITORIES_PATH_V2 + "idont/exist/sources");
-    MockHttpResponse response = new MockHttpResponse();
 
     dispatcher.invoke(request, response);
     assertThat(response.getStatus()).isEqualTo(404);
   }
 
   @Test
-  public void shouldGetResultForSingleFile() throws URISyntaxException, IOException {
-    FileObject fileObject = new FileObject();
-    fileObject.setName("File Object!");
-    fileObject.setPath("/");
-    BrowserResult browserResult = new BrowserResult("revision", fileObject);
-
-    when(browseCommandBuilder.getBrowserResult()).thenReturn(browserResult);
-    MockHttpRequest request = MockHttpRequest.get("/" + RepositoryRootResource.REPOSITORIES_PATH_V2 + "space/repo/sources/revision/fileabc");
-    MockHttpResponse response = new MockHttpResponse();
-
-    dispatcher.invoke(request, response);
-    assertThat(response.getStatus()).isEqualTo(200);
-    assertThat(response.getContentAsString()).contains("\"revision\":\"revision\"");
-  }
-
-  @Test
-  public void shouldGet404ForSingleFileIfRepoNotFound() throws URISyntaxException {
+  void shouldGet404ForSingleFileIfRepoNotFound() throws URISyntaxException {
     when(serviceFactory.create(new NamespaceAndName("idont", "exist"))).thenThrow(new NotFoundException("Test", "a"));
 
     MockHttpRequest request = MockHttpRequest.get("/" + RepositoryRootResource.REPOSITORIES_PATH_V2 + "idont/exist/sources/revision/fileabc");
-    MockHttpResponse response = new MockHttpResponse();
 
     dispatcher.invoke(request, response);
     assertThat(response.getStatus()).isEqualTo(404);


### PR DESCRIPTION
## Proposed changes

Users with `repository:read` permission can only read the metadata of a repository, no source code or otherwise repository related data like branches or tags.

Fixes #1895

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins
- [x] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
