### PR TITLE
Set the line ending used for license files to LF

### DIFF
--- a/build-plugins/src/main/groovy/com/cloudogu/scm/JavaModulePlugin.groovy
+++ b/build-plugins/src/main/groovy/com/cloudogu/scm/JavaModulePlugin.groovy
@@ -111,6 +111,7 @@ class JavaModulePlugin implements Plugin<Project> {
       header project.rootProject.file('LICENSE.txt')
       newLine = true
       ignoreNewLine = true
+      lineEnding = "\n"
 
       exclude "**/*.mustache"
       exclude "**/*.json"

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ plugins {
   id 'maven-publish'
   id "org.sonarqube" version "3.0"
   id "org.scm-manager.changelog" version "0.1.6"
+  id 'org.scm-manager.license' version "0.7.1"
 }
 
 changelog {
@@ -120,6 +121,19 @@ dependencies {
     // mocking
     api libraries.mockitoCore
     api libraries.mockitoJunitJupiter
+  }
+}
+
+license {
+  header rootProject.file("LICENSE.txt")
+  newLine = true
+  ignoreNewLine = true
+  lineEnding = "\n"
+
+  tasks {
+    build {
+      files.from("build.gradle", "settings.gradle", "gradle.properties")
+    }
   }
 }
 

--- a/gradle/changelog/format_liceense_lineendings.yaml
+++ b/gradle/changelog/format_liceense_lineendings.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Set line ending used for license files to LF ([#1904](https://github.com/scm-manager/scm-manager/pull/1904))

--- a/scm-packaging/deb/build.gradle
+++ b/scm-packaging/deb/build.gradle
@@ -169,6 +169,7 @@ artifacts {
 
 license {
   header rootProject.file("LICENSE.txt")
+  lineEnding = "\n"
 
   tasks {
     build {

--- a/scm-packaging/deb/build.gradle
+++ b/scm-packaging/deb/build.gradle
@@ -27,7 +27,7 @@ import org.gradle.util.VersionNumber
 plugins {
   id 'nebula.ospackage' version '8.5.6'
   id 'org.scm-manager.packaging'
-  id 'org.scm-manager.license' version '0.7.1'
+  id 'org.scm-manager.license'
 }
 
 configurations {

--- a/scm-packaging/docker/build.gradle
+++ b/scm-packaging/docker/build.gradle
@@ -119,6 +119,7 @@ artifacts {
 
 license {
   header rootProject.file("LICENSE.txt")
+  lineEnding = "\n"
 
   tasks {
     build {

--- a/scm-packaging/docker/build.gradle
+++ b/scm-packaging/docker/build.gradle
@@ -25,7 +25,7 @@
 plugins {
   id 'com.bmuschko.docker-remote-api' version '6.6.1'
   id 'org.scm-manager.packaging'
-  id 'org.scm-manager.license' version '0.7.1'
+  id 'org.scm-manager.license'
 }
 
 import org.gradle.util.VersionNumber

--- a/scm-packaging/helm/build.gradle
+++ b/scm-packaging/helm/build.gradle
@@ -97,6 +97,7 @@ task publish {
 
 license {
   header rootProject.file("LICENSE.txt")
+  lineEnding = "\n"
 
   exclude '**/Chart.yaml'
   exclude '**/*.txt'

--- a/scm-packaging/helm/build.gradle
+++ b/scm-packaging/helm/build.gradle
@@ -26,7 +26,7 @@ plugins {
   id 'org.unbroken-dome.helm' version '1.5.0'
   id 'org.unbroken-dome.helm-publish' version '1.5.0'
   id 'org.scm-manager.packaging'
-  id 'org.scm-manager.license' version '0.7.1'
+  id 'org.scm-manager.license'
 }
 
 configurations {

--- a/scm-packaging/release-yaml/build.gradle
+++ b/scm-packaging/release-yaml/build.gradle
@@ -26,7 +26,7 @@ import com.cloudogu.scm.GitHubUploadTask
 
 plugins {
   id 'org.scm-manager.packaging'
-  id 'org.scm-manager.license' version '0.7.1'
+  id 'org.scm-manager.license'
 }
 
 configurations {

--- a/scm-packaging/release-yaml/build.gradle
+++ b/scm-packaging/release-yaml/build.gradle
@@ -68,6 +68,8 @@ task publish(type: GitHubUploadTask) {
 
 license {
   header rootProject.file("LICENSE.txt")
+  lineEnding = "\n"
+
   tasks {
     gradle {
       files.from('build.gradle')

--- a/scm-packaging/rpm/build.gradle
+++ b/scm-packaging/rpm/build.gradle
@@ -183,6 +183,7 @@ artifacts {
 
 license {
   header rootProject.file("LICENSE.txt")
+  lineEnding = "\n"
 
   tasks {
     build {

--- a/scm-packaging/rpm/build.gradle
+++ b/scm-packaging/rpm/build.gradle
@@ -49,7 +49,7 @@ buildscript {
 plugins {
   id 'nebula.ospackage' version '8.5.6'
   id 'org.scm-manager.packaging'
-  id 'org.scm-manager.license' version '0.7.1'
+  id 'org.scm-manager.license'
 }
 
 configurations {

--- a/scm-packaging/unix/build.gradle
+++ b/scm-packaging/unix/build.gradle
@@ -28,7 +28,7 @@ plugins {
   id 'org.scm-manager.packaging'
   id 'signing'
   id 'maven-publish'
-  id 'org.scm-manager.license' version '0.7.1'
+  id 'org.scm-manager.license'
 }
 
 configurations {

--- a/scm-packaging/unix/build.gradle
+++ b/scm-packaging/unix/build.gradle
@@ -128,6 +128,7 @@ project.rootProject.publishing.repositories.each { r ->
 
 license {
   header rootProject.file("LICENSE.txt")
+  lineEnding = "\n"
 
   tasks {
     build {

--- a/scm-packaging/windows/build.gradle
+++ b/scm-packaging/windows/build.gradle
@@ -132,6 +132,7 @@ project.rootProject.publishing.repositories.each { r ->
 
 license {
   header rootProject.file("LICENSE.txt")
+  lineEnding = "\n"
 
   tasks {
     build {

--- a/scm-packaging/windows/build.gradle
+++ b/scm-packaging/windows/build.gradle
@@ -29,7 +29,7 @@ plugins {
   id 'org.scm-manager.packaging'
   id 'signing'
   id 'maven-publish'
-  id 'org.scm-manager.license' version '0.7.1'
+  id 'org.scm-manager.license'
 }
 
 configurations {

--- a/scm-ui/build.gradle
+++ b/scm-ui/build.gradle
@@ -24,7 +24,7 @@
 
 plugins {
   id 'com.github.node-gradle.node' version '2.2.4'
-  id 'org.scm-manager.license' version '0.7.1'
+  id 'org.scm-manager.license'
   id 'org.scm-manager.ci'
 }
 

--- a/scm-ui/build.gradle
+++ b/scm-ui/build.gradle
@@ -244,6 +244,7 @@ license {
   header rootProject.file("LICENSE.txt")
   newLine = true
   ignoreNewLine = true
+  lineEnding = "\n"
 
   style {
     feature = 'HASH'


### PR DESCRIPTION
## Proposed changes

Set line ending explicitly to LF because on Windows using the system line ending does not get along well with our git settings.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
