### PR TITLE
Handle Plugin Center Authentication failures

### DIFF
--- a/gradle/changelog/pc_auth_failure.yml
+++ b/gradle/changelog/pc_auth_failure.yml
@@ -1,0 +1,2 @@
+- type: changed
+  description: Fetch plugins without authentication, if prior authentication failed ([#1940](https://github.com/scm-manager/scm-manager/pull/1940))

--- a/scm-ui/ui-api/src/usePluginCenterAuthInfo.ts
+++ b/scm-ui/ui-api/src/usePluginCenterAuthInfo.ts
@@ -28,6 +28,16 @@ import { useMutation, useQuery, useQueryClient } from "react-query";
 import { apiClient } from "./apiclient";
 import { useLocation } from "react-router-dom";
 
+const appendQueryParam = (link: Link, name: string, value: string) => {
+  let href = link.href;
+  if (href.includes("?")) {
+    href += "&";
+  } else {
+    href += "?";
+  }
+  link.href = href + name + "=" + value;
+};
+
 export const usePluginCenterAuthInfo = (): ApiResult<PluginCenterAuthenticationInfo> => {
   const link = useIndexLink("pluginCenterAuth");
   const location = useLocation();
@@ -42,7 +52,10 @@ export const usePluginCenterAuthInfo = (): ApiResult<PluginCenterAuthenticationI
         .then(response => response.json())
         .then((result: PluginCenterAuthenticationInfo) => {
           if (result._links?.login) {
-            (result._links.login as Link).href += `?source=${location.pathname}`;
+            appendQueryParam(result._links.login as Link, "source", location.pathname);
+          }
+          if (result._links?.reconnect) {
+            appendQueryParam(result._links.reconnect as Link, "source", location.pathname);
           }
           return result;
         });

--- a/scm-ui/ui-components/src/SmallLoadingSpinner.tsx
+++ b/scm-ui/ui-components/src/SmallLoadingSpinner.tsx
@@ -22,13 +22,16 @@
  * SOFTWARE.
  */
 import React, { FC } from "react";
+import classNames from "classnames";
 
-const SmallLoadingSpinner: FC = () => {
-  return (
-    <div className="loader-wrapper">
-      <div className="loader is-loading" />
-    </div>
-  );
+type Props = {
+  className?: string;
 };
+
+const SmallLoadingSpinner: FC<Props> = ({ className }) => (
+  <div className={classNames("loader-wrapper", className)}>
+    <div className="loader is-loading" />
+  </div>
+);
 
 export default SmallLoadingSpinner;

--- a/scm-ui/ui-styles/src/components/_main.scss
+++ b/scm-ui/ui-styles/src/components/_main.scss
@@ -370,6 +370,18 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
   border-color: $info !important;
 }
 
+.has-border-danger {
+  border-color: $danger !important;
+}
+
+.has-border-warning {
+  border-color: $warning !important;
+}
+
+.has-border-primary {
+  border-color: $danger !important;
+}
+
 ul.is-separated {
   > li:after {
     content: ",\2800";

--- a/scm-ui/ui-types/src/Plugin.ts
+++ b/scm-ui/ui-types/src/Plugin.ts
@@ -65,4 +65,5 @@ export type PluginCenterAuthenticationInfo = HalRepresentation & {
   pluginCenterSubject?: string;
   date?: string;
   default: boolean;
+  failed: boolean;
 };

--- a/scm-ui/ui-webapp/public/locales/de/admin.json
+++ b/scm-ui/ui-webapp/public/locales/de/admin.json
@@ -88,6 +88,17 @@
     },
     "myCloudogu": {
       "connectionInfo": "Instanz ist mit myCloudogu verbunden.\nAccount: {{pluginCenterSubject}}",
+      "error": {
+        "info": "myCloudogu Authentifizierungs Informationen konnten nicht abgerufen werden. Klick um Details zu sehen.",
+        "title": "Fehler"
+      },
+      "failed": {
+        "info": "Verbindung mit account {{pluginCenterSubject}} zu myCloudogu is fehlgeschlagen",
+        "message": "Die Verbindung der SCM-Manager Instanz mit <0>myCloudogu</0> is fehlgeschlagen. Der Benutzer <1>{{subject}}</1> konnte nicht authentifiziert werden.",
+        "button": {
+          "label": "Erneut mit <0>myCloudogu</0> verbinden"
+        }
+      },
       "login": {
         "button": {
           "label": "Mit <0>myCloudogu</0> verbinden"

--- a/scm-ui/ui-webapp/public/locales/de/admin.json
+++ b/scm-ui/ui-webapp/public/locales/de/admin.json
@@ -89,11 +89,11 @@
     "myCloudogu": {
       "connectionInfo": "Instanz ist mit myCloudogu verbunden.\nAccount: {{pluginCenterSubject}}",
       "error": {
-        "info": "myCloudogu Authentifizierungs Informationen konnten nicht abgerufen werden. Klick um Details zu sehen.",
+        "info": "myCloudogu Authentifizierungsinformationen konnten nicht abgerufen werden. Klicken Sie, um Details zu sehen.",
         "title": "Fehler"
       },
       "failed": {
-        "info": "Verbindung mit account {{pluginCenterSubject}} zu myCloudogu is fehlgeschlagen",
+        "info": "Verbindung zu myCloudogu mit Account {{pluginCenterSubject}} is fehlgeschlagen",
         "message": "Die Verbindung der SCM-Manager Instanz mit <0>myCloudogu</0> is fehlgeschlagen. Der Benutzer <1>{{subject}}</1> konnte nicht authentifiziert werden.",
         "button": {
           "label": "Erneut mit <0>myCloudogu</0> verbinden"

--- a/scm-ui/ui-webapp/public/locales/en/admin.json
+++ b/scm-ui/ui-webapp/public/locales/en/admin.json
@@ -88,6 +88,17 @@
     },
     "myCloudogu": {
       "connectionInfo": "Instance is connected to myCloudogu.\nAccount: {{pluginCenterSubject}}",
+      "error": {
+        "info": "Failed to retrieve myCloudogu authentication information. Click for more details.",
+        "title": "Error"
+      },
+      "failed": {
+        "info": "Connection to myCloudogu failed for account {{pluginCenterSubject}}",
+        "message": "The connection of the SCM Manager instance with <0>myCloudogu</0> failed. The user <1>{{subject}}</1> could not be authenticated. Click Reconnect to restore the connection.",
+        "button": {
+          "label": "Reconnect to <0>myCloudogu</0>"
+        }
+      },
       "login": {
         "button": {
           "label": "Connect to <0>myCloudogu</0>"

--- a/scm-ui/ui-webapp/src/admin/plugins/components/MyCloudoguBanner.tsx
+++ b/scm-ui/ui-webapp/src/admin/plugins/components/MyCloudoguBanner.tsx
@@ -22,25 +22,84 @@
  * SOFTWARE.
  */
 
-import { Button } from "@scm-manager/ui-components";
-import * as React from "react";
-import { FC } from "react";
-import styled from "styled-components";
+import React, { FC } from "react";
 import { Trans, useTranslation } from "react-i18next";
-
-const MyCloudoguBannerWrapper = styled.div`
-  border: 1px solid;
-`;
+import { Link, PluginCenterAuthenticationInfo } from "@scm-manager/ui-types";
+import classNames from "classnames";
+import styled from "styled-components";
+import { Button } from "@scm-manager/ui-components";
 
 type Props = {
-  loginLink?: string;
+  info: PluginCenterAuthenticationInfo;
 };
 
-const MyCloudoguBanner: FC<Props> = ({ loginLink }) => {
+const MyCloudoguBanner: FC<Props> = ({ info }) => {
+  const loginLink = (info._links.login as Link)?.href;
+  if (loginLink) {
+    return <Unauthenticated info={info} link={loginLink} />;
+  }
+
+  if (info.failed) {
+    const reconnectLink = (info._links.reconnect as Link)?.href;
+    if (reconnectLink) {
+      return <FailedAuthentication info={info} link={reconnectLink} />;
+    }
+  }
+
+  return null;
+};
+
+type PropsWithLink = Props & {
+  link: string;
+};
+
+const FailedAuthentication: FC<PropsWithLink> = ({ info, link }) => {
   const [t] = useTranslation("admin");
-  return loginLink ? (
-    <MyCloudoguBannerWrapper className="has-rounded-border is-flex is-flex-direction-column is-align-items-center p-5 mb-4 has-border-success">
-      <Button className="mb-5 has-text-weight-normal has-border-info" reducedMobile={true} link={loginLink}>
+  return (
+    <Container className="has-border-danger">
+      <p className="is-align-self-flex-start">
+        <Trans
+          t={t}
+          i18nKey="plugins.myCloudogu.failed.message"
+          values={{ subject: info.pluginCenterSubject }}
+          components={[<a href="https://my.cloudogu.com/">myCloudogu</a>, <strong />]}
+        />
+      </p>
+      <Button className="mt-5 has-text-weight-normal has-border-info" reducedMobile={true} link={link}>
+        <Trans
+          t={t}
+          i18nKey="plugins.myCloudogu.failed.button.label"
+          components={[<span className="mx-1 has-text-info">myCloudogu</span>]}
+        />
+      </Button>
+    </Container>
+  );
+};
+
+type ContainerProps = {
+  className?: string;
+};
+
+const Container: FC<ContainerProps> = ({ className, children }) => (
+  <DivWithSolidBorder
+    className={classNames(
+      "has-rounded-border is-flex is-flex-direction-column is-align-items-center p-5 mb-4",
+      className
+    )}
+  >
+    {children}
+  </DivWithSolidBorder>
+);
+
+const DivWithSolidBorder = styled.div`
+  border: 2px solid;
+`;
+
+const Unauthenticated: FC<PropsWithLink> = ({ link, info }) => {
+  const [t] = useTranslation("admin");
+  return (
+    <Container className="has-border-success">
+      <Button className="mb-5 has-text-weight-normal has-border-info" reducedMobile={true} link={link}>
         <Trans
           t={t}
           i18nKey="plugins.myCloudogu.login.button.label"
@@ -54,8 +113,8 @@ const MyCloudoguBanner: FC<Props> = ({ loginLink }) => {
           components={[<a href="https://my.cloudogu.com/">myCloudogu</a>]}
         />
       </p>
-    </MyCloudoguBannerWrapper>
-  ) : null;
+    </Container>
+  );
 };
 
 export default MyCloudoguBanner;

--- a/scm-ui/ui-webapp/src/admin/plugins/components/PluginCenterAuthInfo.tsx
+++ b/scm-ui/ui-webapp/src/admin/plugins/components/PluginCenterAuthInfo.tsx
@@ -1,0 +1,131 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import React, { FC, useState } from "react";
+import {
+  ErrorNotification,
+  Icon,
+  Modal,
+  NoStyleButton,
+  SmallLoadingSpinner,
+  Tooltip
+} from "@scm-manager/ui-components";
+import { PluginCenterAuthenticationInfo } from "@scm-manager/ui-types";
+import { useTranslation } from "react-i18next";
+
+type PluginCenterAuthInfoProps = {
+  data?: PluginCenterAuthenticationInfo;
+  isLoading: boolean;
+  error: Error | null;
+};
+
+const PluginCenterAuthInfo: FC<PluginCenterAuthInfoProps> = props => (
+  <div className="ml-3 is-flex is-align-items-center is-size-5">
+    <Inner {...props} />
+  </div>
+);
+
+const Inner: FC<PluginCenterAuthInfoProps> = ({ data, isLoading, error }) => {
+  if (isLoading) {
+    return <SmallLoadingSpinner />;
+  }
+  if (error) {
+    return <AuthenticationError error={error} />;
+  }
+  if (!data || !data.pluginCenterSubject) {
+    return null;
+  }
+  if (data.failed) {
+    return <AuthenticationFailed info={data} />;
+  }
+
+  return <Authenticated info={data} />;
+};
+
+type ErrorProps = {
+  error: Error;
+};
+
+const AuthenticationError: FC<ErrorProps> = ({ error }) => {
+  const [t] = useTranslation("admin");
+  const [showModal, setShowModal] = useState(false);
+  return (
+    <>
+      <Tooltip message={t("plugins.myCloudogu.error.info")} multiline={true}>
+        <NoStyleButton onClick={() => setShowModal(true)}>
+          <Icon name="exclamation-triangle" color="danger" className="is-size-5" />
+        </NoStyleButton>
+      </Tooltip>
+      {showModal ? <ErrorModal error={error} onClose={() => setShowModal(false)} /> : null}
+    </>
+  );
+};
+
+type ErrorModalProps = {
+  error: Error;
+  onClose: () => void;
+};
+
+const ErrorModal: FC<ErrorModalProps> = ({ error, onClose }) => {
+  const [t] = useTranslation("admin");
+  return (
+    <Modal title={t("plugins.myCloudogu.error.title")} closeFunction={onClose} active={true}>
+      <ErrorNotification error={error} />
+    </Modal>
+  );
+};
+
+type InfoProps = {
+  info: PluginCenterAuthenticationInfo;
+};
+
+const AuthenticationFailed: FC<InfoProps> = ({ info }) => {
+  const [t] = useTranslation("admin");
+  return (
+    <Tooltip
+      message={t("plugins.myCloudogu.failed.info", {
+        pluginCenterSubject: info.pluginCenterSubject
+      })}
+      multiline={true}
+    >
+      <Icon name="exclamation-triangle" color="danger" />
+    </Tooltip>
+  );
+};
+
+const Authenticated: FC<InfoProps> = ({ info }) => {
+  const [t] = useTranslation("admin");
+  return (
+    <Tooltip
+      message={t("plugins.myCloudogu.connectionInfo", {
+        pluginCenterSubject: info.pluginCenterSubject
+      })}
+      multiline={true}
+    >
+      <Icon name="check-circle" color="info" />
+    </Tooltip>
+  );
+};
+
+export default PluginCenterAuthInfo;

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/PluginCenterAuthenticationInfoDto.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/PluginCenterAuthenticationInfoDto.java
@@ -46,6 +46,7 @@ public class PluginCenterAuthenticationInfoDto extends HalRepresentation {
   @JsonInclude(NON_NULL)
   private Instant date;
   private boolean isDefault;
+  private boolean failed;
 
   public PluginCenterAuthenticationInfoDto(Links links) {
     super(links);

--- a/scm-webapp/src/main/java/sonia/scm/plugin/PluginCenterAuthenticationFailedEvent.java
+++ b/scm-webapp/src/main/java/sonia/scm/plugin/PluginCenterAuthenticationFailedEvent.java
@@ -21,42 +21,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package sonia.scm.plugin;
 
-import java.time.Instant;
+import lombok.Value;
+import sonia.scm.event.Event;
 
 /**
- * Information about the plugin center authentication.
- * @since 2.28.0
+ * Event is thrown if the authentication to the plugin center fails.
+ * @since 2.30.0
  */
-public interface AuthenticationInfo {
-
-  /**
-   * Returns the username of the SCM-Manager user which has authenticated the plugin center.
-   * @return SCM-Manager username
-   */
-  String getPrincipal();
-
-  /**
-   * Returns the subject of the plugin center user.
-   * @return plugin center subject
-   */
-  String getPluginCenterSubject();
-
-  /**
-   * Returns the date on which the authentication was performed.
-   * @return authentication date
-   */
-  Instant getDate();
-
-  /**
-   * Returns {@code true} if the last authentication has failed.
-   * @return {@code true} if the last authentication has failed.
-   * @since 2.31.0
-   */
-  default boolean isFailed() {
-    return false;
-  }
-
+@Event
+@Value
+public class PluginCenterAuthenticationFailedEvent implements PluginCenterAuthenticationEvent {
+  AuthenticationInfo authenticationInfo;
 }

--- a/scm-webapp/src/main/java/sonia/scm/plugin/PluginCenterLoader.java
+++ b/scm-webapp/src/main/java/sonia/scm/plugin/PluginCenterLoader.java
@@ -69,7 +69,7 @@ class PluginCenterLoader {
       LOG.info("fetch plugins from {}", url);
       AdvancedHttpRequest request = client.get(url).spanKind(SPAN_KIND);
       if (authenticator.isAuthenticated()) {
-        request.bearerAuth(authenticator.fetchAccessToken());
+        authenticator.fetchAccessToken().ifPresent(request::bearerAuth);
       }
       PluginCenterDto pluginCenterDto = request.request().contentFromJson(PluginCenterDto.class);
       return mapper.map(pluginCenterDto);

--- a/scm-webapp/src/main/java/sonia/scm/plugin/PluginInstaller.java
+++ b/scm-webapp/src/main/java/sonia/scm/plugin/PluginInstaller.java
@@ -132,7 +132,7 @@ class PluginInstaller {
   private InputStream download(AvailablePlugin plugin) throws IOException {
     AdvancedHttpRequest request = client.get(plugin.getDescriptor().getUrl()).spanKind(SPAN_KIND);
     if (authenticator.isAuthenticated()) {
-      request.bearerAuth(authenticator.fetchAccessToken());
+      authenticator.fetchAccessToken().ifPresent(request::bearerAuth);
     }
     return request.request().contentAsStream();
   }

--- a/scm-webapp/src/test/java/sonia/scm/plugin/PluginCenterLoaderTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/plugin/PluginCenterLoaderTest.java
@@ -37,6 +37,7 @@ import sonia.scm.net.ahc.AdvancedHttpResponse;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -107,7 +108,7 @@ class PluginCenterLoaderTest {
   @Test
   void shouldAppendAccessToken() throws IOException {
     when(authenticator.isAuthenticated()).thenReturn(true);
-    when(authenticator.fetchAccessToken()).thenReturn("mega-cool-at");
+    when(authenticator.fetchAccessToken()).thenReturn(Optional.of("mega-cool-at"));
 
     mockResponse();
     loader.load(PLUGIN_URL);

--- a/scm-webapp/src/test/java/sonia/scm/plugin/PluginInstallerTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/plugin/PluginInstallerTest.java
@@ -43,6 +43,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -200,7 +201,7 @@ class PluginInstallerTest {
   @Test
   void shouldAppendBearerAuth() throws IOException {
     when(authenticator.isAuthenticated()).thenReturn(true);
-    when(authenticator.fetchAccessToken()).thenReturn("atat");
+    when(authenticator.fetchAccessToken()).thenReturn(Optional.of("atat"));
     mockContent("42");
 
     installer.install(PluginInstallationContext.empty(), createGitPlugin());

--- a/scm-webapp/src/test/java/sonia/scm/update/plugin/PluginCenterAuthentiationUpdateStepTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/update/plugin/PluginCenterAuthentiationUpdateStepTest.java
@@ -72,7 +72,7 @@ class PluginCenterAuthenticationUpdateStepTest {
   @Test
   void shouldUpdateIfRefreshTokenNotEncrypted() throws Exception {
     when(configurationStore.getOptional())
-      .thenReturn(Optional.of(new PluginCenterAuthenticator.Authentication("trillian", "trillian", "some_not_encrypted_token", Instant.now())));
+      .thenReturn(Optional.of(new PluginCenterAuthenticator.Authentication("trillian", "trillian", "some_not_encrypted_token", Instant.now(), false)));
 
     updateStep.doUpdate();
 
@@ -85,7 +85,7 @@ class PluginCenterAuthenticationUpdateStepTest {
   @Test
   void shouldNotUpdateIfRefreshTokenIsAlreadyEncrypted() throws Exception {
     when(configurationStore.getOptional())
-      .thenReturn(Optional.of(new PluginCenterAuthenticator.Authentication("trillian", "trillian", "{enc}my_encrypted_token", Instant.now())));
+      .thenReturn(Optional.of(new PluginCenterAuthenticator.Authentication("trillian", "trillian", "{enc}my_encrypted_token", Instant.now(), false)));
 
     updateStep.doUpdate();
 


### PR DESCRIPTION
## Proposed changes

If the plugin center authentication fails, 
the plugins are fetched without authentication 
and a warning is displayed on the plugin page.

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [x] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
