### PR TITLE
Keep user/group selection in permissions dialog

### DIFF
--- a/gradle/changelog/keep_user_group_selection.yaml
+++ b/gradle/changelog/keep_user_group_selection.yaml
@@ -1,0 +1,2 @@
+- type: changed
+  description: Keeps the selection whether to add a user or a group in the repository permission dialog ([#1919](https://github.com/scm-manager/scm-manager/pull/1919))

--- a/scm-ui/ui-webapp/src/repos/permissions/containers/CreatePermissionForm.tsx
+++ b/scm-ui/ui-webapp/src/repos/permissions/containers/CreatePermissionForm.tsx
@@ -77,7 +77,7 @@ const CreatePermissionForm: FC<Props> = ({
 }) => {
   const initialPermissionState = {
     name: "",
-    role: availableRoles[0].name,
+    role: "READ",
     verbs: [],
     groupPermission: false,
     valid: false

--- a/scm-ui/ui-webapp/src/repos/permissions/containers/CreatePermissionForm.tsx
+++ b/scm-ui/ui-webapp/src/repos/permissions/containers/CreatePermissionForm.tsx
@@ -88,7 +88,12 @@ const CreatePermissionForm: FC<Props> = ({
   const [permission, setPermission] = useState<PermissionState>(initialPermissionState);
   const [t] = useTranslation("repos");
   useEffect(() => {
-    setPermission({ ...initialPermissionState, groupPermission: !!createdPermission?.groupPermission });
+    setPermission({
+      ...initialPermissionState,
+      groupPermission: createdPermission ? createdPermission.groupPermission : initialPermissionState.groupPermission,
+      role: createdPermission ? createdPermission.role : initialPermissionState.role,
+      verbs: createdPermission ? createdPermission?.verbs : initialPermissionState.verbs
+    });
     //eslint-disable-next-line
   }, [createdPermission]);
   const selectedVerbs = permission.role ? findVerbsForRole(availableRoles, permission.role) : permission.verbs;

--- a/scm-ui/ui-webapp/src/repos/permissions/containers/CreatePermissionForm.tsx
+++ b/scm-ui/ui-webapp/src/repos/permissions/containers/CreatePermissionForm.tsx
@@ -88,7 +88,7 @@ const CreatePermissionForm: FC<Props> = ({
   const [permission, setPermission] = useState<PermissionState>(initialPermissionState);
   const [t] = useTranslation("repos");
   useEffect(() => {
-    setPermission(initialPermissionState);
+    setPermission({ ...initialPermissionState, groupPermission: !!createdPermission?.groupPermission });
     //eslint-disable-next-line
   }, [createdPermission]);
   const selectedVerbs = permission.role ? findVerbsForRole(availableRoles, permission.role) : permission.verbs;


### PR DESCRIPTION
## Proposed changes

In the dialog to add permissions for a repository, this will keep
the selection whether to add a user or a group after a new entry
has been added.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
