### PR TITLE
improve tooltip accessibility

### DIFF
--- a/gradle/changelog/tooltip-a11y.yaml
+++ b/gradle/changelog/tooltip-a11y.yaml
@@ -1,0 +1,2 @@
+- type: changed
+  description: improve tooltip accessibility ([#1938](https://github.com/scm-manager/scm-manager/pull/1938))

--- a/scm-ui/ui-components/src/Tooltip.tsx
+++ b/scm-ui/ui-components/src/Tooltip.tsx
@@ -21,12 +21,128 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import React, { ReactNode } from "react";
+import React, { FC, ReactNode, useEffect, useState } from "react";
+import styled from "styled-components";
+import classNames from "classnames";
+
+// See for css reference: https://github.com/Wikiki/bulma-tooltip/blob/master/src/sass/index.sass
+
+const TooltipWrapper = styled.span`
+  position: relative;
+  display: inline-block;
+`;
+
+const ArrowBase = styled.span`
+  z-index: 1020;
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-style: solid;
+`;
+
+const ArrowTop = styled(ArrowBase)`
+  top: 0;
+  right: auto;
+  bottom: auto;
+  left: 50%;
+  margin-top: -5px;
+  margin-right: auto;
+  margin-bottom: auto;
+  margin-left: -5px;
+  border-width: 5px 5px 0 5px;
+`;
+
+const ArrowRight = styled(ArrowBase)`
+  top: auto;
+  right: 0;
+  bottom: 50%;
+  left: auto;
+  margin-top: auto;
+  margin-right: -5px;
+  margin-bottom: -5px;
+  margin-left: auto;
+  border-width: 5px 5px 5px 0;
+`;
+
+const ArrowLeft = styled(ArrowBase)`
+  top: auto;
+  right: auto;
+  bottom: 50%;
+  left: 0;
+  margin-top: auto;
+  margin-right: auto;
+  margin-bottom: -5px;
+  margin-left: -5px;
+  border-width: 5px 0 5px 5px;
+`;
+
+const ArrowBottom = styled(ArrowBase)`
+  top: auto;
+  right: auto;
+  bottom: 0;
+  left: 50%;
+  margin-top: auto;
+  margin-right: auto;
+  margin-bottom: -5px;
+  margin-left: -5px;
+  border-width: 0 5px 5px 5px;
+`;
+
+const Arrow = {
+  bottom: ArrowBottom,
+  left: ArrowLeft,
+  right: ArrowRight,
+  top: ArrowTop
+};
+
+const TooltipContainerBase = styled.div<{ multiline?: boolean }>`
+  z-index: 1020;
+  position: absolute;
+  padding: 0.5rem 1rem;
+  overflow: hidden;
+  hyphens: auto;
+  text-overflow: ${({ multiline }) => (multiline ? "clip" : "ellipsis")};
+  white-space: ${({ multiline }) => (multiline ? "normal" : "pre")};
+  max-width: ${({ multiline }) => (multiline ? "15rem" : "auto")};
+  width: ${({ multiline }) => (multiline ? "15rem" : "auto")};
+  word-break: ${({ multiline }) => (multiline ? "keep-all" : "unset")};
+`;
+
+const TooltipContainerTop = styled(TooltipContainerBase)`
+  left: 50%;
+  bottom: calc(100% + 5px);
+  transform: translateX(-50%);
+`;
+
+const TooltipContainerBottom = styled(TooltipContainerBase)`
+  left: 50%;
+  top: calc(100% + 5px);
+  transform: translateX(-50%);
+`;
+
+const TooltipContainerLeft = styled(TooltipContainerBase)`
+  right: calc(100% + 5px);
+  top: 50%;
+  transform: translateY(-50%);
+`;
+
+const TooltipContainerRight = styled(TooltipContainerBase)`
+  left: calc(100% + 5px);
+  top: 50%;
+  transform: translateY(-50%);
+`;
+
+const Container = {
+  bottom: TooltipContainerBottom,
+  left: TooltipContainerLeft,
+  right: TooltipContainerRight,
+  top: TooltipContainerTop
+};
 
 type Props = {
   message: string;
   className?: string;
-  location: TooltipLocation;
+  location?: TooltipLocation;
   multiline?: boolean;
   children: ReactNode;
   id?: string;
@@ -34,27 +150,53 @@ type Props = {
 
 export type TooltipLocation = "bottom" | "right" | "top" | "left";
 
-class Tooltip extends React.Component<Props> {
-  static defaultProps = {
-    location: "right"
-  };
+const Tooltip: FC<Props> = ({ className, message, location = "right", multiline, children, id }) => {
+  const [open, setOpen] = useState(false);
 
-  render() {
-    const { className, message, location, multiline, children, id } = this.props;
-    let classes = `tooltip has-tooltip-${location}`;
-    if (multiline) {
-      classes += " has-tooltip-multiline";
-    }
-    if (className) {
-      classes += " " + className;
-    }
+  useEffect(() => {
+    const listener = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+    window.addEventListener("keydown", listener);
+    return () => window.removeEventListener("keydown", listener);
+  });
 
-    return (
-      <span className={classes} data-tooltip={message} aria-label={message} id={id}>
-        {children}
-      </span>
-    );
-  }
-}
+  const LocationContainer = Container[location];
+  const LocationArrow = Arrow[location];
+
+  return (
+    <TooltipWrapper
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+      onClick={() => setOpen(false)}
+    >
+      {open ? (
+        <>
+          <LocationArrow className={`tooltip-arrow-${location}`} />
+          <LocationContainer
+            className={classNames(
+              className,
+              "is-size-7",
+              "is-family-primary",
+              "has-rounded-border",
+              "has-text-white",
+              "has-background-grey-dark",
+              "has-text-weight-semibold"
+            )}
+            multiline={multiline}
+            aria-live="polite"
+            id={id}
+            role="tooltip"
+          >
+            {message}
+          </LocationContainer>
+        </>
+      ) : null}
+      {children}
+    </TooltipWrapper>
+  );
+};
 
 export default Tooltip;

--- a/scm-ui/ui-components/src/Tooltip.tsx
+++ b/scm-ui/ui-components/src/Tooltip.tsx
@@ -161,7 +161,7 @@ const Tooltip: FC<Props> = ({ className, message, location = "right", multiline,
     };
     window.addEventListener("keydown", listener);
     return () => window.removeEventListener("keydown", listener);
-  });
+  }, []);
 
   const LocationContainer = Container[location];
   const LocationArrow = Arrow[location];
@@ -174,7 +174,7 @@ const Tooltip: FC<Props> = ({ className, message, location = "right", multiline,
     >
       {open ? (
         <>
-          <LocationArrow className={`tooltip-arrow-${location}`} />
+          <LocationArrow className={`tooltip-arrow-${location}-border-color`} />
           <LocationContainer
             className={classNames(
               className,

--- a/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
+++ b/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
@@ -144,9 +144,10 @@ exports[`Storyshots BreadCrumb Default 1`] = `
         tabIndex={0}
       >
         <span
-          aria-label="breadcrumb.copyPermalink"
-          className="tooltip has-tooltip-right"
-          data-tooltip="breadcrumb.copyPermalink"
+          className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
         >
           <i
             aria-label="breadcrumb.copyPermalink"
@@ -303,9 +304,10 @@ exports[`Storyshots BreadCrumb Long path 1`] = `
         tabIndex={0}
       >
         <span
-          aria-label="breadcrumb.copyPermalink"
-          className="tooltip has-tooltip-right"
-          data-tooltip="breadcrumb.copyPermalink"
+          className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
         >
           <i
             aria-label="breadcrumb.copyPermalink"
@@ -393,9 +395,10 @@ exports[`Storyshots BreadCrumb Not clickable 1`] = `
         tabIndex={0}
       >
         <span
-          aria-label="breadcrumb.copyPermalink"
-          className="tooltip has-tooltip-right"
-          data-tooltip="breadcrumb.copyPermalink"
+          className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
         >
           <i
             aria-label="breadcrumb.copyPermalink"
@@ -515,9 +518,10 @@ exports[`Storyshots BreadCrumb With prefix button 1`] = `
         tabIndex={0}
       >
         <span
-          aria-label="breadcrumb.copyPermalink"
-          className="tooltip has-tooltip-right"
-          data-tooltip="breadcrumb.copyPermalink"
+          className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
         >
           <i
             aria-label="breadcrumb.copyPermalink"
@@ -2460,10 +2464,10 @@ exports[`Storyshots Forms/Checkbox With HelpText 1`] = `
          
         Classic helpText
         <span
-          aria-label="This is a classic help text."
-          className="tooltip has-tooltip-right Help__AbsolutePositionTooltip-ykmmew-0 fpvHMo is-inline-block pl-1 has-tooltip-multiline"
-          data-tooltip="This is a classic help text."
-          id="checkbox_19"
+          className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
         >
           <i
             aria-label=""
@@ -2495,10 +2499,10 @@ exports[`Storyshots Forms/Checkbox With HelpText 1`] = `
          
         Long helpText
         <span
-          aria-label="Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
-          className="tooltip has-tooltip-right Help__AbsolutePositionTooltip-ykmmew-0 fpvHMo is-inline-block pl-1 has-tooltip-multiline"
-          data-tooltip="Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
-          id="checkbox_21"
+          className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
         >
           <i
             aria-label=""
@@ -2637,9 +2641,10 @@ exports[`Storyshots Forms/FileInput Default 1`] = `
         </span>
          
         <span
-          aria-label="Select your most loved file"
-          className="tooltip has-tooltip-right Help__AbsolutePositionTooltip-ykmmew-0 fpvHMo is-inline-block pl-1 has-tooltip-multiline"
-          data-tooltip="Select your most loved file"
+          className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
         >
           <i
             aria-label=""
@@ -3345,10 +3350,10 @@ exports[`Storyshots Forms/Radio With HelpText 1`] = `
         Classic helpText
       </span>
       <span
-        aria-label="This is a classic help text."
-        className="tooltip has-tooltip-right Help__AbsolutePositionTooltip-ykmmew-0 fpvHMo is-inline-block pl-1 has-tooltip-multiline"
-        data-tooltip="This is a classic help text."
-        id="radio_62"
+        className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
       >
         <i
           aria-label=""
@@ -3379,10 +3384,10 @@ exports[`Storyshots Forms/Radio With HelpText 1`] = `
         Long helpText
       </span>
       <span
-        aria-label="Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
-        className="tooltip has-tooltip-right Help__AbsolutePositionTooltip-ykmmew-0 fpvHMo is-inline-block pl-1 has-tooltip-multiline"
-        data-tooltip="Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
-        id="radio_64"
+        className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
       >
         <i
           aria-label=""
@@ -4268,9 +4273,10 @@ exports[`Storyshots Help Default 1`] = `
   className="m-6"
 >
   <span
-    aria-label="This is a help message"
-    className="tooltip has-tooltip-right Help__AbsolutePositionTooltip-ykmmew-0 fpvHMo is-inline-block pl-1 has-tooltip-multiline"
-    data-tooltip="This is a help message"
+    className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <i
       aria-label=""
@@ -4292,15 +4298,10 @@ exports[`Storyshots Help Multiline 1`] = `
       With multiline (default):
     </label>
     <span
-      aria-label="Cleverness nuclear genuine static irresponsibility invited President Zaphod
-Beeblebrox hyperspace ship. Another custard through computer-generated universe
-shapes field strong disaster parties Russell’s ancestors infinite colour
-imaginative generator sweep."
-      className="tooltip has-tooltip-right Help__AbsolutePositionTooltip-ykmmew-0 fpvHMo is-inline-block pl-1 has-tooltip-multiline"
-      data-tooltip="Cleverness nuclear genuine static irresponsibility invited President Zaphod
-Beeblebrox hyperspace ship. Another custard through computer-generated universe
-shapes field strong disaster parties Russell’s ancestors infinite colour
-imaginative generator sweep."
+      className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <i
         aria-label=""
@@ -4316,15 +4317,10 @@ imaginative generator sweep."
       Without multiline:
     </label>
     <span
-      aria-label="Cleverness nuclear genuine static irresponsibility invited President Zaphod
-Beeblebrox hyperspace ship. Another custard through computer-generated universe
-shapes field strong disaster parties Russell’s ancestors infinite colour
-imaginative generator sweep."
-      className="tooltip has-tooltip-right Help__AbsolutePositionTooltip-ykmmew-0 fpvHMo is-inline-block pl-1"
-      data-tooltip="Cleverness nuclear genuine static irresponsibility invited President Zaphod
-Beeblebrox hyperspace ship. Another custard through computer-generated universe
-shapes field strong disaster parties Russell’s ancestors infinite colour
-imaginative generator sweep."
+      className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <i
         aria-label=""
@@ -4672,9 +4668,10 @@ exports[`Storyshots MarkdownView Code without Lang 1`] = `
               id="line-1"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -5821,9 +5818,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-1"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -5864,9 +5862,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-2"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -5893,9 +5892,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-3"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -5956,9 +5956,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-4"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -6004,9 +6005,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-5"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -6052,9 +6054,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-6"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -6100,9 +6103,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-7"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -6129,9 +6133,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-8"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -6293,9 +6298,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-9"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -6486,9 +6492,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-10"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -6534,9 +6541,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-11"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -6563,9 +6571,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-12"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -6661,9 +6670,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-13"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -6764,9 +6774,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-14"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -6877,9 +6888,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-15"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -7075,9 +7087,10 @@ exports[`Storyshots MarkdownView Header Anchor Links 1`] = `
         >
           Changelog
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -7126,9 +7139,10 @@ and this project adheres to
         >
           Compl_icated_H€aDer
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -7157,9 +7171,10 @@ and this project adheres to
           </a>
            - 2021-03-26
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -7181,9 +7196,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -7315,9 +7331,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -7423,9 +7440,10 @@ and this project adheres to
         >
           Changed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -7499,9 +7517,10 @@ and this project adheres to
           </a>
            - 2021-03-17
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -7523,9 +7542,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -7675,9 +7695,10 @@ and this project adheres to
           </a>
            - 2021-03-12
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -7699,9 +7720,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -7794,9 +7816,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -7870,9 +7893,10 @@ and this project adheres to
           </a>
            - 2021-03-03
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -7894,9 +7918,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -8001,9 +8026,10 @@ and this project adheres to
           </a>
            - 2021-03-01
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -8025,9 +8051,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -8159,9 +8186,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -8280,9 +8308,10 @@ and this project adheres to
         >
           Changed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -8395,9 +8424,10 @@ and this project adheres to
           </a>
            - 2021-01-29
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -8419,9 +8449,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -8579,9 +8610,10 @@ and this project adheres to
         >
           Changed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -8705,9 +8737,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -8781,9 +8814,10 @@ and this project adheres to
           </a>
            - 2020-12-17
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -8805,9 +8839,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -8874,9 +8909,10 @@ and this project adheres to
         >
           Changed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -8917,9 +8953,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -9027,9 +9064,10 @@ and this project adheres to
           </a>
            - 2020-12-07
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -9051,9 +9089,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -9109,9 +9148,10 @@ and this project adheres to
           </a>
            - 2020-12-04
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -9133,9 +9173,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -9275,9 +9316,10 @@ and this project adheres to
         >
           Changed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -9318,9 +9360,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -9393,9 +9436,10 @@ and this project adheres to
           </a>
            - 2020-11-24
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -9417,9 +9461,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -9480,9 +9525,10 @@ and this project adheres to
           </a>
            - 2020-11-20
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -9504,9 +9550,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -9599,9 +9646,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -9687,9 +9735,10 @@ and this project adheres to
           </a>
            - 2020-11-11
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -9711,9 +9760,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -9753,9 +9803,10 @@ and this project adheres to
           </a>
            - 2020-11-06
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -9777,9 +9828,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -9863,9 +9915,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -9991,9 +10044,10 @@ and this project adheres to
           </a>
            - 2020-10-27
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -10015,9 +10069,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -10084,9 +10139,10 @@ and this project adheres to
         >
           Changed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -10140,9 +10196,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -10216,9 +10273,10 @@ and this project adheres to
           </a>
            - 2020-10-16
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -10240,9 +10298,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -10290,9 +10349,10 @@ and this project adheres to
           </a>
            - 2020-10-14
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -10314,9 +10374,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -10370,9 +10431,10 @@ and this project adheres to
         >
           Changed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -10420,9 +10482,10 @@ and this project adheres to
           </a>
            - 2020-10-12
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -10444,9 +10507,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -10494,9 +10558,10 @@ and this project adheres to
           </a>
            - 2020-10-09
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -10518,9 +10583,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -10561,9 +10627,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -10637,9 +10704,10 @@ and this project adheres to
           </a>
            - 2020-09-30
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -10661,9 +10729,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -10711,9 +10780,10 @@ and this project adheres to
           </a>
            - 2020-09-25
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -10735,9 +10805,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -10817,9 +10888,10 @@ and this project adheres to
         >
           Changed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -10860,9 +10932,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -11014,9 +11087,10 @@ and this project adheres to
           </a>
            - 2020-09-10
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -11038,9 +11112,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -11133,9 +11208,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -11214,9 +11290,10 @@ and this project adheres to
           </a>
            - 2020-09-01
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -11238,9 +11315,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -11281,9 +11359,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -11461,9 +11540,10 @@ and this project adheres to
           </a>
            - 2020-08-14
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -11485,9 +11565,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -11606,9 +11687,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -11695,9 +11777,10 @@ and this project adheres to
           </a>
            - 2020-08-04
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -11719,9 +11802,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -11762,9 +11846,10 @@ and this project adheres to
         >
           Changed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -11805,9 +11890,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -11868,9 +11954,10 @@ and this project adheres to
           </a>
            - 2020-07-23
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -11892,9 +11979,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -11961,9 +12049,10 @@ and this project adheres to
         >
           Changed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -12022,9 +12111,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -12150,9 +12240,10 @@ and this project adheres to
           </a>
            - 2020-07-03
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -12174,9 +12265,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -12252,9 +12344,10 @@ and this project adheres to
         >
           Changed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -12329,9 +12422,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -12485,9 +12579,10 @@ and this project adheres to
           </a>
            - 2020-06-23
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -12509,9 +12604,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -12593,9 +12689,10 @@ and this project adheres to
           </a>
            - 2020-06-18
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -12617,9 +12714,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -12712,9 +12810,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -12942,9 +13041,10 @@ and this project adheres to
           </a>
            - 2020-06-04
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -12966,9 +13066,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -13048,9 +13149,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -13124,9 +13226,10 @@ and this project adheres to
           </a>
            - 2020-05-08
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -13148,9 +13251,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -13234,9 +13338,10 @@ and this project adheres to
         >
           Changed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -13341,9 +13446,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -13451,9 +13557,10 @@ and this project adheres to
           </a>
            - 2020-04-09
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -13475,9 +13582,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -13531,9 +13639,10 @@ and this project adheres to
         >
           Changed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -13587,9 +13696,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -13650,9 +13760,10 @@ and this project adheres to
           </a>
            - 2020-03-26
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -13674,9 +13785,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -13782,9 +13894,10 @@ and this project adheres to
         >
           Changed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -13840,9 +13953,10 @@ and this project adheres to
         >
           Removed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -13888,9 +14002,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -13980,9 +14095,10 @@ and this project adheres to
           </a>
            - 2020-03-12
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -14004,9 +14120,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -14064,9 +14181,10 @@ and this project adheres to
         >
           Changed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -14114,9 +14232,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -14164,9 +14283,10 @@ and this project adheres to
         >
           Removed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -14211,9 +14331,10 @@ and this project adheres to
           </a>
            - 2020-02-14
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -14235,9 +14356,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -14280,9 +14402,10 @@ and this project adheres to
         >
           Changed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -14359,9 +14482,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -14407,9 +14531,10 @@ and this project adheres to
           </a>
            - 2020-01-31
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -14431,9 +14556,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -14478,9 +14604,10 @@ and this project adheres to
           </a>
            - 2020-01-29
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -14502,9 +14629,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -14562,9 +14690,10 @@ and this project adheres to
         >
           Changed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -14602,9 +14731,10 @@ and this project adheres to
         >
           Fixed
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -14674,9 +14804,10 @@ and this project adheres to
           </a>
            - 2019-12-02
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -14698,9 +14829,10 @@ and this project adheres to
         >
           Added
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -14895,9 +15027,10 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
               id="line-1"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -14928,9 +15061,10 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
               id="line-2"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -14957,9 +15091,10 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
               id="line-3"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -14986,9 +15121,10 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
               id="line-4"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -15015,9 +15151,10 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
               id="line-5"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -15044,9 +15181,10 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
               id="line-6"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -15073,9 +15211,10 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
               id="line-7"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -15102,9 +15241,10 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
               id="line-8"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -15131,9 +15271,10 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
               id="line-9"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -15160,9 +15301,10 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
               id="line-10"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -15189,9 +15331,10 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
               id="line-11"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -16459,9 +16602,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-1"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -16502,9 +16646,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-2"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -16531,9 +16676,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-3"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -16594,9 +16740,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-4"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -16642,9 +16789,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-5"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -16690,9 +16838,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-6"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -16738,9 +16887,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-7"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -16767,9 +16917,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-8"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -16931,9 +17082,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-9"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -17124,9 +17276,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-10"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -17172,9 +17325,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-11"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -17201,9 +17355,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-12"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -17299,9 +17454,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-13"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -17402,9 +17558,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-14"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -17515,9 +17672,10 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               id="line-15"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -17818,9 +17976,10 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               id="line-1"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -17901,9 +18060,10 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               id="line-2"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -17930,9 +18090,10 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               id="line-3"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -17959,9 +18120,10 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               id="line-4"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -17988,9 +18150,10 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               id="line-5"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -18056,9 +18219,10 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               id="line-6"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -18124,9 +18288,10 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               id="line-7"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -18153,9 +18318,10 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               id="line-8"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -18182,9 +18348,10 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               id="line-9"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -18211,9 +18378,10 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               id="line-10"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -18279,9 +18447,10 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               id="line-11"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -18382,9 +18551,10 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               id="line-12"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -18485,9 +18655,10 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               id="line-13"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -18553,9 +18724,10 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               id="line-14"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -18621,9 +18793,10 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               id="line-15"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -18724,9 +18897,10 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               id="line-16"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -18827,9 +19001,10 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               id="line-17"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -18895,9 +19070,10 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               id="line-18"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -18963,9 +19139,10 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               id="line-19"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -19031,9 +19208,10 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               id="line-20"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -19060,9 +19238,10 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               id="line-21"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -19089,9 +19268,10 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               id="line-22"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -19118,9 +19298,10 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               id="line-23"
             >
               <span
-                aria-label="sources.content.copyPermalink"
-                className="tooltip has-tooltip-right"
-                data-tooltip="sources.content.copyPermalink"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label="sources.content.copyPermalink"
@@ -19692,10 +19873,10 @@ exports[`Storyshots Modal/Modal With form elements 1`] = `
               One
             </span>
             <span
-              aria-label="The first one"
-              className="tooltip has-tooltip-right Help__AbsolutePositionTooltip-ykmmew-0 fpvHMo is-inline-block pl-1 has-tooltip-multiline"
-              data-tooltip="The first one"
-              id="radio_122"
+              className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+              onClick={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
             >
               <i
                 aria-label=""
@@ -19726,10 +19907,10 @@ exports[`Storyshots Modal/Modal With form elements 1`] = `
               Two
             </span>
             <span
-              aria-label="The second one"
-              className="tooltip has-tooltip-right Help__AbsolutePositionTooltip-ykmmew-0 fpvHMo is-inline-block pl-1 has-tooltip-multiline"
-              data-tooltip="The second one"
-              id="radio_124"
+              className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+              onClick={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
             >
               <i
                 aria-label=""
@@ -20056,16 +20237,10 @@ exports[`Storyshots Modal/Modal With long tooltips 1`] = `
                
               Checkbox
               <span
-                aria-label="Mind-paralyzing change needed improbability vortex machine sorts sought same theory upending job just allows
-    hostess’s really oblong Infinite Improbability thing into the starship against which behavior accordance.with
-    Kakrafoon humanoid undergarment ship powered by GPP-guided bowl of petunias nothing was frequently away incredibly
-    ordinary mob."
-                className="tooltip has-tooltip-right Help__AbsolutePositionTooltip-ykmmew-0 fpvHMo is-inline-block pl-1 has-tooltip-multiline"
-                data-tooltip="Mind-paralyzing change needed improbability vortex machine sorts sought same theory upending job just allows
-    hostess’s really oblong Infinite Improbability thing into the starship against which behavior accordance.with
-    Kakrafoon humanoid undergarment ship powered by GPP-guided bowl of petunias nothing was frequently away incredibly
-    ordinary mob."
-                id="checkbox_130"
+                className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
               >
                 <i
                   aria-label=""
@@ -20102,16 +20277,10 @@ exports[`Storyshots Modal/Modal With long tooltips 1`] = `
               Radio button
             </span>
             <span
-              aria-label="Mind-paralyzing change needed improbability vortex machine sorts sought same theory upending job just allows
-    hostess’s really oblong Infinite Improbability thing into the starship against which behavior accordance.with
-    Kakrafoon humanoid undergarment ship powered by GPP-guided bowl of petunias nothing was frequently away incredibly
-    ordinary mob."
-              className="tooltip has-tooltip-right Help__AbsolutePositionTooltip-ykmmew-0 fpvHMo is-inline-block pl-1 has-tooltip-multiline"
-              data-tooltip="Mind-paralyzing change needed improbability vortex machine sorts sought same theory upending job just allows
-    hostess’s really oblong Infinite Improbability thing into the starship against which behavior accordance.with
-    Kakrafoon humanoid undergarment ship powered by GPP-guided bowl of petunias nothing was frequently away incredibly
-    ordinary mob."
-              id="radio_132"
+              className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+              onClick={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
             >
               <i
                 aria-label=""
@@ -20139,16 +20308,10 @@ exports[`Storyshots Modal/Modal With long tooltips 1`] = `
             </span>
              
             <span
-              aria-label="Mind-paralyzing change needed improbability vortex machine sorts sought same theory upending job just allows
-    hostess’s really oblong Infinite Improbability thing into the starship against which behavior accordance.with
-    Kakrafoon humanoid undergarment ship powered by GPP-guided bowl of petunias nothing was frequently away incredibly
-    ordinary mob."
-              className="tooltip has-tooltip-right Help__AbsolutePositionTooltip-ykmmew-0 fpvHMo is-inline-block pl-1 has-tooltip-multiline"
-              data-tooltip="Mind-paralyzing change needed improbability vortex machine sorts sought same theory upending job just allows
-    hostess’s really oblong Infinite Improbability thing into the starship against which behavior accordance.with
-    Kakrafoon humanoid undergarment ship powered by GPP-guided bowl of petunias nothing was frequently away incredibly
-    ordinary mob."
-              id="input_134"
+              className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+              onClick={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
             >
               <i
                 aria-label=""
@@ -20188,16 +20351,10 @@ exports[`Storyshots Modal/Modal With long tooltips 1`] = `
             </span>
              
             <span
-              aria-label="Mind-paralyzing change needed improbability vortex machine sorts sought same theory upending job just allows
-    hostess’s really oblong Infinite Improbability thing into the starship against which behavior accordance.with
-    Kakrafoon humanoid undergarment ship powered by GPP-guided bowl of petunias nothing was frequently away incredibly
-    ordinary mob."
-              className="tooltip has-tooltip-right Help__AbsolutePositionTooltip-ykmmew-0 fpvHMo is-inline-block pl-1 has-tooltip-multiline"
-              data-tooltip="Mind-paralyzing change needed improbability vortex machine sorts sought same theory upending job just allows
-    hostess’s really oblong Infinite Improbability thing into the starship against which behavior accordance.with
-    Kakrafoon humanoid undergarment ship powered by GPP-guided bowl of petunias nothing was frequently away incredibly
-    ordinary mob."
-              id="textarea_136"
+              className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+              onClick={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
             >
               <i
                 aria-label=""
@@ -24382,9 +24539,10 @@ exports[`Storyshots Repositories/Diff Binaries 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -24401,9 +24559,10 @@ exports[`Storyshots Repositories/Diff Binaries 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -24682,9 +24841,10 @@ exports[`Storyshots Repositories/Diff Changing Content 1`] = `
                   className="control"
                 >
                   <span
-                    aria-label="diff.sideBySide"
-                    className="tooltip has-tooltip-top"
-                    data-tooltip="diff.sideBySide"
+                    className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
                     <button
                       aria-label="diff.sideBySide"
@@ -24701,9 +24861,10 @@ exports[`Storyshots Repositories/Diff Changing Content 1`] = `
                   className="control"
                 >
                   <span
-                    aria-label="diff.fullscreen.open"
-                    className="tooltip has-tooltip-top"
-                    data-tooltip="diff.fullscreen.open"
+                    className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
                     <button
                       aria-label="diff.fullscreen.open"
@@ -25305,9 +25466,10 @@ exports[`Storyshots Repositories/Diff Changing Content 1`] = `
                   className="control"
                 >
                   <span
-                    aria-label="diff.sideBySide"
-                    className="tooltip has-tooltip-top"
-                    data-tooltip="diff.sideBySide"
+                    className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
                     <button
                       aria-label="diff.sideBySide"
@@ -25324,9 +25486,10 @@ exports[`Storyshots Repositories/Diff Changing Content 1`] = `
                   className="control"
                 >
                   <span
-                    aria-label="diff.fullscreen.open"
-                    className="tooltip has-tooltip-top"
-                    data-tooltip="diff.fullscreen.open"
+                    className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
                     <button
                       aria-label="diff.fullscreen.open"
@@ -26265,9 +26428,10 @@ exports[`Storyshots Repositories/Diff Changing Content 1`] = `
                   className="control"
                 >
                   <span
-                    aria-label="diff.sideBySide"
-                    className="tooltip has-tooltip-top"
-                    data-tooltip="diff.sideBySide"
+                    className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
                     <button
                       aria-label="diff.sideBySide"
@@ -26284,9 +26448,10 @@ exports[`Storyshots Repositories/Diff Changing Content 1`] = `
                   className="control"
                 >
                   <span
-                    aria-label="diff.fullscreen.open"
-                    className="tooltip has-tooltip-top"
-                    data-tooltip="diff.fullscreen.open"
+                    className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
                     <button
                       aria-label="diff.fullscreen.open"
@@ -26796,9 +26961,10 @@ exports[`Storyshots Repositories/Diff Changing Content 1`] = `
                   className="control"
                 >
                   <span
-                    aria-label="diff.sideBySide"
-                    className="tooltip has-tooltip-top"
-                    data-tooltip="diff.sideBySide"
+                    className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
                     <button
                       aria-label="diff.sideBySide"
@@ -26815,9 +26981,10 @@ exports[`Storyshots Repositories/Diff Changing Content 1`] = `
                   className="control"
                 >
                   <span
-                    aria-label="diff.fullscreen.open"
-                    className="tooltip has-tooltip-top"
-                    data-tooltip="diff.fullscreen.open"
+                    className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
                     <button
                       aria-label="diff.fullscreen.open"
@@ -27327,9 +27494,10 @@ exports[`Storyshots Repositories/Diff Changing Content 1`] = `
                   className="control"
                 >
                   <span
-                    aria-label="diff.sideBySide"
-                    className="tooltip has-tooltip-top"
-                    data-tooltip="diff.sideBySide"
+                    className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
                     <button
                       aria-label="diff.sideBySide"
@@ -27346,9 +27514,10 @@ exports[`Storyshots Repositories/Diff Changing Content 1`] = `
                   className="control"
                 >
                   <span
-                    aria-label="diff.fullscreen.open"
-                    className="tooltip has-tooltip-top"
-                    data-tooltip="diff.fullscreen.open"
+                    className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
                     <button
                       aria-label="diff.fullscreen.open"
@@ -28548,9 +28717,10 @@ exports[`Storyshots Repositories/Diff Changing Content 1`] = `
                   className="control"
                 >
                   <span
-                    aria-label="diff.sideBySide"
-                    className="tooltip has-tooltip-top"
-                    data-tooltip="diff.sideBySide"
+                    className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
                     <button
                       aria-label="diff.sideBySide"
@@ -28567,9 +28737,10 @@ exports[`Storyshots Repositories/Diff Changing Content 1`] = `
                   className="control"
                 >
                   <span
-                    aria-label="diff.fullscreen.open"
-                    className="tooltip has-tooltip-top"
-                    data-tooltip="diff.fullscreen.open"
+                    className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
                     <button
                       aria-label="diff.fullscreen.open"
@@ -29129,9 +29300,10 @@ exports[`Storyshots Repositories/Diff Collapsed 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -29148,9 +29320,10 @@ exports[`Storyshots Repositories/Diff Collapsed 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -29167,9 +29340,10 @@ exports[`Storyshots Repositories/Diff Collapsed 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="Jump to source"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="Jump to source"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <a
                     aria-label="Jump to source"
@@ -29189,9 +29363,10 @@ exports[`Storyshots Repositories/Diff Collapsed 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="Jump to target"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="Jump to target"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <a
                     aria-label="Jump to target"
@@ -29253,9 +29428,10 @@ exports[`Storyshots Repositories/Diff Collapsed 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -29272,9 +29448,10 @@ exports[`Storyshots Repositories/Diff Collapsed 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -29291,9 +29468,10 @@ exports[`Storyshots Repositories/Diff Collapsed 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="Jump to source"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="Jump to source"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <a
                     aria-label="Jump to source"
@@ -29313,9 +29491,10 @@ exports[`Storyshots Repositories/Diff Collapsed 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="Jump to target"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="Jump to target"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <a
                     aria-label="Jump to target"
@@ -29377,9 +29556,10 @@ exports[`Storyshots Repositories/Diff Collapsed 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -29396,9 +29576,10 @@ exports[`Storyshots Repositories/Diff Collapsed 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -29415,9 +29596,10 @@ exports[`Storyshots Repositories/Diff Collapsed 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="Jump to source"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="Jump to source"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <a
                     aria-label="Jump to source"
@@ -29437,9 +29619,10 @@ exports[`Storyshots Repositories/Diff Collapsed 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="Jump to target"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="Jump to target"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <a
                     aria-label="Jump to target"
@@ -29501,9 +29684,10 @@ exports[`Storyshots Repositories/Diff Collapsed 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -29520,9 +29704,10 @@ exports[`Storyshots Repositories/Diff Collapsed 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -29539,9 +29724,10 @@ exports[`Storyshots Repositories/Diff Collapsed 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="Jump to source"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="Jump to source"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <a
                     aria-label="Jump to source"
@@ -29561,9 +29747,10 @@ exports[`Storyshots Repositories/Diff Collapsed 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="Jump to target"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="Jump to target"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <a
                     aria-label="Jump to target"
@@ -29625,9 +29812,10 @@ exports[`Storyshots Repositories/Diff Collapsed 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -29644,9 +29832,10 @@ exports[`Storyshots Repositories/Diff Collapsed 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -29663,9 +29852,10 @@ exports[`Storyshots Repositories/Diff Collapsed 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="Jump to source"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="Jump to source"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <a
                     aria-label="Jump to source"
@@ -29685,9 +29875,10 @@ exports[`Storyshots Repositories/Diff Collapsed 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="Jump to target"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="Jump to target"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <a
                     aria-label="Jump to target"
@@ -29749,9 +29940,10 @@ exports[`Storyshots Repositories/Diff Collapsed 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -29768,9 +29960,10 @@ exports[`Storyshots Repositories/Diff Collapsed 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -29787,9 +29980,10 @@ exports[`Storyshots Repositories/Diff Collapsed 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="Jump to source"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="Jump to source"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <a
                     aria-label="Jump to source"
@@ -29809,9 +30003,10 @@ exports[`Storyshots Repositories/Diff Collapsed 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="Jump to target"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="Jump to target"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <a
                     aria-label="Jump to target"
@@ -29882,9 +30077,10 @@ exports[`Storyshots Repositories/Diff CollapsingWithFunction 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -29901,9 +30097,10 @@ exports[`Storyshots Repositories/Diff CollapsingWithFunction 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -29962,9 +30159,10 @@ exports[`Storyshots Repositories/Diff CollapsingWithFunction 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -29981,9 +30179,10 @@ exports[`Storyshots Repositories/Diff CollapsingWithFunction 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -30825,9 +31024,10 @@ exports[`Storyshots Repositories/Diff CollapsingWithFunction 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -30844,9 +31044,10 @@ exports[`Storyshots Repositories/Diff CollapsingWithFunction 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -31284,9 +31485,10 @@ exports[`Storyshots Repositories/Diff CollapsingWithFunction 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -31303,9 +31505,10 @@ exports[`Storyshots Repositories/Diff CollapsingWithFunction 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -31743,9 +31946,10 @@ exports[`Storyshots Repositories/Diff CollapsingWithFunction 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -31762,9 +31966,10 @@ exports[`Storyshots Repositories/Diff CollapsingWithFunction 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -31823,9 +32028,10 @@ exports[`Storyshots Repositories/Diff CollapsingWithFunction 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -31842,9 +32048,10 @@ exports[`Storyshots Repositories/Diff CollapsingWithFunction 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -31912,9 +32119,10 @@ exports[`Storyshots Repositories/Diff Default 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -31931,9 +32139,10 @@ exports[`Storyshots Repositories/Diff Default 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -32498,9 +32707,10 @@ exports[`Storyshots Repositories/Diff Default 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -32517,9 +32727,10 @@ exports[`Storyshots Repositories/Diff Default 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -33361,9 +33572,10 @@ exports[`Storyshots Repositories/Diff Default 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -33380,9 +33592,10 @@ exports[`Storyshots Repositories/Diff Default 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -33820,9 +34033,10 @@ exports[`Storyshots Repositories/Diff Default 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -33839,9 +34053,10 @@ exports[`Storyshots Repositories/Diff Default 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -34279,9 +34494,10 @@ exports[`Storyshots Repositories/Diff Default 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -34298,9 +34514,10 @@ exports[`Storyshots Repositories/Diff Default 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -35345,9 +35562,10 @@ exports[`Storyshots Repositories/Diff Default 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -35364,9 +35582,10 @@ exports[`Storyshots Repositories/Diff Default 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -35888,9 +36107,10 @@ exports[`Storyshots Repositories/Diff Expandable 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -35907,9 +36127,10 @@ exports[`Storyshots Repositories/Diff Expandable 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -36511,9 +36732,10 @@ exports[`Storyshots Repositories/Diff Expandable 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -36530,9 +36752,10 @@ exports[`Storyshots Repositories/Diff Expandable 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -37471,9 +37694,10 @@ exports[`Storyshots Repositories/Diff Expandable 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -37490,9 +37714,10 @@ exports[`Storyshots Repositories/Diff Expandable 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -38002,9 +38227,10 @@ exports[`Storyshots Repositories/Diff Expandable 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -38021,9 +38247,10 @@ exports[`Storyshots Repositories/Diff Expandable 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -38533,9 +38760,10 @@ exports[`Storyshots Repositories/Diff Expandable 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -38552,9 +38780,10 @@ exports[`Storyshots Repositories/Diff Expandable 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -39754,9 +39983,10 @@ exports[`Storyshots Repositories/Diff Expandable 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -39773,9 +40003,10 @@ exports[`Storyshots Repositories/Diff Expandable 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -40334,9 +40565,10 @@ exports[`Storyshots Repositories/Diff External state management 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -40353,9 +40585,10 @@ exports[`Storyshots Repositories/Diff External state management 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -40957,9 +41190,10 @@ exports[`Storyshots Repositories/Diff External state management 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -40976,9 +41210,10 @@ exports[`Storyshots Repositories/Diff External state management 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -41917,9 +42152,10 @@ exports[`Storyshots Repositories/Diff External state management 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -41936,9 +42172,10 @@ exports[`Storyshots Repositories/Diff External state management 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -42448,9 +42685,10 @@ exports[`Storyshots Repositories/Diff External state management 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -42467,9 +42705,10 @@ exports[`Storyshots Repositories/Diff External state management 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -42979,9 +43218,10 @@ exports[`Storyshots Repositories/Diff External state management 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -42998,9 +43238,10 @@ exports[`Storyshots Repositories/Diff External state management 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -44200,9 +44441,10 @@ exports[`Storyshots Repositories/Diff External state management 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -44219,9 +44461,10 @@ exports[`Storyshots Repositories/Diff External state management 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -44780,9 +45023,10 @@ exports[`Storyshots Repositories/Diff File Annotation 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -44799,9 +45043,10 @@ exports[`Storyshots Repositories/Diff File Annotation 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -45370,9 +45615,10 @@ exports[`Storyshots Repositories/Diff File Annotation 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -45389,9 +45635,10 @@ exports[`Storyshots Repositories/Diff File Annotation 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -46237,9 +46484,10 @@ exports[`Storyshots Repositories/Diff File Annotation 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -46256,9 +46504,10 @@ exports[`Storyshots Repositories/Diff File Annotation 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -46700,9 +46949,10 @@ exports[`Storyshots Repositories/Diff File Annotation 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -46719,9 +46969,10 @@ exports[`Storyshots Repositories/Diff File Annotation 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -47163,9 +47414,10 @@ exports[`Storyshots Repositories/Diff File Annotation 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -47182,9 +47434,10 @@ exports[`Storyshots Repositories/Diff File Annotation 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -48233,9 +48486,10 @@ exports[`Storyshots Repositories/Diff File Annotation 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -48252,9 +48506,10 @@ exports[`Storyshots Repositories/Diff File Annotation 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -48780,9 +49035,10 @@ exports[`Storyshots Repositories/Diff File Controls 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -48799,9 +49055,10 @@ exports[`Storyshots Repositories/Diff File Controls 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -48818,9 +49075,10 @@ exports[`Storyshots Repositories/Diff File Controls 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="A skull and crossbones or death's head is a symbol consisting of a human skull and two long bones crossed together under or behind the skull. The design originates in the Late Middle Ages as a symbol of death and especially as a memento mori on tombstones."
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="A skull and crossbones or death's head is a symbol consisting of a human skull and two long bones crossed together under or behind the skull. The design originates in the Late Middle Ages as a symbol of death and especially as a memento mori on tombstones."
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="A skull and crossbones or death's head is a symbol consisting of a human skull and two long bones crossed together under or behind the skull. The design originates in the Late Middle Ages as a symbol of death and especially as a memento mori on tombstones."
@@ -49385,9 +49643,10 @@ exports[`Storyshots Repositories/Diff File Controls 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -49404,9 +49663,10 @@ exports[`Storyshots Repositories/Diff File Controls 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -49423,9 +49683,10 @@ exports[`Storyshots Repositories/Diff File Controls 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="A skull and crossbones or death's head is a symbol consisting of a human skull and two long bones crossed together under or behind the skull. The design originates in the Late Middle Ages as a symbol of death and especially as a memento mori on tombstones."
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="A skull and crossbones or death's head is a symbol consisting of a human skull and two long bones crossed together under or behind the skull. The design originates in the Late Middle Ages as a symbol of death and especially as a memento mori on tombstones."
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="A skull and crossbones or death's head is a symbol consisting of a human skull and two long bones crossed together under or behind the skull. The design originates in the Late Middle Ages as a symbol of death and especially as a memento mori on tombstones."
@@ -50267,9 +50528,10 @@ exports[`Storyshots Repositories/Diff File Controls 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -50286,9 +50548,10 @@ exports[`Storyshots Repositories/Diff File Controls 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -50305,9 +50568,10 @@ exports[`Storyshots Repositories/Diff File Controls 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="A skull and crossbones or death's head is a symbol consisting of a human skull and two long bones crossed together under or behind the skull. The design originates in the Late Middle Ages as a symbol of death and especially as a memento mori on tombstones."
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="A skull and crossbones or death's head is a symbol consisting of a human skull and two long bones crossed together under or behind the skull. The design originates in the Late Middle Ages as a symbol of death and especially as a memento mori on tombstones."
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="A skull and crossbones or death's head is a symbol consisting of a human skull and two long bones crossed together under or behind the skull. The design originates in the Late Middle Ages as a symbol of death and especially as a memento mori on tombstones."
@@ -50745,9 +51009,10 @@ exports[`Storyshots Repositories/Diff File Controls 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -50764,9 +51029,10 @@ exports[`Storyshots Repositories/Diff File Controls 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -50783,9 +51049,10 @@ exports[`Storyshots Repositories/Diff File Controls 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="A skull and crossbones or death's head is a symbol consisting of a human skull and two long bones crossed together under or behind the skull. The design originates in the Late Middle Ages as a symbol of death and especially as a memento mori on tombstones."
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="A skull and crossbones or death's head is a symbol consisting of a human skull and two long bones crossed together under or behind the skull. The design originates in the Late Middle Ages as a symbol of death and especially as a memento mori on tombstones."
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="A skull and crossbones or death's head is a symbol consisting of a human skull and two long bones crossed together under or behind the skull. The design originates in the Late Middle Ages as a symbol of death and especially as a memento mori on tombstones."
@@ -51223,9 +51490,10 @@ exports[`Storyshots Repositories/Diff File Controls 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -51242,9 +51510,10 @@ exports[`Storyshots Repositories/Diff File Controls 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -51261,9 +51530,10 @@ exports[`Storyshots Repositories/Diff File Controls 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="A skull and crossbones or death's head is a symbol consisting of a human skull and two long bones crossed together under or behind the skull. The design originates in the Late Middle Ages as a symbol of death and especially as a memento mori on tombstones."
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="A skull and crossbones or death's head is a symbol consisting of a human skull and two long bones crossed together under or behind the skull. The design originates in the Late Middle Ages as a symbol of death and especially as a memento mori on tombstones."
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="A skull and crossbones or death's head is a symbol consisting of a human skull and two long bones crossed together under or behind the skull. The design originates in the Late Middle Ages as a symbol of death and especially as a memento mori on tombstones."
@@ -52308,9 +52578,10 @@ exports[`Storyshots Repositories/Diff File Controls 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -52327,9 +52598,10 @@ exports[`Storyshots Repositories/Diff File Controls 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -52346,9 +52618,10 @@ exports[`Storyshots Repositories/Diff File Controls 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="A skull and crossbones or death's head is a symbol consisting of a human skull and two long bones crossed together under or behind the skull. The design originates in the Late Middle Ages as a symbol of death and especially as a memento mori on tombstones."
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="A skull and crossbones or death's head is a symbol consisting of a human skull and two long bones crossed together under or behind the skull. The design originates in the Late Middle Ages as a symbol of death and especially as a memento mori on tombstones."
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="A skull and crossbones or death's head is a symbol consisting of a human skull and two long bones crossed together under or behind the skull. The design originates in the Late Middle Ages as a symbol of death and especially as a memento mori on tombstones."
@@ -52870,9 +53143,10 @@ exports[`Storyshots Repositories/Diff Hunks 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -52889,9 +53163,10 @@ exports[`Storyshots Repositories/Diff Hunks 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -53720,9 +53995,10 @@ exports[`Storyshots Repositories/Diff Line Annotation 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -53739,9 +54015,10 @@ exports[`Storyshots Repositories/Diff Line Annotation 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -54318,9 +54595,10 @@ exports[`Storyshots Repositories/Diff Line Annotation 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -54337,9 +54615,10 @@ exports[`Storyshots Repositories/Diff Line Annotation 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -55193,9 +55472,10 @@ exports[`Storyshots Repositories/Diff Line Annotation 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -55212,9 +55492,10 @@ exports[`Storyshots Repositories/Diff Line Annotation 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -55652,9 +55933,10 @@ exports[`Storyshots Repositories/Diff Line Annotation 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -55671,9 +55953,10 @@ exports[`Storyshots Repositories/Diff Line Annotation 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -56111,9 +56394,10 @@ exports[`Storyshots Repositories/Diff Line Annotation 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -56130,9 +56414,10 @@ exports[`Storyshots Repositories/Diff Line Annotation 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -57177,9 +57462,10 @@ exports[`Storyshots Repositories/Diff Line Annotation 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -57196,9 +57482,10 @@ exports[`Storyshots Repositories/Diff Line Annotation 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -57732,9 +58019,10 @@ exports[`Storyshots Repositories/Diff OnClick 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -57751,9 +58039,10 @@ exports[`Storyshots Repositories/Diff OnClick 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -58358,9 +58647,10 @@ exports[`Storyshots Repositories/Diff OnClick 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -58377,9 +58667,10 @@ exports[`Storyshots Repositories/Diff OnClick 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -59283,9 +59574,10 @@ exports[`Storyshots Repositories/Diff OnClick 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -59302,9 +59594,10 @@ exports[`Storyshots Repositories/Diff OnClick 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -59772,9 +60065,10 @@ exports[`Storyshots Repositories/Diff OnClick 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -59791,9 +60085,10 @@ exports[`Storyshots Repositories/Diff OnClick 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -60261,9 +60556,10 @@ exports[`Storyshots Repositories/Diff OnClick 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -60280,9 +60576,10 @@ exports[`Storyshots Repositories/Diff OnClick 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -61403,9 +61700,10 @@ exports[`Storyshots Repositories/Diff OnClick 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -61422,9 +61720,10 @@ exports[`Storyshots Repositories/Diff OnClick 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -61982,9 +62281,10 @@ exports[`Storyshots Repositories/Diff Side-By-Side 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.combined"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.combined"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.combined"
@@ -62001,9 +62301,10 @@ exports[`Storyshots Repositories/Diff Side-By-Side 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -62661,9 +62962,10 @@ exports[`Storyshots Repositories/Diff Side-By-Side 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.combined"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.combined"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.combined"
@@ -62680,9 +62982,10 @@ exports[`Storyshots Repositories/Diff Side-By-Side 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -63614,9 +63917,10 @@ exports[`Storyshots Repositories/Diff Side-By-Side 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.combined"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.combined"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.combined"
@@ -63633,9 +63937,10 @@ exports[`Storyshots Repositories/Diff Side-By-Side 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -64125,9 +64430,10 @@ exports[`Storyshots Repositories/Diff Side-By-Side 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.combined"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.combined"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.combined"
@@ -64144,9 +64450,10 @@ exports[`Storyshots Repositories/Diff Side-By-Side 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -64636,9 +64943,10 @@ exports[`Storyshots Repositories/Diff Side-By-Side 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.combined"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.combined"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.combined"
@@ -64655,9 +64963,10 @@ exports[`Storyshots Repositories/Diff Side-By-Side 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -65871,9 +66180,10 @@ exports[`Storyshots Repositories/Diff Side-By-Side 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.combined"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.combined"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.combined"
@@ -65890,9 +66200,10 @@ exports[`Storyshots Repositories/Diff Side-By-Side 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -66487,9 +66798,10 @@ exports[`Storyshots Repositories/Diff SyntaxHighlighting (Markdown) 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -66506,9 +66818,10 @@ exports[`Storyshots Repositories/Diff SyntaxHighlighting (Markdown) 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -66855,9 +67168,10 @@ exports[`Storyshots Repositories/Diff SyntaxHighlighting 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -66874,9 +67188,10 @@ exports[`Storyshots Repositories/Diff SyntaxHighlighting 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -67441,9 +67756,10 @@ exports[`Storyshots Repositories/Diff SyntaxHighlighting 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -67460,9 +67776,10 @@ exports[`Storyshots Repositories/Diff SyntaxHighlighting 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -68304,9 +68621,10 @@ exports[`Storyshots Repositories/Diff SyntaxHighlighting 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -68323,9 +68641,10 @@ exports[`Storyshots Repositories/Diff SyntaxHighlighting 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -68763,9 +69082,10 @@ exports[`Storyshots Repositories/Diff SyntaxHighlighting 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -68782,9 +69102,10 @@ exports[`Storyshots Repositories/Diff SyntaxHighlighting 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -69222,9 +69543,10 @@ exports[`Storyshots Repositories/Diff SyntaxHighlighting 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -69241,9 +69563,10 @@ exports[`Storyshots Repositories/Diff SyntaxHighlighting 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -70288,9 +70611,10 @@ exports[`Storyshots Repositories/Diff SyntaxHighlighting 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -70307,9 +70631,10 @@ exports[`Storyshots Repositories/Diff SyntaxHighlighting 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -70831,9 +71156,10 @@ exports[`Storyshots Repositories/Diff WithLinkToFile 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -70850,9 +71176,10 @@ exports[`Storyshots Repositories/Diff WithLinkToFile 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -71454,9 +71781,10 @@ exports[`Storyshots Repositories/Diff WithLinkToFile 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -71473,9 +71801,10 @@ exports[`Storyshots Repositories/Diff WithLinkToFile 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -72414,9 +72743,10 @@ exports[`Storyshots Repositories/Diff WithLinkToFile 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -72433,9 +72763,10 @@ exports[`Storyshots Repositories/Diff WithLinkToFile 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -72945,9 +73276,10 @@ exports[`Storyshots Repositories/Diff WithLinkToFile 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -72964,9 +73296,10 @@ exports[`Storyshots Repositories/Diff WithLinkToFile 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -73476,9 +73809,10 @@ exports[`Storyshots Repositories/Diff WithLinkToFile 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -73495,9 +73829,10 @@ exports[`Storyshots Repositories/Diff WithLinkToFile 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -74697,9 +75032,10 @@ exports[`Storyshots Repositories/Diff WithLinkToFile 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.sideBySide"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.sideBySide"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.sideBySide"
@@ -74716,9 +75052,10 @@ exports[`Storyshots Repositories/Diff WithLinkToFile 1`] = `
                 className="control"
               >
                 <span
-                  aria-label="diff.fullscreen.open"
-                  className="tooltip has-tooltip-top"
-                  data-tooltip="diff.fullscreen.open"
+                  className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <button
                     aria-label="diff.fullscreen.open"
@@ -75284,9 +75621,10 @@ exports[`Storyshots Repositories/RepositoryEntry Archived 1`] = `
                   className="RepositoryFlags__RepositoryFlagContainer-sc-1swhx1t-0 fDXIgs"
                 >
                   <span
-                    aria-label="archive.tooltip"
-                    className="tooltip has-tooltip-right"
-                    data-tooltip="archive.tooltip"
+                    className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
                     <span
                       className="tag is-light is-small p-1 is-size-7 has-text-weight-bold"
@@ -75735,9 +76073,10 @@ exports[`Storyshots Repositories/RepositoryEntry Exporting 1`] = `
                   className="RepositoryFlags__RepositoryFlagContainer-sc-1swhx1t-0 fDXIgs"
                 >
                   <span
-                    aria-label="exporting.tooltip"
-                    className="tooltip has-tooltip-right"
-                    data-tooltip="exporting.tooltip"
+                    className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
                     <span
                       className="tag is-light is-small p-1 is-size-7 has-text-weight-bold"
@@ -75856,9 +76195,10 @@ exports[`Storyshots Repositories/RepositoryEntry HealthCheck Failure 1`] = `
                   className="RepositoryFlags__RepositoryFlagContainer-sc-1swhx1t-0 fDXIgs"
                 >
                   <span
-                    aria-label="healthCheckFailure.tooltip"
-                    className="tooltip has-tooltip-right"
-                    data-tooltip="healthCheckFailure.tooltip"
+                    className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
                     <span
                       className="tag is-danger is-small is-clickable p-1 is-size-7 has-text-weight-bold"
@@ -75978,9 +76318,10 @@ exports[`Storyshots Repositories/RepositoryEntry MultiRepositoryTags 1`] = `
                   className="RepositoryFlags__RepositoryFlagContainer-sc-1swhx1t-0 fDXIgs"
                 >
                   <span
-                    aria-label="archive.tooltip"
-                    className="tooltip has-tooltip-right"
-                    data-tooltip="archive.tooltip"
+                    className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
                     <span
                       className="tag is-light is-small p-1 is-size-7 has-text-weight-bold"
@@ -75989,9 +76330,10 @@ exports[`Storyshots Repositories/RepositoryEntry MultiRepositoryTags 1`] = `
                     </span>
                   </span>
                   <span
-                    aria-label="exporting.tooltip"
-                    className="tooltip has-tooltip-right"
-                    data-tooltip="exporting.tooltip"
+                    className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
                     <span
                       className="tag is-light is-small p-1 is-size-7 has-text-weight-bold"
@@ -76110,9 +76452,10 @@ exports[`Storyshots Repositories/RepositoryEntry RepositoryFlag EP 1`] = `
                   className="RepositoryFlags__RepositoryFlagContainer-sc-1swhx1t-0 fDXIgs"
                 >
                   <span
-                    aria-label="healthCheckFailure.tooltip"
-                    className="tooltip has-tooltip-right"
-                    data-tooltip="healthCheckFailure.tooltip"
+                    className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
                     <span
                       className="tag is-danger is-small is-clickable p-1 is-size-7 has-text-weight-bold"
@@ -76708,9 +77051,10 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           id="line-1"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -76751,9 +77095,10 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           id="line-2"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -76780,9 +77125,10 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           id="line-3"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -76843,9 +77189,10 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           id="line-4"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -76891,9 +77238,10 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           id="line-5"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -76939,9 +77287,10 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           id="line-6"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -76987,9 +77336,10 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           id="line-7"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -77016,9 +77366,10 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           id="line-8"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -77114,9 +77465,10 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           id="line-9"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -77323,9 +77675,10 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           id="line-10"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -77431,9 +77784,10 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           id="line-11"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -77489,9 +77843,10 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           id="line-12"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -77518,9 +77873,10 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           id="line-13"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -77667,9 +78023,10 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           id="line-14"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -77835,9 +78192,10 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           id="line-15"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -77864,9 +78222,10 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           id="line-16"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -77977,9 +78336,10 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           id="line-17"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -78092,9 +78452,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-1"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -78172,9 +78533,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-2"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -78201,9 +78563,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-3"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -78302,9 +78665,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-4"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -78403,9 +78767,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-5"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -78504,9 +78869,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-6"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -78533,9 +78899,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-7"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -78666,9 +79033,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-8"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -78799,9 +79167,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-9"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -78932,9 +79301,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-10"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -78961,9 +79331,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-11"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -79050,9 +79421,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-12"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -79079,9 +79451,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-13"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -79264,9 +79637,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-14"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -79461,9 +79835,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-15"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -79615,9 +79990,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-16"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -79728,9 +80104,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-17"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -79816,9 +80193,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-18"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -79864,9 +80242,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-19"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -79893,9 +80272,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-20"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -80008,9 +80388,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-21"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -80056,9 +80437,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-22"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -80206,9 +80588,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-23"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -80291,9 +80674,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-24"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -80444,9 +80828,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-25"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -80559,9 +80944,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-26"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -80692,9 +81078,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-27"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -80780,9 +81167,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-28"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -80828,9 +81216,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-29"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -80876,9 +81265,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-30"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -80905,9 +81295,10 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           id="line-31"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -81020,9 +81411,10 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
           id="line-1"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -81134,9 +81526,10 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
           id="line-2"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -81163,9 +81556,10 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
           id="line-3"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -81303,9 +81697,10 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
           id="line-4"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -81472,9 +81867,10 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
           id="line-5"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -81570,9 +81966,10 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
           id="line-6"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -81658,9 +82055,10 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
           id="line-7"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -81843,9 +82241,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-1"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -81898,9 +82297,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-2"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -81927,9 +82327,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-3"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -82013,9 +82414,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-4"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -82099,9 +82501,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-5"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -82185,9 +82588,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-6"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -82271,9 +82675,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-7"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -82357,9 +82762,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-8"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -82443,9 +82849,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-9"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -82529,9 +82936,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-10"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -82615,9 +83023,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-11"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -82644,9 +83053,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-12"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -82692,9 +83102,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-13"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -82721,9 +83132,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-14"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -82781,9 +83193,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-15"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -82810,9 +83223,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-16"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -82870,9 +83284,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-17"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -82899,9 +83314,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-18"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -82928,9 +83344,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-19"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -82957,9 +83374,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-20"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83017,9 +83435,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-21"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83046,9 +83465,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-22"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83075,9 +83495,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-23"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83104,9 +83525,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-24"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83164,9 +83586,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-25"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83193,9 +83616,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-26"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83222,9 +83646,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-27"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83251,9 +83676,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-28"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83311,9 +83737,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-29"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83340,9 +83767,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-30"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83369,9 +83797,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-31"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83398,9 +83827,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-32"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83458,9 +83888,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-33"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83487,9 +83918,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-34"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83516,9 +83948,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-35"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83545,9 +83978,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-36"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83605,9 +84039,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-37"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83634,9 +84069,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-38"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83663,9 +84099,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-39"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83692,9 +84129,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-40"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83721,9 +84159,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-41"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83750,9 +84189,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-42"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83779,9 +84219,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-43"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83839,9 +84280,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-44"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83868,9 +84310,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-45"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83897,9 +84340,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-46"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83926,9 +84370,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-47"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83955,9 +84400,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-48"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -83984,9 +84430,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-49"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84013,9 +84460,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-50"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84042,9 +84490,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-51"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84071,9 +84520,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-52"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84100,9 +84550,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-53"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84160,9 +84611,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-54"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84189,9 +84641,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-55"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84218,9 +84671,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-56"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84247,9 +84701,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-57"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84295,9 +84750,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-58"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84324,9 +84780,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-59"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84353,9 +84810,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-60"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84382,9 +84840,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-61"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84430,9 +84889,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-62"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84459,9 +84919,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-63"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84488,9 +84949,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-64"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84517,9 +84979,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-65"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84565,9 +85028,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-66"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84594,9 +85058,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-67"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84623,9 +85088,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-68"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84652,9 +85118,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-69"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84681,9 +85148,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-70"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84710,9 +85178,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-71"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84770,9 +85239,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-72"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84799,9 +85269,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-73"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84859,9 +85330,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-74"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84888,9 +85360,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-75"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84936,9 +85409,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-76"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -84984,9 +85458,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-77"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -85032,9 +85507,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-78"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -85061,9 +85537,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-79"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -85109,9 +85586,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-80"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -85157,9 +85635,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-81"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -85205,9 +85684,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-82"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -85253,9 +85733,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-83"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -85301,9 +85782,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-84"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -85349,9 +85831,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-85"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -85397,9 +85880,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-86"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -85426,9 +85910,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-87"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -85486,9 +85971,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-88"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -85515,9 +86001,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-89"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -85563,9 +86050,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-90"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -85611,9 +86099,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-91"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -85659,9 +86148,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-92"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -85707,9 +86197,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-93"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -85755,9 +86246,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-94"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -85803,9 +86295,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-95"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -85851,9 +86344,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-96"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -85880,9 +86374,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-97"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -85909,9 +86404,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-98"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -85938,9 +86434,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-99"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -85998,9 +86495,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-100"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -86027,9 +86525,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-101"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -86056,9 +86555,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-102"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -86085,9 +86585,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-103"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -86133,9 +86634,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-104"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -86162,9 +86664,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-105"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -86191,9 +86694,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-106"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -86220,9 +86724,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-107"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -86249,9 +86754,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-108"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -86278,9 +86784,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-109"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -86338,9 +86845,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-110"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -86367,9 +86875,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-111"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -86396,9 +86905,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-112"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -86425,9 +86935,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-113"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -86579,9 +87090,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-114"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -86789,9 +87301,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-115"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -86919,9 +87432,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-116"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -87049,9 +87563,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-117"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -87179,9 +87694,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-118"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -87309,9 +87825,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-119"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -87439,9 +87956,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-120"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -87478,9 +87996,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-121"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -87507,9 +88026,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-122"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -87536,9 +88056,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-123"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -87565,9 +88086,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-124"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -87594,9 +88116,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-125"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -87654,9 +88177,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-126"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -87683,9 +88207,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-127"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -87743,9 +88268,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-128"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -87772,9 +88298,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-129"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -87835,9 +88362,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-130"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -87864,9 +88392,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-131"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -87924,9 +88453,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-132"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -87953,9 +88483,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-133"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -87982,9 +88513,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-134"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88011,9 +88543,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-135"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88066,9 +88599,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-136"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88106,9 +88640,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-137"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88135,9 +88670,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-138"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88164,9 +88700,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-139"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88193,9 +88730,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-140"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88222,9 +88760,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-141"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88251,9 +88790,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-142"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88280,9 +88820,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-143"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88309,9 +88850,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-144"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88338,9 +88880,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-145"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88367,9 +88910,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-146"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88396,9 +88940,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-147"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88425,9 +88970,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-148"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88454,9 +89000,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-149"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88483,9 +89030,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-150"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88523,9 +89071,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-151"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88572,9 +89121,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-152"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88601,9 +89151,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-153"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88630,9 +89181,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-154"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88659,9 +89211,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-155"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88688,9 +89241,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-156"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88717,9 +89271,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-157"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88777,9 +89332,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-158"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88806,9 +89362,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-159"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -88988,9 +89545,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-160"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -89017,9 +89575,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-161"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -89088,9 +89647,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-162"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -89117,9 +89677,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-163"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -89240,9 +89801,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-164"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -89269,9 +89831,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-165"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -89340,9 +89903,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-166"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -89369,9 +89933,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-167"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -89556,9 +90121,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-168"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -89585,9 +90151,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-169"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -89656,9 +90223,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-170"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -89685,9 +90253,10 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           id="line-171"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -89828,9 +90397,10 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           id="line-1"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -89901,9 +90471,10 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           id="line-2"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -89930,9 +90501,10 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           id="line-3"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -89994,9 +90566,10 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           id="line-4"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -90023,9 +90596,10 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           id="line-5"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -90117,9 +90691,10 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           id="line-6"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -90146,9 +90721,10 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           id="line-7"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -90244,9 +90820,10 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           id="line-8"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -90327,9 +90904,10 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           id="line-9"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -90430,9 +91008,10 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           id="line-10"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -90503,9 +91082,10 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           id="line-11"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -90601,9 +91181,10 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           id="line-12"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -90649,9 +91230,10 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           id="line-13"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -90678,9 +91260,10 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           id="line-14"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -90736,9 +91319,10 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           id="line-15"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -90870,9 +91454,10 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           id="line-16"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -90948,9 +91533,10 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           id="line-17"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -91021,9 +91607,10 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           id="line-18"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -91084,9 +91671,10 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           id="line-19"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -91147,9 +91735,10 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           id="line-20"
         >
           <span
-            aria-label="sources.content.copyPermalink"
-            className="tooltip has-tooltip-right"
-            data-tooltip="sources.content.copyPermalink"
+            className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <i
               aria-label="sources.content.copyPermalink"
@@ -94678,9 +95267,10 @@ exports[`Storyshots Tooltip Default 1`] = `
     className="Tooltipstories__Spacing-sc-1c34uq-1 goABUu"
   >
     <span
-      aria-label="Heart of Gold"
-      className="tooltip has-tooltip-right"
-      data-tooltip="Heart of Gold"
+      className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <button
         className="button is-info"
@@ -94698,9 +95288,10 @@ exports[`Storyshots Tooltip Default 1`] = `
     className="Tooltipstories__Spacing-sc-1c34uq-1 goABUu"
   >
     <span
-      aria-label="Heart of Gold"
-      className="tooltip has-tooltip-top"
-      data-tooltip="Heart of Gold"
+      className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <button
         className="button is-info"
@@ -94718,9 +95309,10 @@ exports[`Storyshots Tooltip Default 1`] = `
     className="Tooltipstories__Spacing-sc-1c34uq-1 goABUu"
   >
     <span
-      aria-label="Heart of Gold"
-      className="tooltip has-tooltip-left"
-      data-tooltip="Heart of Gold"
+      className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <button
         className="button is-info"
@@ -94738,9 +95330,10 @@ exports[`Storyshots Tooltip Default 1`] = `
     className="Tooltipstories__Spacing-sc-1c34uq-1 goABUu"
   >
     <span
-      aria-label="Heart of Gold"
-      className="tooltip has-tooltip-bottom"
-      data-tooltip="Heart of Gold"
+      className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <button
         className="button is-info"
@@ -94765,23 +95358,10 @@ exports[`Storyshots Tooltip Multiline 1`] = `
     className="Tooltipstories__Spacing-sc-1c34uq-1 goABUu"
   >
     <span
-      aria-label="Characters:
-
-- Arthur Dent
-- Ford Prefect
-- Zaphod Beeblebrox
-- Marvin the Paranoid Android
-- Trillian
-- Slartibartfast"
-      className="tooltip has-tooltip-right"
-      data-tooltip="Characters:
-
-- Arthur Dent
-- Ford Prefect
-- Zaphod Beeblebrox
-- Marvin the Paranoid Android
-- Trillian
-- Slartibartfast"
+      className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <button
         className="button is-info"
@@ -94799,23 +95379,10 @@ exports[`Storyshots Tooltip Multiline 1`] = `
     className="Tooltipstories__Spacing-sc-1c34uq-1 goABUu"
   >
     <span
-      aria-label="Characters:
-
-- Arthur Dent
-- Ford Prefect
-- Zaphod Beeblebrox
-- Marvin the Paranoid Android
-- Trillian
-- Slartibartfast"
-      className="tooltip has-tooltip-top"
-      data-tooltip="Characters:
-
-- Arthur Dent
-- Ford Prefect
-- Zaphod Beeblebrox
-- Marvin the Paranoid Android
-- Trillian
-- Slartibartfast"
+      className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <button
         className="button is-info"
@@ -94833,23 +95400,10 @@ exports[`Storyshots Tooltip Multiline 1`] = `
     className="Tooltipstories__Spacing-sc-1c34uq-1 goABUu"
   >
     <span
-      aria-label="Characters:
-
-- Arthur Dent
-- Ford Prefect
-- Zaphod Beeblebrox
-- Marvin the Paranoid Android
-- Trillian
-- Slartibartfast"
-      className="tooltip has-tooltip-left"
-      data-tooltip="Characters:
-
-- Arthur Dent
-- Ford Prefect
-- Zaphod Beeblebrox
-- Marvin the Paranoid Android
-- Trillian
-- Slartibartfast"
+      className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <button
         className="button is-info"
@@ -94867,23 +95421,10 @@ exports[`Storyshots Tooltip Multiline 1`] = `
     className="Tooltipstories__Spacing-sc-1c34uq-1 goABUu"
   >
     <span
-      aria-label="Characters:
-
-- Arthur Dent
-- Ford Prefect
-- Zaphod Beeblebrox
-- Marvin the Paranoid Android
-- Trillian
-- Slartibartfast"
-      className="tooltip has-tooltip-bottom"
-      data-tooltip="Characters:
-
-- Arthur Dent
-- Ford Prefect
-- Zaphod Beeblebrox
-- Marvin the Paranoid Android
-- Trillian
-- Slartibartfast"
+      className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <button
         className="button is-info"
@@ -94908,13 +95449,10 @@ exports[`Storyshots Tooltip Short Multiline 1`] = `
     className="Tooltipstories__Spacing-sc-1c34uq-1 goABUu"
   >
     <span
-      aria-label="* a
-* b
-* c"
-      className="tooltip has-tooltip-right"
-      data-tooltip="* a
-* b
-* c"
+      className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <button
         className="button is-info"
@@ -94932,13 +95470,10 @@ exports[`Storyshots Tooltip Short Multiline 1`] = `
     className="Tooltipstories__Spacing-sc-1c34uq-1 goABUu"
   >
     <span
-      aria-label="* a
-* b
-* c"
-      className="tooltip has-tooltip-top"
-      data-tooltip="* a
-* b
-* c"
+      className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <button
         className="button is-info"
@@ -94956,13 +95491,10 @@ exports[`Storyshots Tooltip Short Multiline 1`] = `
     className="Tooltipstories__Spacing-sc-1c34uq-1 goABUu"
   >
     <span
-      aria-label="* a
-* b
-* c"
-      className="tooltip has-tooltip-left"
-      data-tooltip="* a
-* b
-* c"
+      className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <button
         className="button is-info"
@@ -94980,13 +95512,10 @@ exports[`Storyshots Tooltip Short Multiline 1`] = `
     className="Tooltipstories__Spacing-sc-1c34uq-1 goABUu"
   >
     <span
-      aria-label="* a
-* b
-* c"
-      className="tooltip has-tooltip-bottom"
-      data-tooltip="* a
-* b
-* c"
+      className="Tooltip__TooltipWrapper-fmp853-0 PCJqp"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <button
         className="button is-info"

--- a/scm-ui/ui-styles/package.json
+++ b/scm-ui/ui-styles/package.json
@@ -12,7 +12,6 @@
     "@fortawesome/fontawesome-free": "^5.11.2",
     "bulma": "^0.9.3",
     "bulma-popover": "^1.0.0",
-    "bulma-tooltip": "^3.0.0",
     "react-diff-view": "^2.4.1"
   },
   "devDependencies": {

--- a/scm-ui/ui-styles/src/components/_tooltip.scss
+++ b/scm-ui/ui-styles/src/components/_tooltip.scss
@@ -21,8 +21,19 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-@import "bulma/bulma";
-@import "../variables/_derived.scss";
-@import "bulma-popover/css/bulma-popover";
-@import "../components/_main.scss";
-@import "../components/_tooltip.scss";
+
+.tooltip-arrow-top {
+  border-color: $grey-dark transparent transparent transparent;
+}
+
+.tooltip-arrow-right {
+  border-color: transparent $grey-dark transparent transparent;
+}
+
+.tooltip-arrow-bottom {
+  border-color: transparent transparent $grey-dark transparent;
+}
+
+.tooltip-arrow-left {
+  border-color: transparent transparent transparent $grey-dark;
+}

--- a/scm-ui/ui-styles/src/components/_tooltip.scss
+++ b/scm-ui/ui-styles/src/components/_tooltip.scss
@@ -22,18 +22,18 @@
  * SOFTWARE.
  */
 
-.tooltip-arrow-top {
+.tooltip-arrow-top-border-color {
   border-color: $grey-dark transparent transparent transparent;
 }
 
-.tooltip-arrow-right {
+.tooltip-arrow-right-border-color {
   border-color: transparent $grey-dark transparent transparent;
 }
 
-.tooltip-arrow-bottom {
+.tooltip-arrow-bottom-border-color {
   border-color: transparent transparent $grey-dark transparent;
 }
 
-.tooltip-arrow-left {
+.tooltip-arrow-left-border-color {
   border-color: transparent transparent transparent $grey-dark;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6638,11 +6638,6 @@ bulma-popover@^1.0.0:
   resolved "https://registry.yarnpkg.com/bulma-popover/-/bulma-popover-1.0.3.tgz#bc948b7b855bedbe8adf20737fc569ac87623a91"
   integrity sha512-/StxOsgTvxrK1OIVrzUk7w4+Lyg9VvXDeh/wj9HhsYoCkqLqRi+EYm9htX6FP0GvscwlPradkgZG6bb997oBBA==
 
-bulma-tooltip@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/bulma-tooltip/-/bulma-tooltip-3.0.2.tgz#2cf0abab1de2eba07f9d84eb7f07a8a88819ea92"
-  integrity sha512-CsT3APjhlZScskFg38n8HYL8oYNUHQtcu4sz6ERarxkUpBRbk9v0h/5KAvXeKapVSn2dp9l7bOGit5SECP8EWQ==
-
 bulma@^0.9.3:
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.9.3.tgz#ddccb7436ebe3e21bf47afe01d3c43a296b70243"


### PR DESCRIPTION
## Proposed changes

There has been the requirement to improve accessibility for our tooltips by allowing tooltips to be closed via the escape key as well as allowing users to hover over the tooltip text. These combined requirements were not possible with the previous implementation that used a bulma-tooltip extension. That meant we had to implement the full tooltip html and css from scratch. A declared goal was to keep the new implementation as close to the previous look-and-feel as possible. The redundant dependency has been removed in the process.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
