### PR TITLE
Fix input dialog for password field

### DIFF
--- a/gradle/changelog/password_field.yaml
+++ b/gradle/changelog/password_field.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Password field in "Create User" dialog and other ((#1934)[https://github.com/scm-manager/scm-manager/pull/1934])

--- a/scm-ui/ui-components/src/forms/PasswordConfirmation.tsx
+++ b/scm-ui/ui-components/src/forms/PasswordConfirmation.tsx
@@ -58,7 +58,13 @@ const PasswordConfirmation: FC<InnerProps> = ({ passwordChanged, passwordValidat
     setPasswordConfirmationFailed(password !== newConfirmedPassword);
   };
 
-  const handlePasswordChange = (newPassword: string) => {
+  const handlePasswordChange = (event: React.ChangeEvent<HTMLInputElement> | string) => {
+    let newPassword;
+    if (typeof event === "string") {
+      newPassword = event;
+    } else {
+      newPassword = event.target.value;
+    }
     setPasswordConfirmationFailed(newPassword !== confirmedPassword);
     setPassword(newPassword);
     setPasswordValid(validatePassword(newPassword));
@@ -70,7 +76,7 @@ const PasswordConfirmation: FC<InnerProps> = ({ passwordChanged, passwordValidat
         <InputField
           label={t("password.newPassword")}
           type="password"
-          onChange={event => handlePasswordChange(event.target.value)}
+          onChange={event => handlePasswordChange(event)}
           value={password}
           validationError={!passwordValid}
           errorMessage={t("password.passwordInvalid")}


### PR DESCRIPTION
## Proposed changes

Fixes an javascript error in the create user dialog where the "event" from the password field is a simple string, no event.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [x] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
