### PR TITLE
Collapse folders with only one child folder

### DIFF
--- a/gradle/changelog/collapse_folders.yaml
+++ b/gradle/changelog/collapse_folders.yaml
@@ -1,0 +1,2 @@
+- type: added
+  description: Collapses folders in code view which only have a folder as their only child ([#1951](https://github.com/scm-manager/scm-manager/pull/1951))

--- a/scm-core/src/main/java/sonia/scm/repository/api/BrowseCommandBuilder.java
+++ b/scm-core/src/main/java/sonia/scm/repository/api/BrowseCommandBuilder.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.repository.api;
 
 //~--- non-JDK imports --------------------------------------------------------
@@ -85,7 +85,6 @@ public final class BrowseCommandBuilder
    *
    * @param cacheManager cache manager
    * @param browseCommand implementation of the {@link BrowseCommand}
-   * @param browseCommand
    * @param repository repository to query
    * @param preProcessorUtil
    */
@@ -126,7 +125,7 @@ public final class BrowseCommandBuilder
    * @throws IOException
    */
   public BrowserResult getBrowserResult() throws IOException {
-    BrowserResult result = null;
+    BrowserResult result;
 
     if (disableCache)
     {
@@ -137,9 +136,7 @@ public final class BrowseCommandBuilder
       }
 
       result = browseCommand.getBrowserResult(request);
-      if (!request.isRecursive() && request.isCollapsed()) {
-        new BrowserResultCollapser().collapseFolders(browseCommand, request, result.getFile());
-      }
+      collapseFoldersIfRequested(result);
     }
     else
     {
@@ -155,9 +152,7 @@ public final class BrowseCommandBuilder
         }
 
         result = browseCommand.getBrowserResult(request);
-        if (!request.isRecursive() && request.isCollapsed()) {
-          new BrowserResultCollapser().collapseFolders(browseCommand, request, result.getFile());
-        }
+        collapseFoldersIfRequested(result);
 
         if (result != null)
         {
@@ -176,6 +171,12 @@ public final class BrowseCommandBuilder
     }
 
     return result;
+  }
+
+  private void collapseFoldersIfRequested(BrowserResult result) throws IOException {
+    if (!request.isRecursive() && request.isCollapse()) {
+      new BrowserResultCollapser().collapseFolders(browseCommand, request, result.getFile());
+    }
   }
 
   //~--- set methods ----------------------------------------------------------
@@ -327,10 +328,11 @@ public final class BrowseCommandBuilder
   }
 
   /**
-   * Collapse empty folders until a folder has content and return the path to such folder as a single item.
+   * Collapse folders with only one sub-folder until a folder is empty, contains files or has more than one sub-folder
+   * and return the path to such folder as a single item.
    *
-   * @param collapse {@code true} if empty folders should be collapsed, otherwise {@code false}.
-   * @since 2.30.3
+   * @param collapse {@code true} if folders with only one sub-folder should be collapsed, otherwise {@code false}.
+   * @since 2.31.0
    */
   public BrowseCommandBuilder setCollapse(boolean collapse) {
     request.setCollapse(collapse);

--- a/scm-core/src/main/java/sonia/scm/repository/api/BrowseCommandBuilder.java
+++ b/scm-core/src/main/java/sonia/scm/repository/api/BrowseCommandBuilder.java
@@ -135,8 +135,7 @@ public final class BrowseCommandBuilder
           request);
       }
 
-      result = browseCommand.getBrowserResult(request);
-      collapseFoldersIfRequested(result);
+      result = computeBrowserResult();
     }
     else
     {
@@ -151,8 +150,7 @@ public final class BrowseCommandBuilder
           logger.debug("create browser result for {}", request);
         }
 
-        result = browseCommand.getBrowserResult(request);
-        collapseFoldersIfRequested(result);
+        result = computeBrowserResult();
 
         if (result != null)
         {
@@ -173,10 +171,12 @@ public final class BrowseCommandBuilder
     return result;
   }
 
-  private void collapseFoldersIfRequested(BrowserResult result) throws IOException {
-    if (!request.isRecursive() && request.isCollapse()) {
+  private BrowserResult computeBrowserResult() throws IOException {
+    BrowserResult result = browseCommand.getBrowserResult(request);
+    if (result != null && !request.isRecursive() && request.isCollapse()) {
       new BrowserResultCollapser().collapseFolders(browseCommand, request, result.getFile());
     }
+    return result;
   }
 
   //~--- set methods ----------------------------------------------------------

--- a/scm-core/src/main/java/sonia/scm/repository/api/BrowseCommandBuilder.java
+++ b/scm-core/src/main/java/sonia/scm/repository/api/BrowseCommandBuilder.java
@@ -137,6 +137,9 @@ public final class BrowseCommandBuilder
       }
 
       result = browseCommand.getBrowserResult(request);
+      if (!request.isRecursive() && request.isCollapsed()) {
+        new BrowserResultCollapser().collapseFolders(browseCommand, request, result.getFile());
+      }
     }
     else
     {
@@ -152,6 +155,9 @@ public final class BrowseCommandBuilder
         }
 
         result = browseCommand.getBrowserResult(request);
+        if (!request.isRecursive() && request.isCollapsed()) {
+          new BrowserResultCollapser().collapseFolders(browseCommand, request, result.getFile());
+        }
 
         if (result != null)
         {

--- a/scm-core/src/main/java/sonia/scm/repository/api/BrowseCommandBuilder.java
+++ b/scm-core/src/main/java/sonia/scm/repository/api/BrowseCommandBuilder.java
@@ -166,7 +166,7 @@ public final class BrowseCommandBuilder
       }
       else if (logger.isDebugEnabled())
       {
-        logger.debug("retrive browser result from cache for {}", request);
+        logger.debug("retrieve browser result from cache for {}", request);
       }
     }
 
@@ -371,7 +371,7 @@ public final class BrowseCommandBuilder
     public CacheKey(Repository repository, BrowseCommandRequest request)
     {
       this.repositoryId = repository.getId();
-      this.request = request;
+      this.request = request.clone();
     }
 
     //~--- methods ------------------------------------------------------------

--- a/scm-core/src/main/java/sonia/scm/repository/api/BrowseCommandBuilder.java
+++ b/scm-core/src/main/java/sonia/scm/repository/api/BrowseCommandBuilder.java
@@ -320,6 +320,17 @@ public final class BrowseCommandBuilder
     return this;
   }
 
