### PR TITLE
Hide plugin dependencies on uninstall

### DIFF
--- a/gradle/changelog/delete_plugin_dependencies.yaml
+++ b/gradle/changelog/delete_plugin_dependencies.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Hide plugin dependencies on uninstall ([#1977](https://github.com/scm-manager/scm-manager/pull/1977))

--- a/scm-ui/ui-webapp/src/admin/plugins/components/PluginModal.tsx
+++ b/scm-ui/ui-webapp/src/admin/plugins/components/PluginModal.tsx
@@ -129,7 +129,7 @@ const PluginModal: FC<Props> = ({ onClose, pluginAction, plugin }) => {
 
   const renderDependencies = () => {
     let dependencies = null;
-    if (plugin.dependencies && plugin.dependencies.length > 0) {
+    if (pluginAction !== PluginAction.UNINSTALL && plugin.dependencies && plugin.dependencies.length > 0) {
       dependencies = (
         <div className="media">
           <Notification type="warning">
@@ -148,7 +148,11 @@ const PluginModal: FC<Props> = ({ onClose, pluginAction, plugin }) => {
 
   const renderOptionalDependencies = () => {
     let optionalDependencies = null;
-    if (plugin.optionalDependencies && plugin.optionalDependencies.length > 0) {
+    if (
+      pluginAction !== PluginAction.UNINSTALL &&
+      plugin.optionalDependencies &&
+      plugin.optionalDependencies.length > 0
+    ) {
       optionalDependencies = (
         <div className="media">
           <Notification type="warning">


### PR DESCRIPTION
## Proposed changes

When uninstalling a plugin, there should be no notification about installing or updating plugins.

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
