### PR TITLE
Remove plugin center login without url

### DIFF
--- a/gradle/changelog/remove_plugin_center_login_without_url.yaml
+++ b/gradle/changelog/remove_plugin_center_login_without_url.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Remove plugin center login without url ([#1978](https://github.com/scm-manager/scm-manager/pull/1978))

--- a/scm-ui/ui-api/src/config.ts
+++ b/scm-ui/ui-api/src/config.ts
@@ -46,6 +46,7 @@ export const useUpdateConfig = () => {
       onSuccess: async () => {
         await queryClient.invalidateQueries("config");
         await queryClient.invalidateQueries("index");
+        await queryClient.invalidateQueries("pluginCenterAuth");
       }
     }
   );

--- a/scm-ui/ui-webapp/public/locales/de/config.json
+++ b/scm-ui/ui-webapp/public/locales/de/config.json
@@ -21,7 +21,8 @@
       "authenticate": "Authentifizieren",
       "authenticated": "Das Plugin Center ist als <0 /> authentifiziert",
       "subjectTooltip": "Authentifiziert als {{ principal }} {{ ago }}",
-      "logout": "Abmelden"
+      "logout": "Abmelden",
+      "notConfiguredHint": "Authentifizierungs URL ist nicht gesetzt"
     }
   },
   "proxySettings": {

--- a/scm-ui/ui-webapp/public/locales/en/config.json
+++ b/scm-ui/ui-webapp/public/locales/en/config.json
@@ -21,7 +21,8 @@
       "authenticate": "Authenticate",
       "authenticated": "Plugin Center is authenticated as <0 />",
       "subjectTooltip": "Authenticated by {{ principal }} {{ ago }}",
-      "logout": "Logout"
+      "logout": "Logout",
+      "notConfiguredHint": "Authentication URL is not configured"
     }
   },
   "proxySettings": {

--- a/scm-ui/ui-webapp/src/admin/components/form/PluginCenterAuthentication.tsx
+++ b/scm-ui/ui-webapp/src/admin/components/form/PluginCenterAuthentication.tsx
@@ -91,7 +91,7 @@ const LoginButtonOrConfigurationHint: FC<{ link: Link | undefined }> = ({ link }
       </Button>
     );
   }
-  return <Message>{t("pluginSettings.auth.notConfiguredHint")}</Message>
+  return <Message>{t("pluginSettings.auth.notConfiguredHint")}</Message>;
 };
 
 const PluginCenterAuthentication: FC = () => {

--- a/scm-ui/ui-webapp/src/admin/components/form/PluginCenterAuthentication.tsx
+++ b/scm-ui/ui-webapp/src/admin/components/form/PluginCenterAuthentication.tsx
@@ -82,16 +82,13 @@ const AuthenticatedInfo: FC<Props> = ({ authenticationInfo }) => {
   );
 };
 