+  /**
+   * Collapse empty folders until a folder has content and return the path to such folder as a single item.
+   *
+   * @param collapse {@code true} if empty folders should be collapsed, otherwise {@code false}.
+   * @since 2.30.3
+   */
+  public BrowseCommandBuilder setCollapse(boolean collapse) {
+    request.setCollapse(collapse);
+    return this;
+  }
+
   private void updateCache(BrowserResult updatedResult) {
     if (!disableCache) {
       CacheKey key = new CacheKey(repository, request);

--- a/scm-core/src/main/java/sonia/scm/repository/api/BrowserResultCollapser.java
+++ b/scm-core/src/main/java/sonia/scm/repository/api/BrowserResultCollapser.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class BrowserResultCollapser {
+class BrowserResultCollapser {
 
   private BrowseCommand browseCommand;
   private BrowseCommandRequest request;
@@ -51,24 +51,22 @@ public class BrowserResultCollapser {
     List<FileObject> collapsedChildren = new ArrayList<>();
     for (FileObject child : fo.getChildren()) {
       if (child.isDirectory()) {
-        traverseFolder(child, collapsedChildren);
-      } else {
-        collapsedChildren.add(child);
+        child = traverseFolder(child);
       }
+      collapsedChildren.add(child);
     }
     fo.setChildren(collapsedChildren);
   }
 
-  private void traverseFolder(FileObject parent, List<FileObject> collapsedChildren) throws IOException {
+  private FileObject traverseFolder(FileObject parent) throws IOException {
     request.setPath(parent.getPath());
     BrowserResult result = browseCommand.getBrowserResult(request);
-    if (!isCollapsible(result.getFile())) {
-      collapsedChildren.add(parent);
-    } else {
+    if (isCollapsible(result.getFile())) {
       FileObject child = result.getFile().getChildren().iterator().next();
       child.setName(parent.getName() + "/" + child.getName());
-      traverseFolder(child, collapsedChildren);
+      return traverseFolder(child);
     }
+    return parent;
   }
 
   private boolean isCollapsible(FileObject fo) {

--- a/scm-core/src/main/java/sonia/scm/repository/api/BrowserResultCollapser.java
+++ b/scm-core/src/main/java/sonia/scm/repository/api/BrowserResultCollapser.java
@@ -65,12 +65,9 @@ public class BrowserResultCollapser {
     if (!isCollapsible(result.getFile())) {
       collapsedChildren.add(parent);
     } else {
-      for (FileObject child : result.getFile().getChildren()) {
-        if (child.isDirectory()) {
-          child.setName(parent.getName() + "/" + child.getName());
-          traverseFolder(child, collapsedChildren);
-        }
-      }
+      FileObject child = result.getFile().getChildren().iterator().next();
+      child.setName(parent.getName() + "/" + child.getName());
+      traverseFolder(child, collapsedChildren);
     }
   }
 

--- a/scm-core/src/main/java/sonia/scm/repository/api/BrowserResultCollapser.java
+++ b/scm-core/src/main/java/sonia/scm/repository/api/BrowserResultCollapser.java
@@ -1,0 +1,93 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.repository.api;
+
+import sonia.scm.repository.BrowserResult;
+import sonia.scm.repository.FileObject;
+import sonia.scm.repository.spi.BrowseCommand;
+import sonia.scm.repository.spi.BrowseCommandRequest;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.ListIterator;
+
+public class BrowserResultCollapser {
+
+  private BrowseCommand browseCommand;
+  private BrowseCommandRequest request;
+
+  public void collapseFolders(BrowseCommand browseCommand, BrowseCommandRequest request, FileObject fo) throws IOException {
+    if (!fo.isDirectory()) {
+      return;
+    }
+    this.browseCommand = browseCommand;
+    this.request = request;
+
+    ArrayList<FileObject> collapsedChildren = new ArrayList<>(fo.getChildren());
+    ListIterator<FileObject> iter = collapsedChildren.listIterator();
+    while (iter.hasNext()) {
+      FileObject child = iter.next();
+      if (child.isDirectory()) {
+        iter.remove();
+        traverseFolder(child, iter);
+      }
+    }
+    fo.setChildren(collapsedChildren);
+  }
+
+  private void traverseFolder(FileObject fo, ListIterator<FileObject> iter) throws IOException {
+    BrowseCommandRequest childRequest = createChildRequest(request, fo.getPath());
+    BrowserResult result = browseCommand.getBrowserResult(childRequest);
+    if (isEmptyOrHasFiles(result.getFile())) {
+      iter.add(fo);
+    } else {
+      for (FileObject child : result.getFile().getChildren()) {
+        child.setName(fo.getName() + "/" + child.getName());
+        traverseFolder(child, iter);
+      }
+    }
+  }
+
+  private BrowseCommandRequest createChildRequest(BrowseCommandRequest request, String path) {
+    BrowseCommandRequest childRequest = request.clone();
+    childRequest.setLimit(Integer.MAX_VALUE);
+    childRequest.setOffset(0);
+    childRequest.setPath(path);
+    return childRequest;
+  }
+
+  private boolean isEmptyOrHasFiles(FileObject fo) {
+    if (fo.getChildren().isEmpty()) {
+      return true;
+    }
+    for (FileObject child : fo.getChildren()) {
+      if (!child.isDirectory()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+}

--- a/scm-core/src/main/java/sonia/scm/repository/api/BrowserResultCollapser.java
+++ b/scm-core/src/main/java/sonia/scm/repository/api/BrowserResultCollapser.java
@@ -46,7 +46,7 @@ public class BrowserResultCollapser {
     this.request = new BrowseCommandRequest();
     this.request.setRevision(request.getRevision());
     this.request.setDisableLastCommit(true);
-    this.request.setLimit(Integer.MAX_VALUE);
+    this.request.setLimit(2);
 
     List<FileObject> collapsedChildren = new ArrayList<>();
     for (FileObject child : fo.getChildren()) {

--- a/scm-core/src/main/java/sonia/scm/repository/spi/BrowseCommandRequest.java
+++ b/scm-core/src/main/java/sonia/scm/repository/spi/BrowseCommandRequest.java
@@ -53,7 +53,7 @@ public final class BrowseCommandRequest extends FileBaseCommandRequest {
   private final transient Consumer<BrowserResult> updater;
 
   private int offset;
-  private boolean collpase;
+  private boolean collapse;
 
   public BrowseCommandRequest() {
     this(null);
@@ -65,7 +65,7 @@ public final class BrowseCommandRequest extends FileBaseCommandRequest {
 
   @Override
   public BrowseCommandRequest clone() {
-    BrowseCommandRequest clone = null;
+    BrowseCommandRequest clone;
 
     try {
       clone = (BrowseCommandRequest) super.clone();
@@ -185,8 +185,8 @@ public final class BrowseCommandRequest extends FileBaseCommandRequest {
    * @return {@code true} if empty folders are collapsed, otherwise {@code false}
    * @since 2.30.3
    */
-  public boolean isCollapsed() {
-    return collpase;
+  public boolean isCollapse() {
+    return collapse;
   }
 
   /**
@@ -196,7 +196,7 @@ public final class BrowseCommandRequest extends FileBaseCommandRequest {
    * @since 2.30.3
    */
   public void setCollapse(boolean collapse) {
-    this.collpase = collapse;
+    this.collapse = collapse;
   }
 
   public void updateCache(BrowserResult update) {

--- a/scm-core/src/main/java/sonia/scm/repository/spi/BrowseCommandRequest.java
+++ b/scm-core/src/main/java/sonia/scm/repository/spi/BrowseCommandRequest.java
@@ -31,19 +31,29 @@ import sonia.scm.repository.BrowserResult;
 import java.util.function.Consumer;
 
 /**
- *
  * @author Sebastian Sdorra
  * @since 1.17
  */
 @EqualsAndHashCode(callSuper = true)
 @ToString
-public final class BrowseCommandRequest extends FileBaseCommandRequest
-{
+public final class BrowseCommandRequest extends FileBaseCommandRequest {
 
   public static final int DEFAULT_REQUEST_LIMIT = 100;
 
   private static final long serialVersionUID = 7956624623516803183L;
+
+  private boolean disableLastCommit = false;
+  private boolean disableSubRepositoryDetection = false;
+  private boolean recursive = false;
+  private int limit = DEFAULT_REQUEST_LIMIT;
+
+  // WARNING / TODO: This field creates a reverse channel from the implementation to the API. This will break
+  // whenever the API runs in a different process than the SPI (for example to run explicit hosts for git repositories).
+  @EqualsAndHashCode.Exclude
+  private final transient Consumer<BrowserResult> updater;
+
   private int offset;
+  private boolean collpase;
 
   public BrowseCommandRequest() {
     this(null);
@@ -54,16 +64,12 @@ public final class BrowseCommandRequest extends FileBaseCommandRequest
   }
 
   @Override
-  public BrowseCommandRequest clone()
-  {
+  public BrowseCommandRequest clone() {
     BrowseCommandRequest clone = null;
 
-    try
-    {
+    try {
       clone = (BrowseCommandRequest) super.clone();
-    }
-    catch (CloneNotSupportedException e)
-    {
+    } catch (CloneNotSupportedException e) {
 
       // this shouldn't happen, since we are Cloneable
       throw new InternalError("CatCommandRequest seems not to be cloneable");
@@ -73,54 +79,92 @@ public final class BrowseCommandRequest extends FileBaseCommandRequest
   }
 
   /**
-   * True to disable the last commit.
+   * Returns true if the last commit is disabled.
    *
-   *
-   * @param disableLastCommit true to disable the last commit
-   *
+   * @return true if the last commit is disabled
    * @since 1.26
    */
-  public void setDisableLastCommit(boolean disableLastCommit)
-  {
+  public boolean isDisableLastCommit() {
+    return disableLastCommit;
+  }
+
+  /**
+   * True to disable the last commit.
+   *
+   * @param disableLastCommit true to disable the last commit
+   * @since 1.26
+   */
+  public void setDisableLastCommit(boolean disableLastCommit) {
     this.disableLastCommit = disableLastCommit;
+  }
+
+  /**
+   * Returns true if the detection of sub repositories is disabled.
+   *
+   * @return true if sub repository detection is disabled.
+   * @since 1.26
+   */
+  public boolean isDisableSubRepositoryDetection() {
+    return disableSubRepositoryDetection;
   }
 
   /**
    * Enable or Disable sub repository detection. Default is enabled.
    *
-   *
    * @param disableSubRepositoryDetection true to disable sub repository detection
-   *
    * @since 1.26
    */
   public void setDisableSubRepositoryDetection(
-    boolean disableSubRepositoryDetection)
-  {
+    boolean disableSubRepositoryDetection) {
     this.disableSubRepositoryDetection = disableSubRepositoryDetection;
+  }
+
+  /**
+   * Returns true if recursive file object browsing is enabled.
+   *
+   * @return true recursive is enabled
+   * @since 1.26
+   */
+  public boolean isRecursive() {
+    return recursive;
   }
 
   /**
    * True to enable recursive file object browsing.
    *
-   *
    * @param recursive true to enable recursive browsing
-   *
    * @since 1.26
    */
-  public void setRecursive(boolean recursive)
-  {
+  public void setRecursive(boolean recursive) {
     this.recursive = recursive;
+  }
+
+  /**
+   * Returns the limit for the number of result files.
+   *
+   * @since 2.0.0
+   */
+  public int getLimit() {
+    return limit;
   }
 
   /**
    * Limit the number of result files to <code>limit</code> entries.
    *
    * @param limit The maximal number of files this request shall return.
-   *
    * @since 2.0.0
    */
   public void setLimit(int limit) {
     this.limit = limit;
+  }
+
+  /**
+   * The number of the entry, the result start with. All preceding entries will be omitted.
+   *
+   * @since 2.0.0
+   */
+  public int getOffset() {
+    return offset;
   }
 
   /**
@@ -134,63 +178,25 @@ public final class BrowseCommandRequest extends FileBaseCommandRequest
     this.offset = offset;
   }
 
-  //~--- get methods ----------------------------------------------------------
-
   /**
-   * Returns true if the last commit is disabled.
+   * Returns whether empty folders are collapsed until a folder has content and return the path to such folder as a
+   * single item or not.
    *
-   *
-   * @return true if the last commit is disabled
-   *
-   * @since 1.26
+   * @return {@code true} if empty folders are collapsed, otherwise {@code false}
+   * @since 2.30.3
    */
-  public boolean isDisableLastCommit()
-  {
-    return disableLastCommit;
+  public boolean isCollapsed() {
+    return collpase;
   }
 
   /**
-   * Returns true if the detection of sub repositories is disabled.
+   * Collapse empty folders until a folder has content and return the path to such folder as a single item.
    *
-   *
-   * @return true if sub repository detection is disabled.
-   *
-   * @since 1.26
+   * @param collapse {@code true} if empty folders should be collapsed, otherwise {@code false}.
+   * @since 2.30.3
    */
-  public boolean isDisableSubRepositoryDetection()
-  {
-    return disableSubRepositoryDetection;
-  }
-
-  /**
-   * Returns true if recursive file object browsing is enabled.
-   *
-   *
-   * @return true recursive is enabled
-   *
-   * @since 1.26
-   */
-  public boolean isRecursive()
-  {
-    return recursive;
-  }
-
-  /**
-   * Returns the limit for the number of result files.
-   *
-   * @since 2.0.0
-   */
-  public int getLimit() {
-    return limit;
-  }
-
-  /**
-   * The number of the entry, the result start with. All preceding entries will be omitted.
-   *
-   * @since 2.0.0
-   */
-  public int getOffset() {
-    return offset;
+  public void setCollapse(boolean collapse) {
+    this.collpase = collapse;
   }
 
   public void updateCache(BrowserResult update) {
@@ -199,23 +205,4 @@ public final class BrowseCommandRequest extends FileBaseCommandRequest
     }
   }
 
-  //~--- fields ---------------------------------------------------------------
-
-  /** disable last commit */
-  private boolean disableLastCommit = false;
-
-  /** disable detection of sub repositories */
-  private boolean disableSubRepositoryDetection = false;
-
-  /** browse file objects recursive */
-  private boolean recursive = false;
-
-
-  /** Limit the number of result files to <code>limit</code> entries. */
-  private int limit = DEFAULT_REQUEST_LIMIT;
-
-  // WARNING / TODO: This field creates a reverse channel from the implementation to the API. This will break
-  // whenever the API runs in a different process than the SPI (for example to run explicit hosts for git repositories).
-  @EqualsAndHashCode.Exclude
-  private final transient Consumer<BrowserResult> updater;
 }

--- a/scm-core/src/test/java/sonia/scm/repository/api/BrowserResultCollapserTest.java
+++ b/scm-core/src/test/java/sonia/scm/repository/api/BrowserResultCollapserTest.java
@@ -1,0 +1,179 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package sonia.scm.repository.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+import sonia.scm.repository.BrowserResult;
+import sonia.scm.repository.FileObject;
+import sonia.scm.repository.spi.BrowseCommand;
+import sonia.scm.repository.spi.BrowseCommandRequest;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BrowserResultCollapserTest {
+
+  @Mock
+  private BrowseCommand browseCommand;
+
+  private Map<String, FileObject> browseResults;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    browseResults = new HashMap<>();
+    when(browseCommand.getBrowserResult(any(BrowseCommandRequest.class)))
+      .thenAnswer(
+        (Answer<BrowserResult>) invocation -> {
+          BrowseCommandRequest request = (BrowseCommandRequest) invocation.getArguments()[0];
+          return createBrowserResult(browseResults.get(request.getPath()));
+        }
+      );
+  }
+
+  @Test
+  void collapseFoldersShouldNotCollapseNonEmptyFolders() throws Exception {
+    FileObject root = createFolder(null, "");
+
+    FileObject not_empty_1A = createFolder(root, "not_empty_1A");
+    createFile(not_empty_1A);
+
+    FileObject not_empty_1B = createFolder(root, "not_empty_1B");
+    createFile(not_empty_1B);
+
+    BrowserResult result = new BrowserResult("revision", root);
+    BrowseCommandRequest request = new BrowseCommandRequest();
+
+    new BrowserResultCollapser().collapseFolders(browseCommand, request, result.getFile());
+
+    FileObject f = result.getFile();
+    Collection<FileObject> children = f.getChildren();
+    assertThat(children.size()).isEqualTo(2);
+    assertThat(contains(children, "not_empty_1A", "not_empty_1A")).isTrue();
+    assertThat(contains(children, "not_empty_1B", "not_empty_1B")).isTrue();
+  }
+
+  @Test
+  void collapseFoldersShouldCollapseSimpleEmptyFolders() throws Exception {
+    FileObject root = createFolder(null, "");
+
+    FileObject not_empty_1A = createFolder(root, "not_empty_1A");
+    createFile(not_empty_1A);
+
+    FileObject empty_1A = createFolder(root, "empty_1A");
+    FileObject not_empty_2A = createFolder(empty_1A, "not_empty_2A");
+    createFile(not_empty_2A);
+
+    BrowserResult result = new BrowserResult("revision", root);
+    BrowseCommandRequest request = new BrowseCommandRequest();
+
+    new BrowserResultCollapser().collapseFolders(browseCommand, request, result.getFile());
+
+    FileObject f = result.getFile();
+    Collection<FileObject> children = f.getChildren();
+    assertThat(children.size()).isEqualTo(2);
+    assertThat(contains(children, "not_empty_1A", "not_empty_1A")).isTrue();
+    assertThat(contains(children, "empty_1A/not_empty_2A", "empty_1A/not_empty_2A")).isTrue();
+  }
+
+  @Test
+  void collapseFoldersShouldCollapseComplexEmptyFolders() throws Exception {
+    FileObject root = createFolder(null, "");
+
+    FileObject not_empty_1A = createFolder(root, "not_empty_1A");
+    createFile(not_empty_1A);
+
+    FileObject empty_1A = createFolder(root, "empty_1A");
+    FileObject empty_2A = createFolder(empty_1A, "empty_2A");
+    FileObject not_empty_3A = createFolder(empty_2A, "not_empty_3A");
+    createFile(not_empty_3A);
+    FileObject empty_2B = createFolder(empty_1A, "empty_2B");
+    FileObject empty_3A = createFolder(empty_2B, "empty_3A");
+    FileObject not_empty_4A = createFolder(empty_3A, "not_empty_4A");
+    createFile(not_empty_4A);
+
+    FileObject empty_1B = createFolder(root, "empty_1B");
+    FileObject not_empty_2A = createFolder(empty_1B, "not_empty_2A");
+    createFile(not_empty_2A);
+
+    BrowserResult result = new BrowserResult("revision", root);
+    BrowseCommandRequest request = new BrowseCommandRequest();
+
+    new BrowserResultCollapser().collapseFolders(browseCommand, request, result.getFile());
+
+    FileObject f = result.getFile();
+    Collection<FileObject> children = f.getChildren();
+    assertThat(children.size()).isEqualTo(4);
+    assertThat(contains(children, "not_empty_1A", "not_empty_1A")).isTrue();
+    assertThat(contains(children, "empty_1A/empty_2A/not_empty_3A", "empty_1A/empty_2A/not_empty_3A")).isTrue();
+    assertThat(contains(children, "empty_1A/empty_2B/empty_3A/not_empty_4A", "empty_1A/empty_2B/empty_3A/not_empty_4A")).isTrue();
+    assertThat(contains(children, "empty_1B/not_empty_2A", "empty_1B/not_empty_2A")).isTrue();
+  }
+
+  private boolean contains(Collection<FileObject> children, String name, String path) {
+    return children.stream().anyMatch(c -> c.getName().equals(name) && c.getPath().equals(path));
+  }
+
+  private BrowserResult createBrowserResult(FileObject f) {
+    return new BrowserResult("revision", f);
+  }
+
+  private FileObject createFolder(FileObject parent, String name) {
+    FileObject f = createFileObject(parent, name);
+    f.setDirectory(true);
+    if (parent != null) {
+      parent.addChild(f);
+    }
+    return f;
+  }
+
+  private void createFile(FileObject parent) {
+    FileObject f = createFileObject(parent, "test.txt");
+    f.setDirectory(false);
+    if (parent != null) {
+      parent.addChild(f);
+    }
+  }
+
+  private FileObject createFileObject(FileObject parent, String name) {
+    FileObject f = new FileObject();
+    f.setName(name);
+    String path = (parent != null && !parent.getPath().equals("") ? parent.getPath() + "/" : "") + name;
+    f.setPath(path);
+    browseResults.put(path, f);
+    return f;
+  }
+
+}

--- a/scm-core/src/test/java/sonia/scm/repository/api/BrowserResultCollapserTest.java
+++ b/scm-core/src/test/java/sonia/scm/repository/api/BrowserResultCollapserTest.java
@@ -89,7 +89,7 @@ class BrowserResultCollapserTest {
 
     FileObject f = result.getFile();
     Collection<FileObject> children = f.getChildren();
-    assertThat(children.size()).isEqualTo(2);
+    assertThat(children).hasSize(2);
     assertContains(children, "folder_a", "folder_a");
     assertContains(children, "folder_b", "folder_b");
   }
@@ -120,7 +120,7 @@ class BrowserResultCollapserTest {
 
     FileObject f = result.getFile();
     Collection<FileObject> children = f.getChildren();
-    assertThat(children.size()).isEqualTo(2);
+    assertThat(children).hasSize(2);
     assertContains(children, "folder_a", "folder_a");
     assertContains(children, "folder_b/subfolder", "folder_b/subfolder");
   }
@@ -165,7 +165,7 @@ class BrowserResultCollapserTest {
 
     FileObject f = result.getFile();
     Collection<FileObject> children = f.getChildren();
-    assertThat(children.size()).isEqualTo(4);
+    assertThat(children).hasSize(4);
     assertContains(children, "folder_a", "folder_a");
     assertContains(children, "folder_b", "folder_b");
     assertContains(children, "folder_c/subfolder_b", "folder_c/subfolder_b");
@@ -197,7 +197,7 @@ class BrowserResultCollapserTest {
 
     FileObject f = result.getFile();
     Collection<FileObject> children = f.getChildren();
-    assertThat(children.size()).isEqualTo(2);
+    assertThat(children).hasSize(2);
     assertContains(children, "folder_a", "folder_a");
     assertContains(children, "folder_b", "folder_b");
   }
@@ -260,16 +260,16 @@ class BrowserResultCollapserTest {
 
     FileObject f = result.getFile();
     Collection<FileObject> children = f.getChildren();
-    assertThat(children.size()).isEqualTo(3);
+    assertThat(children).hasSize(3);
     assertContains(children, "src/main/java/sonia/scm/server", "scm-server/src/main/java/sonia/scm/server");
     assertContains(children, "build.gradle", "scm-server/build.gradle");
     assertContains(children, "gradle.lockfile", "scm-server/gradle.lockfile");
   }
 
   private void assertContains(Collection<FileObject> children, String name, String path) {
-    assertThat(children.stream().anyMatch(c -> c.getName().equals(name) && c.getPath().equals(path)))
+    assertThat(children)
       .as("%s not found", name)
-      .isTrue();
+      .anyMatch(c -> c.getName().equals(name) && c.getPath().equals(path));
   }
 
   private BrowserResult createBrowserResult(FileObject f) {

--- a/scm-core/src/test/java/sonia/scm/repository/api/BrowserResultCollapserTest.java
+++ b/scm-core/src/test/java/sonia/scm/repository/api/BrowserResultCollapserTest.java
@@ -32,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
 import sonia.scm.repository.BrowserResult;
 import sonia.scm.repository.FileObject;
+import sonia.scm.repository.SubRepository;
 import sonia.scm.repository.spi.BrowseCommand;
 import sonia.scm.repository.spi.BrowseCommandRequest;
 
@@ -41,6 +42,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -63,15 +65,22 @@ class BrowserResultCollapserTest {
       );
   }
 
+  /*
+    /
+    ├─ folder_a
+    │  └─ file
+    └─ folder_b
+       └─ file
+   */
   @Test
-  void collapseFoldersShouldNotCollapseNonEmptyFolders() throws Exception {
+  void collapseFoldersShouldNotCollapseNonEmptyFolder() throws Exception {
     FileObject root = createFolder(null, "");
 
-    FileObject not_empty_1A = createFolder(root, "not_empty_1A");
-    createFile(not_empty_1A);
+    FileObject folder_a = createFolder(root, "folder_a");
+    createFile(folder_a);
 
-    FileObject not_empty_1B = createFolder(root, "not_empty_1B");
-    createFile(not_empty_1B);
+    FileObject folder_b = createFolder(root, "folder_b");
+    createFile(folder_b);
 
     BrowserResult result = new BrowserResult("revision", root);
     BrowseCommandRequest request = new BrowseCommandRequest();
@@ -81,20 +90,28 @@ class BrowserResultCollapserTest {
     FileObject f = result.getFile();
     Collection<FileObject> children = f.getChildren();
     assertThat(children.size()).isEqualTo(2);
-    assertThat(contains(children, "not_empty_1A", "not_empty_1A")).isTrue();
-    assertThat(contains(children, "not_empty_1B", "not_empty_1B")).isTrue();
+    assertContains(children, "folder_a", "folder_a");
+    assertContains(children, "folder_b", "folder_b");
   }
 
+  /*
+    /
+    ├─ folder_a
+    │  └─ file
+    └─ folder_b
+       └─ subfolder
+          └─ file
+   */
   @Test
-  void collapseFoldersShouldCollapseSimpleEmptyFolders() throws Exception {
+  void collapseFoldersShouldCollapseFolderWithJustOneSubFolder() throws Exception {
     FileObject root = createFolder(null, "");
 
-    FileObject not_empty_1A = createFolder(root, "not_empty_1A");
-    createFile(not_empty_1A);
+    FileObject folder_a = createFolder(root, "folder_a");
+    createFile(folder_a);
 
-    FileObject empty_1A = createFolder(root, "empty_1A");
-    FileObject not_empty_2A = createFolder(empty_1A, "not_empty_2A");
-    createFile(not_empty_2A);
+    FileObject folder_b = createFolder(root, "folder_b");
+    FileObject subfolder = createFolder(folder_b, "subfolder");
+    createFile(subfolder);
 
     BrowserResult result = new BrowserResult("revision", root);
     BrowseCommandRequest request = new BrowseCommandRequest();
@@ -104,29 +121,42 @@ class BrowserResultCollapserTest {
     FileObject f = result.getFile();
     Collection<FileObject> children = f.getChildren();
     assertThat(children.size()).isEqualTo(2);
-    assertThat(contains(children, "not_empty_1A", "not_empty_1A")).isTrue();
-    assertThat(contains(children, "empty_1A/not_empty_2A", "empty_1A/not_empty_2A")).isTrue();
+    assertContains(children, "folder_a", "folder_a");
+    assertContains(children, "folder_b/subfolder", "folder_b/subfolder");
   }
 
+  /*
+    /
+    ├─ folder_a
+    │  └─ file
+    ├─ folder_b
+    │  ├─ subfolder_a
+    │  │  └─ subfolder_a_subfolder
+    │  │     └─ file
+    │  └─ subfolder_b
+    └─ folder_c
+       └─ subfolder_a
+          └─ file
+   */
   @Test
-  void collapseFoldersShouldCollapseComplexEmptyFolders() throws Exception {
+  void collapseFoldersShouldNotCollapseFolderWithMoreThanSingleSubFolder() throws Exception {
     FileObject root = createFolder(null, "");
 
-    FileObject not_empty_1A = createFolder(root, "not_empty_1A");
-    createFile(not_empty_1A);
+    FileObject folder_a = createFolder(root, "folder_a");
+    createFile(folder_a);
 
-    FileObject empty_1A = createFolder(root, "empty_1A");
-    FileObject empty_2A = createFolder(empty_1A, "empty_2A");
-    FileObject not_empty_3A = createFolder(empty_2A, "not_empty_3A");
-    createFile(not_empty_3A);
-    FileObject empty_2B = createFolder(empty_1A, "empty_2B");
-    FileObject empty_3A = createFolder(empty_2B, "empty_3A");
-    FileObject not_empty_4A = createFolder(empty_3A, "not_empty_4A");
-    createFile(not_empty_4A);
+    FileObject folder_b = createFolder(root, "folder_b");
+    FileObject subfolder_a = createFolder(folder_b, "subfolder_a");
+    FileObject subfolder_a_subfolder = createFolder(subfolder_a, "subfolder_a_subfolder");
+    createFile(subfolder_a_subfolder);
+    createFolder(folder_b, "subfolder_b");
 
-    FileObject empty_1B = createFolder(root, "empty_1B");
-    FileObject not_empty_2A = createFolder(empty_1B, "not_empty_2A");
-    createFile(not_empty_2A);
+    FileObject folder_c = createFolder(root, "folder_c");
+    FileObject subfolder_b = createFolder(folder_c, "subfolder_b");
+    createFile(subfolder_b);
+
+    FileObject folder_d = createFolder(root, "folder_d");
+    createFolder(folder_d, "subfolder_c");
 
     BrowserResult result = new BrowserResult("revision", root);
     BrowseCommandRequest request = new BrowseCommandRequest();
@@ -136,14 +166,110 @@ class BrowserResultCollapserTest {
     FileObject f = result.getFile();
     Collection<FileObject> children = f.getChildren();
     assertThat(children.size()).isEqualTo(4);
-    assertThat(contains(children, "not_empty_1A", "not_empty_1A")).isTrue();
-    assertThat(contains(children, "empty_1A/empty_2A/not_empty_3A", "empty_1A/empty_2A/not_empty_3A")).isTrue();
-    assertThat(contains(children, "empty_1A/empty_2B/empty_3A/not_empty_4A", "empty_1A/empty_2B/empty_3A/not_empty_4A")).isTrue();
-    assertThat(contains(children, "empty_1B/not_empty_2A", "empty_1B/not_empty_2A")).isTrue();
+    assertContains(children, "folder_a", "folder_a");
+    assertContains(children, "folder_b", "folder_b");
+    assertContains(children, "folder_c/subfolder_b", "folder_c/subfolder_b");
+    assertContains(children, "folder_d/subfolder_c", "folder_d/subfolder_c");
   }
 
-  private boolean contains(Collection<FileObject> children, String name, String path) {
-    return children.stream().anyMatch(c -> c.getName().equals(name) && c.getPath().equals(path));
+  /*
+    /
+    ├─ folder_a
+    │  └─ file
+    └─ folder_b
+       └─ subrepository
+   */
+  @Test
+  void collapseFoldersShouldNotCollapseSubRepositoryFolder() throws Exception {
+    FileObject root = createFolder(null, "");
+
+    FileObject folder_a = createFolder(root, "folder_a");
+    createFile(folder_a);
+
+    FileObject folder_b = createFolder(root, "folder_b");
+    FileObject subfolder = createFolder(folder_b, "subfolder");
+    subfolder.setSubRepository(mock(SubRepository.class));
+
+    BrowserResult result = new BrowserResult("revision", root);
+    BrowseCommandRequest request = new BrowseCommandRequest();
+
+    new BrowserResultCollapser().collapseFolders(browseCommand, request, result.getFile());
+
+    FileObject f = result.getFile();
+    Collection<FileObject> children = f.getChildren();
+    assertThat(children.size()).isEqualTo(2);
+    assertContains(children, "folder_a", "folder_a");
+    assertContains(children, "folder_b", "folder_b");
+  }
+
+  /*
+    /
+    ├─ scm-plugins
+    │  ├─ build.gradle
+    │  └─ gradle.lockfile
+    ├─ scm-server
+    │  ├─ src
+    │  │  └─ main
+    │  │     └─ java
+    │  │        └─ sonia
+    │  │           └─ scm
+    │  │              └─ server
+    │  │                 ├─ ScmServer.java
+    │  │                 ├─ ScmServerDaemon.java
+    │  │                 └─ ScmServerException.java
+    │  ├─ build.gradle
+    │  └─ gradle.lockfile
+    ├─ scm-test
+    │  ├─ build.gradle
+    │  └─ gradle.lockfile
+    ├─ .dockerignore
+    └─ .editorconfig
+   */
+  @Test
+  void collapseFoldersShouldWorkProperlyWithRealLifeExample() throws Exception {
+    FileObject root = createFolder(null, "");
+
+    FileObject scmPlugins = createFolder(root, "scm-plugins");
+    createFile(scmPlugins, "build.gradle");
+    createFile(scmPlugins, "gradle.lockfile");
+
+    FileObject scmServer = createFolder(root, "scm-server");
+    FileObject src = createFolder(scmServer, "src");
+    FileObject main = createFolder(src, "main");
+    FileObject java = createFolder(main, "java");
+    FileObject sonia = createFolder(java, "sonia");
+    FileObject scm = createFolder(sonia, "scm");
+    FileObject server = createFolder(scm, "server");
+    createFile(server, "ScmServer.java");
+    createFile(server, "ScmServerDaemon.java");
+    createFile(server, "ScmServerException.java");
+    createFile(scmServer, "build.gradle");
+    createFile(scmServer, "gradle.lockfile");
+
+    FileObject scmTest = createFolder(root, "scm-test");
+    createFile(scmTest, "build.gradle");
+    createFile(scmTest, "gradle.lockfile");
+
+    createFile(root, ".dockerignore");
+    createFile(root, ".editorconfig");
+
+    BrowserResult result = new BrowserResult("revision", scmServer);
+    BrowseCommandRequest request = new BrowseCommandRequest();
+
+    new BrowserResultCollapser().collapseFolders(browseCommand, request, result.getFile());
+
+    FileObject f = result.getFile();
+    Collection<FileObject> children = f.getChildren();
+    assertThat(children.size()).isEqualTo(3);
+    assertContains(children, "src/main/java/sonia/scm/server", "scm-server/src/main/java/sonia/scm/server");
+    assertContains(children, "build.gradle", "scm-server/build.gradle");
+    assertContains(children, "gradle.lockfile", "scm-server/gradle.lockfile");
+  }
+
+  private void assertContains(Collection<FileObject> children, String name, String path) {
+    assertThat(children.stream().anyMatch(c -> c.getName().equals(name) && c.getPath().equals(path)))
+      .as("%s not found", name)
+      .isTrue();
   }
 
   private BrowserResult createBrowserResult(FileObject f) {
@@ -160,7 +286,11 @@ class BrowserResultCollapserTest {
   }
 
   private void createFile(FileObject parent) {
-    FileObject f = createFileObject(parent, "test.txt");
+    createFile(parent, "file");
+  }
+
+  private void createFile(FileObject parent, String name) {
+    FileObject f = createFileObject(parent, name);
     f.setDirectory(false);
     if (parent != null) {
       parent.addChild(f);

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitBrowseCommand.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/GitBrowseCommand.java
@@ -128,6 +128,8 @@ public class GitBrowseCommand extends AbstractGitCommand
     throws IOException {
     logger.debug("try to create browse result for {}", request);
 
+    resultCount = 0;
+
     this.request = request;
     repo = open();
     revId = computeRevIdToBrowse();

--- a/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/spi/javahg/HgFileviewCommand.java
+++ b/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/spi/javahg/HgFileviewCommand.java
@@ -167,7 +167,11 @@ public class HgFileviewCommand extends AbstractCommand
 
     HgInputStream stream = launchStream();
 
-    return new HgFileviewCommandResultReader(stream, disableLastCommit).parseResult();
+    try {
+      return new HgFileviewCommandResultReader(stream, disableLastCommit).parseResult();
+    } finally {
+      stream.close();
+    }
   }
 
   /**

--- a/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/spi/HgBrowseCommandTest.java
+++ b/scm-plugins/scm-hg-plugin/src/test/java/sonia/scm/repository/spi/HgBrowseCommandTest.java
@@ -192,6 +192,23 @@ public class HgBrowseCommandTest extends AbstractHgCommandTestBase {
   }
 
   @Test
+  public void testMultipleCallsOfSameRequest() throws IOException {
+    BrowseCommandRequest request = new BrowseCommandRequest();
+    request.setLimit(1);
+
+    for (int i = 0; i < 5; ++i) {
+      HgBrowseCommand hgBrowseCommand = new HgBrowseCommand(cmdContext);
+      BrowserResult result = hgBrowseCommand.getBrowserResult(request);
+      FileObject root = result.getFile();
+
+      Collection<FileObject> foList = root.getChildren();
+
+      assertThat(foList).extracting("name").containsExactly("c", "a.txt");
+      assertThat(root.isTruncated()).isTrue();
+    }
+  }
+
+  @Test
   public void testOffset() throws IOException {
     BrowseCommandRequest request = new BrowseCommandRequest();
     request.setLimit(2);

--- a/scm-plugins/scm-svn-plugin/src/main/java/sonia/scm/repository/spi/SvnBrowseCommand.java
+++ b/scm-plugins/scm-svn-plugin/src/main/java/sonia/scm/repository/spi/SvnBrowseCommand.java
@@ -80,6 +80,8 @@ public class SvnBrowseCommand extends AbstractSvnCommand
       logger.debug("browser repository {} in path \"{}\" at revision {}", repository, path, revisionNumber);
     }
 
+    resultCount = 0;
+
     BrowserResult result = null;
 
     try {

--- a/scm-ui/ui-api/src/sources.test.ts
+++ b/scm-ui/ui-api/src/sources.test.ts
@@ -126,7 +126,7 @@ describe("Test sources hooks", () => {
   describe("useSources tests", () => {
     it("should return root directory", async () => {
       const queryClient = createInfiniteCachingClient();
-      fetchMock.getOnce("/api/v2/src", rootDirectory);
+      fetchMock.getOnce("/api/v2/src?collapse=true", rootDirectory);
       const { result, waitFor } = renderHook(() => useSources(puzzle42), {
         wrapper: createWrapper(undefined, queryClient),
       });
@@ -136,7 +136,7 @@ describe("Test sources hooks", () => {
 
     it("should return file from url with revision and path", async () => {
       const queryClient = createInfiniteCachingClient();
-      fetchMock.getOnce("/api/v2/src/abc/README.md", readmeMd);
+      fetchMock.getOnce("/api/v2/src/abc/README.md?collapse=true", readmeMd);
       const { result, waitFor } = renderHook(() => useSources(puzzle42, { revision: "abc", path: "README.md" }), {
         wrapper: createWrapper(undefined, queryClient),
       });
@@ -146,7 +146,7 @@ describe("Test sources hooks", () => {
 
     it("should fetch next page", async () => {
       const queryClient = createInfiniteCachingClient();
-      fetchMock.getOnce("/api/v2/src", mainDirectoryTruncated);
+      fetchMock.getOnce("/api/v2/src?collapse=true", mainDirectoryTruncated);
       fetchMock.getOnce("/api/v2/src/2", mainDirectory);
       const { result, waitFor, waitForNextUpdate } = renderHook(() => useSources(puzzle42), {
         wrapper: createWrapper(undefined, queryClient),
@@ -168,7 +168,7 @@ describe("Test sources hooks", () => {
     it("should refetch if partial files exists", async () => {
       const queryClient = createInfiniteCachingClient();
       fetchMock.get(
-        "/api/v2/src",
+        "/api/v2/src?collapse=true",
         {
           ...mainDirectory,
           _embedded: {
@@ -180,7 +180,7 @@ describe("Test sources hooks", () => {
         }
       );
       fetchMock.get(
-        "/api/v2/src",
+        "/api/v2/src?collapse=true",
         {
           ...mainDirectory,
           _embedded: {
@@ -206,9 +206,9 @@ describe("Test sources hooks", () => {
 
     it("should not refetch if computation is aborted", async () => {
       const queryClient = createInfiniteCachingClient();
-      fetchMock.getOnce("/api/v2/src/abc/main/special.md", sepecialMdComputationAborted, { repeat: 1 });
+      fetchMock.getOnce("/api/v2/src/abc/main/special.md?collapse=true", sepecialMdComputationAborted, { repeat: 1 });
       // should never be called
-      fetchMock.getOnce("/api/v2/src/abc/main/special.md", sepecialMd, {
+      fetchMock.getOnce("/api/v2/src/abc/main/special.md?collapse=true", sepecialMd, {
         repeat: 1,
         overwriteRoutes: false,
       });

--- a/scm-ui/ui-api/src/sources.ts
+++ b/scm-ui/ui-api/src/sources.ts
@@ -28,17 +28,20 @@ import * as urls from "./urls";
 import { useInfiniteQuery } from "react-query";
 import { repoQueryKey } from "./keys";
 import { useEffect } from "react";
+import { createQueryString } from "./utils";
 
 export type UseSourcesOptions = {
   revision?: string;
   path?: string;
   refetchPartialInterval?: number;
   enabled?: boolean;
+  collapse?: boolean;
 };
 
 const UseSourcesDefaultOptions: UseSourcesOptions = {
   enabled: true,
   refetchPartialInterval: 3000,
+  collapse: true
 };
 
 export const useSources = (repository: Repository, opts: UseSourcesOptions = UseSourcesDefaultOptions) => {
@@ -48,7 +51,7 @@ export const useSources = (repository: Repository, opts: UseSourcesOptions = Use
   };
   const link = createSourcesLink(repository, options);
   const { isLoading, error, data, isFetchingNextPage, fetchNextPage, refetch } = useInfiniteQuery<File, Error, File>(
-    repoQueryKey(repository, "sources", options.revision || "", options.path || ""),
+    repoQueryKey(repository, "sources", options.revision || "", options.path || "", options.collapse ? "collapse" : ""),
     ({ pageParam }) => {
       return apiClient.get(pageParam || link).then((response) => response.json());
     },
@@ -92,6 +95,9 @@ const createSourcesLink = (repository: Repository, options: UseSourcesOptions) =
     if (options.path) {
       link = urls.concat(link, options.path);
     }
+  }
+  if (options.collapse) {
+    return `${link}?${createQueryString({ collapse: "true" })}`;
   }
   return link;
 };

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/SourceRootResource.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/SourceRootResource.java
@@ -60,32 +60,33 @@ public class SourceRootResource {
   @Path("")
   @Produces(VndMediaType.SOURCE)
   @Operation(summary = "List of sources", description = "Returns all sources for repository head.", tags = "Repository")
-  public FileObjectDto getAllWithoutRevision(@PathParam("namespace") String namespace, @PathParam("name") String name, @DefaultValue("0") @QueryParam("offset") int offset) throws IOException {
-    return getSource(namespace, name, "/", null, offset);
+  public FileObjectDto getAllWithoutRevision(@PathParam("namespace") String namespace, @PathParam("name") String name, @DefaultValue("0") @QueryParam("offset") int offset, @DefaultValue("false") @QueryParam("collapse") boolean collapse) throws IOException {
+    return getSource(namespace, name, "/", null, offset, collapse);
   }
 
   @GET
   @Path("{revision}")
   @Produces(VndMediaType.SOURCE)
   @Operation(summary = "List of sources by revision", description = "Returns all sources for the given revision.", tags = "Repository")
-  public FileObjectDto getAll(@PathParam("namespace") String namespace, @PathParam("name") String name, @PathParam("revision") String revision, @DefaultValue("0") @QueryParam("offset") int offset) throws IOException {
-    return getSource(namespace, name, "/", revision, offset);
+  public FileObjectDto getAll(@PathParam("namespace") String namespace, @PathParam("name") String name, @PathParam("revision") String revision, @DefaultValue("0") @QueryParam("offset") int offset, @DefaultValue("false") @QueryParam("collapse") boolean collapse) throws IOException {
+    return getSource(namespace, name, "/", revision, offset, collapse);
   }
 
   @GET
   @Path("{revision}/{path: .*}")
   @Produces(VndMediaType.SOURCE)
   @Operation(summary = "List of sources by revision in path", description = "Returns all sources for the given revision in a specific path.", tags = "Repository")
-  public FileObjectDto get(@PathParam("namespace") String namespace, @PathParam("name") String name, @PathParam("revision") String revision, @PathParam("path") String path, @DefaultValue("0") @QueryParam("offset") int offset) throws IOException {
-    return getSource(namespace, name, path, revision, offset);
+  public FileObjectDto get(@PathParam("namespace") String namespace, @PathParam("name") String name, @PathParam("revision") String revision, @PathParam("path") String path, @DefaultValue("0") @QueryParam("offset") int offset, @DefaultValue("false") @QueryParam("collapse") boolean collapse) throws IOException {
+    return getSource(namespace, name, path, revision, offset, collapse);
   }
 
-  private FileObjectDto getSource(String namespace, String repoName, String path, String revision, int offset) throws IOException {
+  private FileObjectDto getSource(String namespace, String repoName, String path, String revision, int offset, boolean collapse) throws IOException {
     NamespaceAndName namespaceAndName = new NamespaceAndName(namespace, repoName);
     try (RepositoryService repositoryService = serviceFactory.create(namespaceAndName)) {
       BrowseCommandBuilder browseCommand = repositoryService.getBrowseCommand();
       browseCommand.setPath(path);
       browseCommand.setOffset(offset);
+      browseCommand.setCollapse(collapse);
       if (revision != null && !revision.isEmpty()) {
         browseCommand.setRevision(revision);
       }

--- a/scm-webapp/src/test/java/sonia/scm/api/v2/resources/SourceRootResourceTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/api/v2/resources/SourceRootResourceTest.java
@@ -24,7 +24,6 @@
 
 package sonia.scm.api.v2.resources;
 
-import com.google.inject.util.Providers;
 import org.jboss.resteasy.mock.MockHttpRequest;
 import org.jboss.resteasy.mock.MockHttpResponse;
 import org.junit.Before;
@@ -49,11 +48,10 @@ import java.net.URISyntaxException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class SourceRootResourceTest extends RepositoryTestBase {
 
-  private RestDispatcher dispatcher = new RestDispatcher();
+  private final RestDispatcher dispatcher = new RestDispatcher();
   private final URI baseUri = URI.create("/");
   private final ResourceLinks resourceLinks = ResourceLinksMock.createMock(baseUri);
 
@@ -64,12 +62,9 @@ public class SourceRootResourceTest extends RepositoryTestBase {
   @Mock
   private BrowseCommandBuilder browseCommandBuilder;
 
-  private BrowserResultToFileObjectDtoMapper browserResultToFileObjectDtoMapper;
-
-
   @Before
   public void prepareEnvironment() {
-    browserResultToFileObjectDtoMapper = Mappers.getMapper(BrowserResultToFileObjectDtoMapper.class);
+    BrowserResultToFileObjectDtoMapper browserResultToFileObjectDtoMapper = Mappers.getMapper(BrowserResultToFileObjectDtoMapper.class);
     browserResultToFileObjectDtoMapper.setResourceLinks(resourceLinks);
     when(serviceFactory.create(new NamespaceAndName("space", "repo"))).thenReturn(service);
     when(service.getBrowseCommand()).thenReturn(browseCommandBuilder);
@@ -87,9 +82,9 @@ public class SourceRootResourceTest extends RepositoryTestBase {
 
     dispatcher.invoke(request, response);
     assertThat(response.getStatus()).isEqualTo(200);
-    System.out.println(response.getContentAsString());
-    assertThat(response.getContentAsString()).contains("\"revision\":\"revision\"");
-    assertThat(response.getContentAsString()).contains("\"children\":");
+    String content = response.getContentAsString();
+    assertThat(content).contains("\"revision\":\"revision\"");
+    assertThat(content).contains("\"children\":");
   }
 
   @Test

--- a/scm-webapp/src/test/java/sonia/scm/api/v2/resources/SourceRootResourceTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/api/v2/resources/SourceRootResourceTest.java
@@ -46,6 +46,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
@@ -122,6 +123,26 @@ public class SourceRootResourceTest extends RepositoryTestBase {
 
     dispatcher.invoke(request, response);
     assertThat(response.getStatus()).isEqualTo(404);
+  }
+
+  @Test
+  public void collapseShouldBeFalseByDefault() throws Exception {
+    MockHttpRequest request = MockHttpRequest.get("/" + RepositoryRootResource.REPOSITORIES_PATH_V2 + "space/repo/sources");
+    MockHttpResponse response = new MockHttpResponse();
+
+    dispatcher.invoke(request, response);
+
+    verify(browseCommandBuilder).setCollapse(false);
+  }
+
+  @Test
+  public void shouldSetCollapseToTrue() throws Exception {
+    MockHttpRequest request = MockHttpRequest.get("/" + RepositoryRootResource.REPOSITORIES_PATH_V2 + "space/repo/sources?collapse=true");
+    MockHttpResponse response = new MockHttpResponse();
+
+    dispatcher.invoke(request, response);
+
+    verify(browseCommandBuilder).setCollapse(true);
   }
 
   private BrowserResult createBrowserResult() {


### PR DESCRIPTION
## Proposed changes

Collapses a folder in code view which only has another folder as its only child. This lets you access a sub-folder which has content directly instead of navigating down the folder tree by clicking every folder separately.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
