### PR TITLE
Do not fail on error 502 during restart actions

### DIFF
--- a/gradle/changelog/restart_bad_gateway.yaml
+++ b/gradle/changelog/restart_bad_gateway.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Do not fail on 502 during restart actions ([#1941](https://github.com/scm-manager/scm-manager/pull/1941))

--- a/scm-ui/ui-api/src/apiclient.test.ts
+++ b/scm-ui/ui-api/src/apiclient.test.ts
@@ -22,9 +22,9 @@
  * SOFTWARE.
  */
 
-import {apiClient, createUrl, extractXsrfTokenFromCookie} from "./apiclient";
+import { apiClient, createUrl, extractXsrfTokenFromCookie } from "./apiclient";
 import fetchMock from "fetch-mock";
-import {BackendError, BadGatewayError} from "./errors";
+import { BackendError, BadGatewayError } from "./errors";
 
 describe("create url", () => {
   it("should not change absolute urls", () => {

--- a/scm-ui/ui-api/src/apiclient.test.ts
+++ b/scm-ui/ui-api/src/apiclient.test.ts
@@ -22,9 +22,9 @@
  * SOFTWARE.
  */
 
-import { apiClient, createUrl, extractXsrfTokenFromCookie } from "./apiclient";
+import {apiClient, createUrl, extractXsrfTokenFromCookie} from "./apiclient";
 import fetchMock from "fetch-mock";
-import { BackendError } from "./errors";
+import {BackendError, BadGatewayError} from "./errors";
 
 describe("create url", () => {
   it("should not change absolute urls", () => {
@@ -45,9 +45,9 @@ describe("error handling tests", () => {
     context: [
       {
         type: "planet",
-        id: "earth",
-      },
-    ],
+        id: "earth"
+      }
+    ]
   };
 
   afterEach(() => {
@@ -55,9 +55,9 @@ describe("error handling tests", () => {
     fetchMock.restore();
   });
 
-  it("should create a normal error, if the content type is not scmm-error", (done) => {
+  it("should create a normal error, if the content type is not scmm-error", done => {
     fetchMock.getOnce("/api/v2/error", {
-      status: 404,
+      status: 404
     });
 
     apiClient.get("/error").catch((err: Error) => {
@@ -67,13 +67,24 @@ describe("error handling tests", () => {
     });
   });
 
-  it("should create an backend error, if the content type is scmm-error", (done) => {
+  it("should create a bad gateway error", done => {
+    fetchMock.getOnce("/api/v2/error", {
+      status: 502
+    });
+
+    apiClient.get("/error").catch((err: Error) => {
+      expect(err).toBeInstanceOf(BadGatewayError);
+      done();
+    });
+  });
+
+  it("should create an backend error, if the content type is scmm-error", done => {
     fetchMock.getOnce("/api/v2/error", {
       status: 404,
       headers: {
-        "Content-Type": "application/vnd.scmm-error+json;v=2",
+        "Content-Type": "application/vnd.scmm-error+json;v=2"
       },
-      body: earthNotFoundError,
+      body: earthNotFoundError
     });
 
     apiClient.get("/error").catch((err: BackendError) => {
@@ -87,8 +98,8 @@ describe("error handling tests", () => {
       expect(err.context).toEqual([
         {
           type: "planet",
-          id: "earth",
-        },
+          id: "earth"
+        }
       ]);
       done();
     });

--- a/scm-ui/ui-api/src/errors.ts
+++ b/scm-ui/ui-api/src/errors.ts
@@ -79,6 +79,15 @@ export class UnauthorizedError extends Error {
   }
 }
 
+export class BadGatewayError extends Error {
+  statusCode: number;
+
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.statusCode = statusCode;
+  }
+}
+
 export class TokenExpiredError extends UnauthorizedError {}
 
 export class ForbiddenError extends Error {

--- a/scm-ui/ui-api/src/plugins.ts
+++ b/scm-ui/ui-api/src/plugins.ts
@@ -38,7 +38,7 @@ const waitForRestartAfter = (
   promise: Promise<any>,
   { initialDelay = 1000, timeout = 500 }: WaitForRestartOptions = {}
 ): Promise<void> => {
-  const endTime = Number(new Date()) + (4 * 60 * 1000);
+  const endTime = Number(new Date()) + 4 * 60 * 1000;
   let started = false;
 
   const executor = <T = any>(data: T) => (resolve: (result: T) => void, reject: (error: Error) => void) => {

--- a/scm-ui/ui-api/src/plugins.ts
+++ b/scm-ui/ui-api/src/plugins.ts
@@ -27,6 +27,7 @@ import { isPluginCollection, PendingPlugins, Plugin, PluginCollection } from "@s
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { apiClient } from "./apiclient";
 import { requiredLink } from "./links";
+import { BadGatewayError } from "./errors";
 
 type WaitForRestartOptions = {
   initialDelay?: number;
@@ -40,28 +41,35 @@ const waitForRestartAfter = (
   const endTime = Number(new Date()) + 60000;
   let started = false;
 
-  const executor =
-    <T = any>(data: T) =>
-    (resolve: (result: T) => void, reject: (error: Error) => void) => {
-      // we need some initial delay
-      if (!started) {
-        started = true;
-        setTimeout(executor(data), initialDelay, resolve, reject);
-      } else {
-        apiClient
-          .get("")
-          .then(() => resolve(data))
-          .catch(() => {
-            if (Number(new Date()) < endTime) {
-              setTimeout(executor(data), timeout, resolve, reject);
-            } else {
-              reject(new Error("timeout reached"));
-            }
-          });
-      }
-    };
+  const executor = <T = any>(data: T) => (resolve: (result: T) => void, reject: (error: Error) => void) => {
+    // we need some initial delay
+    if (!started) {
+      started = true;
+      setTimeout(executor(data), initialDelay, resolve, reject);
+    } else {
+      apiClient
+        .get("")
+        .then(() => resolve(data))
+        .catch(() => {
+          if (Number(new Date()) < endTime) {
+            setTimeout(executor(data), timeout, resolve, reject);
+          } else {
+            reject(new Error("timeout reached"));
+          }
+        });
+    }
+  };
 
-  return promise.then((data) => new Promise<void>(executor(data)));
+  return promise
+    .catch(err => {
+      if (err instanceof BadGatewayError) {
+        // in some rare cases the reverse proxy stops forwarding traffic to scm before the response is returned
+        // in such a case the reverse proxy returns 502 (bad gateway), so we treat 502 not as error
+        return "ok";
+      }
+      throw err;
+    })
+    .then(data => new Promise<void>(executor(data)));
 };
 
 export type UseAvailablePluginsOptions = {
@@ -72,10 +80,10 @@ export const useAvailablePlugins = ({ enabled }: UseAvailablePluginsOptions = {}
   const indexLink = useRequiredIndexLink("availablePlugins");
   return useQuery<PluginCollection, Error>(
     ["plugins", "available"],
-    () => apiClient.get(indexLink).then((response) => response.json()),
+    () => apiClient.get(indexLink).then(response => response.json()),
     {
       enabled,
-      retry: 3,
+      retry: 3
     }
   );
 };
@@ -88,10 +96,10 @@ export const useInstalledPlugins = ({ enabled }: UseInstalledPluginsOptions = {}
   const indexLink = useRequiredIndexLink("installedPlugins");
   return useQuery<PluginCollection, Error>(
     ["plugins", "installed"],
-    () => apiClient.get(indexLink).then((response) => response.json()),
+    () => apiClient.get(indexLink).then(response => response.json()),
     {
       enabled,
-      retry: 3,
+      retry: 3
     }
   );
 };
@@ -100,10 +108,10 @@ export const usePendingPlugins = (): ApiResult<PendingPlugins> => {
   const indexLink = useIndexLink("pendingPlugins");
   return useQuery<PendingPlugins, Error>(
     ["plugins", "pending"],
-    () => apiClient.get(indexLink!).then((response) => response.json()),
+    () => apiClient.get(indexLink!).then(response => response.json()),
     {
       enabled: !!indexLink,
-      retry: 3,
+      retry: 3
     }
   );
 };
@@ -135,19 +143,19 @@ export const useInstallPlugin = () => {
       return promise;
     },
     {
-      onSuccess: () => queryClient.invalidateQueries("plugins"),
+      onSuccess: () => queryClient.invalidateQueries("plugins")
     }
   );
   return {
     install: (plugin: Plugin, restartOptions: RestartOptions = {}) =>
       mutate({
         plugin,
-        restartOptions,
+        restartOptions
       }),
     isLoading,
     error,
     data,
-    isInstalled: !!data,
+    isInstalled: !!data
   };
 };
 
@@ -162,18 +170,18 @@ export const useUninstallPlugin = () => {
       return promise;
     },
     {
-      onSuccess: () => queryClient.invalidateQueries("plugins"),
+      onSuccess: () => queryClient.invalidateQueries("plugins")
     }
   );
   return {
     uninstall: (plugin: Plugin, restartOptions: RestartOptions = {}) =>
       mutate({
         plugin,
-        restartOptions,
+        restartOptions
       }),
     isLoading,
     error,
-    isUninstalled: !!data,
+    isUninstalled: !!data
   };
 };
 
@@ -196,18 +204,18 @@ export const useUpdatePlugins = () => {
       return promise;
     },
     {
-      onSuccess: () => queryClient.invalidateQueries("plugins"),
+      onSuccess: () => queryClient.invalidateQueries("plugins")
     }
   );
   return {
     update: (plugin: Plugin | PluginCollection, restartOptions: RestartOptions = {}) =>
       mutate({
         plugins: plugin,
-        restartOptions,
+        restartOptions
       }),
     isLoading,
     error,
-    isUpdated: !!data,
+    isUpdated: !!data
   };
 };
 
@@ -222,7 +230,7 @@ export const useExecutePendingPlugins = () => {
     ({ pending, restartOptions }) =>
       waitForRestartAfter(apiClient.post(requiredLink(pending, "execute")), restartOptions),
     {
-      onSuccess: () => queryClient.invalidateQueries("plugins"),
+      onSuccess: () => queryClient.invalidateQueries("plugins")
     }
   );
   return {
@@ -230,22 +238,22 @@ export const useExecutePendingPlugins = () => {
       mutate({ pending, restartOptions }),
     isLoading,
     error,
-    isExecuted: !!data,
+    isExecuted: !!data
   };
 };
 
 export const useCancelPendingPlugins = () => {
   const queryClient = useQueryClient();
   const { mutate, isLoading, error, data } = useMutation<unknown, Error, PendingPlugins>(
-    (pending) => apiClient.post(requiredLink(pending, "cancel")),
+    pending => apiClient.post(requiredLink(pending, "cancel")),
     {
-      onSuccess: () => queryClient.invalidateQueries("plugins"),
+      onSuccess: () => queryClient.invalidateQueries("plugins")
     }
   );
   return {
     update: (pending: PendingPlugins) => mutate(pending),
     isLoading,
     error,
-    isCancelled: !!data,
+    isCancelled: !!data
   };
 };

--- a/scm-ui/ui-api/src/plugins.ts
+++ b/scm-ui/ui-api/src/plugins.ts
@@ -38,7 +38,7 @@ const waitForRestartAfter = (
   promise: Promise<any>,
   { initialDelay = 1000, timeout = 500 }: WaitForRestartOptions = {}
 ): Promise<void> => {
-  const endTime = Number(new Date()) + 60000;
+  const endTime = Number(new Date()) + (4 * 60 * 1000);
   let started = false;
 
   const executor = <T = any>(data: T) => (resolve: (result: T) => void, reject: (error: Error) => void) => {


### PR DESCRIPTION
## Proposed changes

In some rare cases a reverse proxy stops forwarding traffic to scm,
before the response is returned to scm.
In such a case the reverse proxy returns 502 (bad gateway),
so we treat 502 not as error for restart actions.

### Your checklist for this pull request

**Contributor**:
- [X] PR is well described and the description can be used as a commit message on squash
- [X] Related issues linked to PR if existing and labels set
- [X] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