-const LoginButtonOrConfigurationHint: FC<{ link: Link | undefined }> = ({ link }) => {
+const LoginButton: FC<{ link: Link }> = ({ link }) => {
   const [t] = useTranslation("config");
-  if (link) {
-    return (
-      <Button color="primary" link={link.href}>
-        {t("pluginSettings.auth.authenticate")}
-      </Button>
-    );
-  }
-  return <Message>{t("pluginSettings.auth.notConfiguredHint")}</Message>;
+  return (
+    <Button color="primary" link={link.href}>
+      {t("pluginSettings.auth.authenticate")}
+    </Button>
+  );
 };
 
 const PluginCenterAuthentication: FC = () => {
@@ -119,12 +116,16 @@ const PluginCenterAuthentication: FC = () => {
     return <AuthenticatedInfo authenticationInfo={data} />;
   }
 
-  return (
-    <Notification type="inherit" className="is-flex is-justify-content-space-between is-align-content-center">
-      <Message>{t("pluginSettings.auth.notAuthenticated")}</Message>
-      <LoginButtonOrConfigurationHint link={data._links.login as Link} />
-    </Notification>
-  );
+  if (data._links.login) {
+    return (
+      <Notification type="inherit" className="is-flex is-justify-content-space-between is-align-content-center">
+        <Message>{t("pluginSettings.auth.notAuthenticated")}</Message>
+        <LoginButton link={data._links.login as Link} />
+      </Notification>
+    );
+  } else {
+    return null;
+  }
 };
 
 export default PluginCenterAuthentication;

--- a/scm-ui/ui-webapp/src/admin/components/form/PluginCenterAuthentication.tsx
+++ b/scm-ui/ui-webapp/src/admin/components/form/PluginCenterAuthentication.tsx
@@ -26,7 +26,6 @@ import React, { FC } from "react";
 import { usePluginCenterAuthInfo, usePluginCenterLogout } from "@scm-manager/ui-api";
 import { Button, ErrorNotification, Notification, Tooltip, useDateFormatter } from "@scm-manager/ui-components";
 import { Link, PluginCenterAuthenticationInfo } from "@scm-manager/ui-types";
-import { useLocation } from "react-router-dom";
 import styled from "styled-components";
 import { Trans, useTranslation } from "react-i18next";
 
@@ -85,7 +84,6 @@ const AuthenticatedInfo: FC<Props> = ({ authenticationInfo }) => {
 
 const PluginCenterAuthentication: FC = () => {
   const { data, isLoading, error } = usePluginCenterAuthInfo();
-  const location = useLocation();
   const [t] = useTranslation("config");
 
   if (isLoading) {
@@ -113,7 +111,7 @@ const PluginCenterAuthentication: FC = () => {
     <Notification type="inherit" className="is-flex is-justify-content-space-between is-align-content-center">
       <Message>{t("pluginSettings.auth.notAuthenticated")}</Message>
       {data._links.login ? (
-        <Button color="primary" link={(data._links.login as Link).href + "?source=" + location.pathname}>
+        <Button color="primary" link={(data._links.login as Link).href}>
           {t("pluginSettings.auth.authenticate")}
         </Button>
       ) : null}

--- a/scm-ui/ui-webapp/src/admin/components/form/PluginCenterAuthentication.tsx
+++ b/scm-ui/ui-webapp/src/admin/components/form/PluginCenterAuthentication.tsx
@@ -82,6 +82,18 @@ const AuthenticatedInfo: FC<Props> = ({ authenticationInfo }) => {
   );
 };
 
+const LoginButtonOrConfigurationHint: FC<{ link: Link | undefined }> = ({ link }) => {
+  const [t] = useTranslation("config");
+  if (link) {
+    return (
+      <Button color="primary" link={link.href}>
+        {t("pluginSettings.auth.authenticate")}
+      </Button>
+    );
+  }
+  return <Message>{t("pluginSettings.auth.notConfiguredHint")}</Message>
+};
+
 const PluginCenterAuthentication: FC = () => {
   const { data, isLoading, error } = usePluginCenterAuthInfo();
   const [t] = useTranslation("config");
@@ -110,11 +122,7 @@ const PluginCenterAuthentication: FC = () => {
   return (
     <Notification type="inherit" className="is-flex is-justify-content-space-between is-align-content-center">
       <Message>{t("pluginSettings.auth.notAuthenticated")}</Message>
-      {data._links.login ? (
-        <Button color="primary" link={(data._links.login as Link).href}>
-          {t("pluginSettings.auth.authenticate")}
-        </Button>
-      ) : null}
+      <LoginButtonOrConfigurationHint link={data._links.login as Link} />
     </Notification>
   );
 };

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/PluginCenterAuthResource.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/PluginCenterAuthResource.java
@@ -263,7 +263,7 @@ public class PluginCenterAuthResource {
             .toASCIIString();
           builder.single(Link.link("reconnect", reconnectLink));
         }
-      } else {
+      } else if (!Strings.isNullOrEmpty(configuration.getPluginAuthUrl())) {
         builder.single(Link.link(METHOD_LOGIN, uriInfo.getAbsolutePathBuilder().path(METHOD_LOGIN).build().toASCIIString()));
       }
     }

--- a/scm-webapp/src/test/java/sonia/scm/api/v2/resources/PluginCenterAuthResourceTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/api/v2/resources/PluginCenterAuthResourceTest.java
@@ -149,6 +149,16 @@ class PluginCenterAuthResourceTest {
 
     @Test
     @SubjectAware(value = "marvin", permissions = "plugin:write")
+    void shouldNotReturnLoginLinkIfPermittedButNotConfigured() throws URISyntaxException, IOException {
+      scmConfiguration.setPluginAuthUrl(null);
+
+      JsonNode root = getJson("/v2/plugins/auth");
+
+      assertThat(root.get("_links").get("login")).isNull();
+    }
+
+    @Test
+    @SubjectAware(value = "marvin", permissions = "plugin:write")
     void shouldReturnReconnectAndLogoutLinkForFailedAuthentication() throws URISyntaxException, IOException {
       JsonNode root = requestAuthInfo(true);
 


### PR DESCRIPTION
## Proposed changes

This removes the "login" button for the plugin center, when the authentication url is not set. 

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
