### PR TITLE
Fix branch decoding in overview

### DIFF
--- a/gradle/changelog/branch_overview.yaml
+++ b/gradle/changelog/branch_overview.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Branch decoding in overview ([#1963](https://github.com/scm-manager/scm-manager/pull/1963))

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/BranchDetailsResource.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/BranchDetailsResource.java
@@ -169,7 +169,7 @@ public class BranchDetailsResource {
     @QueryParam("branches") List<@Length(min = 1, max = 100) @Pattern(regexp = VALID_BRANCH_NAMES) String> branches
   ) {
     try (RepositoryService service = serviceFactory.create(new NamespaceAndName(namespace, name))) {
-      List<BranchDetailsDto> dtos = getBranchDetailsDtos(service, decodeBranchNames(branches));
+      List<BranchDetailsDto> dtos = getBranchDetailsDtos(service, branches);
       Links links = Links.linkingTo().self(resourceLinks.branchDetailsCollection().self(namespace, name)).build();
       Embedded embedded = Embedded.embeddedBuilder().with("branchDetails", dtos).build();
 
@@ -193,9 +193,5 @@ public class BranchDetailsResource {
       }
     }
     return dtos;
-  }
-
-  private Collection<String> decodeBranchNames(Collection<String> branches) {
-    return branches.stream().map(HttpUtil::decode).collect(Collectors.toList());
   }
 }


### PR DESCRIPTION
## Proposed changes

Removes wrong additional decoding in branch overview. This decoding led to an error, because a branch like `some+branch` was decoded to `some branch` with a space instead of the plus sign leading to a 404 while loading the details.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
