### PR TITLE
fix certain plugin bundles being executed multiple times

### DIFF
--- a/gradle/changelog/duplicate_module_execution.yaml
+++ b/gradle/changelog/duplicate_module_execution.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Some plugin bundles are executed multiple times ([#1980](https://github.com/scm-manager/scm-manager/pull/1980))

--- a/scm-ui/ui-modules/src/index.ts
+++ b/scm-ui/ui-modules/src/index.ts
@@ -59,12 +59,11 @@ const resolveModule = (name: string) => {
 const defineModule = (name: string, module: Module) => {
   Promise.all(module.dependencies.map(resolveModule))
     .then(resolvedDependencies => {
-      delete queue[name];
-
       modules["@scm-manager/" + name] = module.fn(...resolvedDependencies);
 
       Object.keys(queue).forEach(queuedModuleName => {
         const queueModule = queue[queuedModuleName];
+        delete queue[queuedModuleName];
         defineModule(queuedModuleName, queueModule);
       });
     })


### PR DESCRIPTION
## Proposed changes

If a queued module is only removed from the queue upon successfully resolving all its dependencies,
it could fail multiple times, causing multiple entries to appear in the queue.
This in turn causes the module to get executed multiple times.
The solution is to immediately remove the module when it is de-queued.
If it fails again, it is then re-added to the queue.
It was not possible to implement a unit test that correctly reflects the production environment.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
