### PR TITLE
Fix colors in autocomplete component

### DIFF
--- a/scm-ui/ui-components/src/Autocomplete.tsx
+++ b/scm-ui/ui-components/src/Autocomplete.tsx
@@ -112,6 +112,7 @@ class Autocomplete extends React.Component<Props, State> {
           ) : (
             <Async
               className="autocomplete-entry"
+              classNamePrefix="autocomplete-entry"
               cacheOptions
               loadOptions={loadSuggestions}
               onChange={this.handleInputChange}

--- a/scm-ui/ui-components/src/Autocomplete.tsx
+++ b/scm-ui/ui-components/src/Autocomplete.tsx
@@ -89,6 +89,7 @@ class Autocomplete extends React.Component<Props, State> {
           {creatable ? (
             <AsyncCreatable
               className="autocomplete-entry"
+              classNamePrefix="autocomplete-entry"
               cacheOptions
               loadOptions={loadSuggestions}
               onChange={this.handleInputChange}
@@ -110,6 +111,7 @@ class Autocomplete extends React.Component<Props, State> {
             />
           ) : (
             <Async
+              className="autocomplete-entry"
               cacheOptions
               loadOptions={loadSuggestions}
               onChange={this.handleInputChange}

--- a/scm-ui/ui-styles/src/components/_main.scss
+++ b/scm-ui/ui-styles/src/components/_main.scss
@@ -815,16 +815,16 @@ form .field:not(.is-grouped) {
   color: $link-invert !important;
 }
 
+.autocomplete-entry__option--is-selected {
+  // TODO better use link-light or something
+  background-color: $blue-light !important;
+  color: $link-invert !important;
+}
+
 .autocomplete-entry__single-value {
   color: $text !important;
 }
 
-.autocomplete-entry__control--is-focused {
-  border-color: $input-focus-border-color !important;
-}
-
-.autocomplete-entry {
-}
 .autocomplete-entry > div {
   color: $text-strong !important;
 }
@@ -842,8 +842,14 @@ form .field:not(.is-grouped) {
   border-color: $input-hover-border-color !important;
 }
 
-.autocomplete-entry__control:focus {
+.autocomplete-entry__control--is-focused {
   border-color: $input-focus-border-color !important;
+  box-shadow: $input-focus-box-shadow-size $input-focus-box-shadow-color !important;
+}
+
+.autocomplete-entry__control--is-focused:hover {
+  border-color: $input-focus-border-color !important;
+  box-shadow: $input-focus-box-shadow-size $input-focus-box-shadow-color !important;
 }
 
 .autocomplete-entry__input {

--- a/scm-ui/ui-styles/src/components/_main.scss
+++ b/scm-ui/ui-styles/src/components/_main.scss
@@ -568,7 +568,6 @@ form .field:not(.is-grouped) {
 .select select,
 .textarea,
 .file-name {
-  border-color: $blue-light;
   box-shadow: none;
 }
 
@@ -811,11 +810,42 @@ form .field:not(.is-grouped) {
   color: $text !important;
 }
 
-.autocomplete-entry > div {
-  border-color: $blue-light;
+.autocomplete-entry__option--is-focused {
+  background-color: $link !important;
+  color: $link-invert !important;
+}
 
-  &:hover,
-  &.is-hovered {
-    border-color: #4a4a4a;
-  }
+.autocomplete-entry__single-value {
+  color: $text !important;
+}
+
+.autocomplete-entry__control--is-focused {
+  border-color: $input-focus-border-color !important;
+}
+
+.autocomplete-entry {
+}
+.autocomplete-entry > div {
+  color: $text-strong !important;
+}
+
+.autocomplete-entry__menu {
+  background-color: $background !important;
+}
+
+.autocomplete-entry__control {
+  background-color: $scheme-main !important;
+  border-color: $input-border-color !important;
+}
+
+.autocomplete-entry__control:hover {
+  border-color: $input-hover-border-color !important;
+}
+
+.autocomplete-entry__control:focus {
+  border-color: $input-focus-border-color !important;
+}
+
+.autocomplete-entry__input {
+  color: $text-strong !important;
 }

--- a/scm-ui/ui-styles/src/highcontrast.scss
+++ b/scm-ui/ui-styles/src/highcontrast.scss
@@ -452,6 +452,10 @@ a.has-text-secondary-most:focus {
   background-color: $white !important;
 }
 
+.has-background-light {
+  color: $grey-dark;
+}
+
 .has-hover-visible:hover {
   color: $white-bis !important;
 }

--- a/scm-ui/ui-styles/src/highcontrast.scss
+++ b/scm-ui/ui-styles/src/highcontrast.scss
@@ -482,22 +482,3 @@ fieldset[disabled] .input::placeholder {
   border: 1px solid $info;
   box-shadow: none;
 }
-
-.autocomplete-entry > div {
-  background-color: $scheme-main;
-  color: $white-bis;
-
-  /* Text input */
-  &:nth-child(2) * {
-    color: $white-bis;
-  }
-
-  /* Suggestions */
-  &:nth-child(3) {
-    border: 1px solid $info;
-
-    > div div:hover {
-      background-color: #4672fe !important;
-    }
-  }
-}

--- a/scm-ui/ui-styles/src/variables/_commons.scss
+++ b/scm-ui/ui-styles/src/variables/_commons.scss
@@ -32,3 +32,5 @@ $blue-light: #98d8f3;
 $danger: #ff3860;
 
 $family-monospace: "Courier New", Monaco, Menlo, "Ubuntu Mono", "source-code-pro", monospace;
+
+$input-border-color: $blue-light;


### PR DESCRIPTION
## Proposed changes

Further fixes for the high contrast mode, modly regarded to the autocomplete component.

This is a fixup for #1892

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash

**Reviewer**:
- [X] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [X] All new code/logic is implemented on the right spot / "Should this be done here?"
- [X] UI changes fits into the layout
- [X] The UI views / components are responsive (mobile views)

### Checklist for branch merge request (not required for forks)

- [X] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [X] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
