### PR TITLE
Correct styling of syntax highlighter .section elements

### DIFF
--- a/gradle/changelog/highlighter_styling.yaml
+++ b/gradle/changelog/highlighter_styling.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Correct styling of syntax highlighter .section elements ([#1984](https://github.com/scm-manager/scm-manager/pull/1984))

--- a/scm-ui/ui-components/src/SyntaxHighlighterRenderer.tsx
+++ b/scm-ui/ui-components/src/SyntaxHighlighterRenderer.tsx
@@ -61,6 +61,10 @@ const RowContainer = styled.div`
   &:hover i {
     visibility: visible;
   }
+  // override bulma default styling of .section
+  .section {
+    padding: 0;
+  }
 `;
 
 type CreateLinePermaLinkFn = (lineNumber: number) => string;

--- a/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
+++ b/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
@@ -4647,7 +4647,7 @@ exports[`Storyshots MarkdownView Code without Lang 1`] = `
             }
           >
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-1"
             >
               <div
@@ -5800,7 +5800,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
             }
           >
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-1"
             >
               <div
@@ -5844,7 +5844,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-2"
             >
               <div
@@ -5874,7 +5874,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-3"
             >
               <div
@@ -5938,7 +5938,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-4"
             >
               <div
@@ -5987,7 +5987,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-5"
             >
               <div
@@ -6036,7 +6036,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-6"
             >
               <div
@@ -6085,7 +6085,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-7"
             >
               <div
@@ -6115,7 +6115,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-8"
             >
               <div
@@ -6280,7 +6280,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-9"
             >
               <div
@@ -6474,7 +6474,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-10"
             >
               <div
@@ -6523,7 +6523,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-11"
             >
               <div
@@ -6553,7 +6553,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-12"
             >
               <div
@@ -6652,7 +6652,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-13"
             >
               <div
@@ -6756,7 +6756,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-14"
             >
               <div
@@ -6870,7 +6870,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-15"
             >
               <div
@@ -15012,7 +15012,7 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
             }
           >
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-1"
             >
               <div
@@ -15046,7 +15046,7 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-2"
             >
               <div
@@ -15076,7 +15076,7 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-3"
             >
               <div
@@ -15106,7 +15106,7 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-4"
             >
               <div
@@ -15136,7 +15136,7 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-5"
             >
               <div
@@ -15166,7 +15166,7 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-6"
             >
               <div
@@ -15196,7 +15196,7 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-7"
             >
               <div
@@ -15226,7 +15226,7 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-8"
             >
               <div
@@ -15256,7 +15256,7 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-9"
             >
               <div
@@ -15286,7 +15286,7 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-10"
             >
               <div
@@ -15316,7 +15316,7 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-11"
             >
               <div
@@ -16590,7 +16590,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
             }
           >
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-1"
             >
               <div
@@ -16634,7 +16634,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-2"
             >
               <div
@@ -16664,7 +16664,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-3"
             >
               <div
@@ -16728,7 +16728,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-4"
             >
               <div
@@ -16777,7 +16777,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-5"
             >
               <div
@@ -16826,7 +16826,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-6"
             >
               <div
@@ -16875,7 +16875,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-7"
             >
               <div
@@ -16905,7 +16905,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-8"
             >
               <div
@@ -17070,7 +17070,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-9"
             >
               <div
@@ -17264,7 +17264,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-10"
             >
               <div
@@ -17313,7 +17313,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-11"
             >
               <div
@@ -17343,7 +17343,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-12"
             >
               <div
@@ -17442,7 +17442,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-13"
             >
               <div
@@ -17546,7 +17546,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-14"
             >
               <div
@@ -17660,7 +17660,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-15"
             >
               <div
@@ -17967,7 +17967,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
             }
           >
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-1"
             >
               <div
@@ -18051,7 +18051,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-2"
             >
               <div
@@ -18081,7 +18081,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-3"
             >
               <div
@@ -18111,7 +18111,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-4"
             >
               <div
@@ -18141,7 +18141,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-5"
             >
               <div
@@ -18210,7 +18210,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-6"
             >
               <div
@@ -18279,7 +18279,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-7"
             >
               <div
@@ -18309,7 +18309,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-8"
             >
               <div
@@ -18339,7 +18339,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-9"
             >
               <div
@@ -18369,7 +18369,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-10"
             >
               <div
@@ -18438,7 +18438,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-11"
             >
               <div
@@ -18542,7 +18542,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-12"
             >
               <div
@@ -18646,7 +18646,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-13"
             >
               <div
@@ -18715,7 +18715,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-14"
             >
               <div
@@ -18784,7 +18784,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-15"
             >
               <div
@@ -18888,7 +18888,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-16"
             >
               <div
@@ -18992,7 +18992,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-17"
             >
               <div
@@ -19061,7 +19061,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-18"
             >
               <div
@@ -19130,7 +19130,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-19"
             >
               <div
@@ -19199,7 +19199,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-20"
             >
               <div
@@ -19229,7 +19229,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-21"
             >
               <div
@@ -19259,7 +19259,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-22"
             >
               <div
@@ -19289,7 +19289,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
               </span>
             </div>
             <div
-              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+              className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
               id="line-23"
             >
               <div
@@ -72436,7 +72436,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
         }
       >
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-1"
         >
           <div
@@ -72480,7 +72480,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-2"
         >
           <div
@@ -72510,7 +72510,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-3"
         >
           <div
@@ -72574,7 +72574,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-4"
         >
           <div
@@ -72623,7 +72623,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-5"
         >
           <div
@@ -72672,7 +72672,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-6"
         >
           <div
@@ -72721,7 +72721,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-7"
         >
           <div
@@ -72751,7 +72751,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-8"
         >
           <div
@@ -72850,7 +72850,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-9"
         >
           <div
@@ -73060,7 +73060,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-10"
         >
           <div
@@ -73169,7 +73169,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-11"
         >
           <div
@@ -73228,7 +73228,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-12"
         >
           <div
@@ -73258,7 +73258,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-13"
         >
           <div
@@ -73408,7 +73408,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-14"
         >
           <div
@@ -73577,7 +73577,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-15"
         >
           <div
@@ -73607,7 +73607,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-16"
         >
           <div
@@ -73721,7 +73721,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-17"
         >
           <div
@@ -73840,7 +73840,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
         }
       >
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-1"
         >
           <div
@@ -73921,7 +73921,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-2"
         >
           <div
@@ -73951,7 +73951,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-3"
         >
           <div
@@ -74053,7 +74053,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-4"
         >
           <div
@@ -74155,7 +74155,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-5"
         >
           <div
@@ -74257,7 +74257,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-6"
         >
           <div
@@ -74287,7 +74287,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-7"
         >
           <div
@@ -74421,7 +74421,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-8"
         >
           <div
@@ -74555,7 +74555,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-9"
         >
           <div
@@ -74689,7 +74689,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-10"
         >
           <div
@@ -74719,7 +74719,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-11"
         >
           <div
@@ -74809,7 +74809,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-12"
         >
           <div
@@ -74839,7 +74839,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-13"
         >
           <div
@@ -75025,7 +75025,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-14"
         >
           <div
@@ -75223,7 +75223,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-15"
         >
           <div
@@ -75378,7 +75378,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-16"
         >
           <div
@@ -75492,7 +75492,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-17"
         >
           <div
@@ -75581,7 +75581,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-18"
         >
           <div
@@ -75630,7 +75630,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-19"
         >
           <div
@@ -75660,7 +75660,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-20"
         >
           <div
@@ -75776,7 +75776,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-21"
         >
           <div
@@ -75825,7 +75825,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-22"
         >
           <div
@@ -75976,7 +75976,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-23"
         >
           <div
@@ -76062,7 +76062,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-24"
         >
           <div
@@ -76216,7 +76216,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-25"
         >
           <div
@@ -76332,7 +76332,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-26"
         >
           <div
@@ -76466,7 +76466,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-27"
         >
           <div
@@ -76555,7 +76555,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-28"
         >
           <div
@@ -76604,7 +76604,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-29"
         >
           <div
@@ -76653,7 +76653,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-30"
         >
           <div
@@ -76683,7 +76683,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-31"
         >
           <div
@@ -76802,7 +76802,7 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
         }
       >
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-1"
         >
           <div
@@ -76917,7 +76917,7 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-2"
         >
           <div
@@ -76947,7 +76947,7 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-3"
         >
           <div
@@ -77088,7 +77088,7 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-4"
         >
           <div
@@ -77258,7 +77258,7 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-5"
         >
           <div
@@ -77357,7 +77357,7 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-6"
         >
           <div
@@ -77446,7 +77446,7 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-7"
         >
           <div
@@ -77635,7 +77635,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
         }
       >
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-1"
         >
           <div
@@ -77691,7 +77691,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-2"
         >
           <div
@@ -77721,7 +77721,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-3"
         >
           <div
@@ -77808,7 +77808,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-4"
         >
           <div
@@ -77895,7 +77895,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-5"
         >
           <div
@@ -77982,7 +77982,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-6"
         >
           <div
@@ -78069,7 +78069,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-7"
         >
           <div
@@ -78156,7 +78156,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-8"
         >
           <div
@@ -78243,7 +78243,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-9"
         >
           <div
@@ -78330,7 +78330,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-10"
         >
           <div
@@ -78417,7 +78417,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-11"
         >
           <div
@@ -78447,7 +78447,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-12"
         >
           <div
@@ -78496,7 +78496,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-13"
         >
           <div
@@ -78526,7 +78526,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-14"
         >
           <div
@@ -78587,7 +78587,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-15"
         >
           <div
@@ -78617,7 +78617,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-16"
         >
           <div
@@ -78678,7 +78678,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-17"
         >
           <div
@@ -78708,7 +78708,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-18"
         >
           <div
@@ -78738,7 +78738,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-19"
         >
           <div
@@ -78768,7 +78768,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-20"
         >
           <div
@@ -78829,7 +78829,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-21"
         >
           <div
@@ -78859,7 +78859,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-22"
         >
           <div
@@ -78889,7 +78889,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-23"
         >
           <div
@@ -78919,7 +78919,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-24"
         >
           <div
@@ -78980,7 +78980,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-25"
         >
           <div
@@ -79010,7 +79010,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-26"
         >
           <div
@@ -79040,7 +79040,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-27"
         >
           <div
@@ -79070,7 +79070,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-28"
         >
           <div
@@ -79131,7 +79131,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-29"
         >
           <div
@@ -79161,7 +79161,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-30"
         >
           <div
@@ -79191,7 +79191,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-31"
         >
           <div
@@ -79221,7 +79221,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-32"
         >
           <div
@@ -79282,7 +79282,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-33"
         >
           <div
@@ -79312,7 +79312,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-34"
         >
           <div
@@ -79342,7 +79342,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-35"
         >
           <div
@@ -79372,7 +79372,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-36"
         >
           <div
@@ -79433,7 +79433,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-37"
         >
           <div
@@ -79463,7 +79463,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-38"
         >
           <div
@@ -79493,7 +79493,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-39"
         >
           <div
@@ -79523,7 +79523,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-40"
         >
           <div
@@ -79553,7 +79553,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-41"
         >
           <div
@@ -79583,7 +79583,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-42"
         >
           <div
@@ -79613,7 +79613,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-43"
         >
           <div
@@ -79674,7 +79674,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-44"
         >
           <div
@@ -79704,7 +79704,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-45"
         >
           <div
@@ -79734,7 +79734,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-46"
         >
           <div
@@ -79764,7 +79764,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-47"
         >
           <div
@@ -79794,7 +79794,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-48"
         >
           <div
@@ -79824,7 +79824,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-49"
         >
           <div
@@ -79854,7 +79854,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-50"
         >
           <div
@@ -79884,7 +79884,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-51"
         >
           <div
@@ -79914,7 +79914,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-52"
         >
           <div
@@ -79944,7 +79944,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-53"
         >
           <div
@@ -80005,7 +80005,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-54"
         >
           <div
@@ -80035,7 +80035,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-55"
         >
           <div
@@ -80065,7 +80065,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-56"
         >
           <div
@@ -80095,7 +80095,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-57"
         >
           <div
@@ -80144,7 +80144,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-58"
         >
           <div
@@ -80174,7 +80174,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-59"
         >
           <div
@@ -80204,7 +80204,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-60"
         >
           <div
@@ -80234,7 +80234,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-61"
         >
           <div
@@ -80283,7 +80283,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-62"
         >
           <div
@@ -80313,7 +80313,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-63"
         >
           <div
@@ -80343,7 +80343,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-64"
         >
           <div
@@ -80373,7 +80373,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-65"
         >
           <div
@@ -80422,7 +80422,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-66"
         >
           <div
@@ -80452,7 +80452,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-67"
         >
           <div
@@ -80482,7 +80482,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-68"
         >
           <div
@@ -80512,7 +80512,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-69"
         >
           <div
@@ -80542,7 +80542,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-70"
         >
           <div
@@ -80572,7 +80572,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-71"
         >
           <div
@@ -80633,7 +80633,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-72"
         >
           <div
@@ -80663,7 +80663,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-73"
         >
           <div
@@ -80724,7 +80724,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-74"
         >
           <div
@@ -80754,7 +80754,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-75"
         >
           <div
@@ -80803,7 +80803,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-76"
         >
           <div
@@ -80852,7 +80852,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-77"
         >
           <div
@@ -80901,7 +80901,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-78"
         >
           <div
@@ -80931,7 +80931,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-79"
         >
           <div
@@ -80980,7 +80980,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-80"
         >
           <div
@@ -81029,7 +81029,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-81"
         >
           <div
@@ -81078,7 +81078,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-82"
         >
           <div
@@ -81127,7 +81127,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-83"
         >
           <div
@@ -81176,7 +81176,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-84"
         >
           <div
@@ -81225,7 +81225,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-85"
         >
           <div
@@ -81274,7 +81274,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-86"
         >
           <div
@@ -81304,7 +81304,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-87"
         >
           <div
@@ -81365,7 +81365,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-88"
         >
           <div
@@ -81395,7 +81395,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-89"
         >
           <div
@@ -81444,7 +81444,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-90"
         >
           <div
@@ -81493,7 +81493,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-91"
         >
           <div
@@ -81542,7 +81542,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-92"
         >
           <div
@@ -81591,7 +81591,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-93"
         >
           <div
@@ -81640,7 +81640,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-94"
         >
           <div
@@ -81689,7 +81689,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-95"
         >
           <div
@@ -81738,7 +81738,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-96"
         >
           <div
@@ -81768,7 +81768,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-97"
         >
           <div
@@ -81798,7 +81798,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-98"
         >
           <div
@@ -81828,7 +81828,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-99"
         >
           <div
@@ -81889,7 +81889,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-100"
         >
           <div
@@ -81919,7 +81919,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-101"
         >
           <div
@@ -81949,7 +81949,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-102"
         >
           <div
@@ -81979,7 +81979,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-103"
         >
           <div
@@ -82028,7 +82028,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-104"
         >
           <div
@@ -82058,7 +82058,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-105"
         >
           <div
@@ -82088,7 +82088,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-106"
         >
           <div
@@ -82118,7 +82118,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-107"
         >
           <div
@@ -82148,7 +82148,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-108"
         >
           <div
@@ -82178,7 +82178,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-109"
         >
           <div
@@ -82239,7 +82239,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-110"
         >
           <div
@@ -82269,7 +82269,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-111"
         >
           <div
@@ -82299,7 +82299,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-112"
         >
           <div
@@ -82329,7 +82329,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-113"
         >
           <div
@@ -82484,7 +82484,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-114"
         >
           <div
@@ -82695,7 +82695,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-115"
         >
           <div
@@ -82826,7 +82826,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-116"
         >
           <div
@@ -82957,7 +82957,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-117"
         >
           <div
@@ -83088,7 +83088,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-118"
         >
           <div
@@ -83219,7 +83219,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-119"
         >
           <div
@@ -83350,7 +83350,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-120"
         >
           <div
@@ -83390,7 +83390,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-121"
         >
           <div
@@ -83420,7 +83420,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-122"
         >
           <div
@@ -83450,7 +83450,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-123"
         >
           <div
@@ -83480,7 +83480,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-124"
         >
           <div
@@ -83510,7 +83510,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-125"
         >
           <div
@@ -83571,7 +83571,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-126"
         >
           <div
@@ -83601,7 +83601,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-127"
         >
           <div
@@ -83662,7 +83662,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-128"
         >
           <div
@@ -83692,7 +83692,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-129"
         >
           <div
@@ -83756,7 +83756,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-130"
         >
           <div
@@ -83786,7 +83786,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-131"
         >
           <div
@@ -83847,7 +83847,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-132"
         >
           <div
@@ -83877,7 +83877,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-133"
         >
           <div
@@ -83907,7 +83907,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-134"
         >
           <div
@@ -83937,7 +83937,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-135"
         >
           <div
@@ -83993,7 +83993,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-136"
         >
           <div
@@ -84034,7 +84034,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-137"
         >
           <div
@@ -84064,7 +84064,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-138"
         >
           <div
@@ -84094,7 +84094,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-139"
         >
           <div
@@ -84124,7 +84124,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-140"
         >
           <div
@@ -84154,7 +84154,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-141"
         >
           <div
@@ -84184,7 +84184,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-142"
         >
           <div
@@ -84214,7 +84214,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-143"
         >
           <div
@@ -84244,7 +84244,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-144"
         >
           <div
@@ -84274,7 +84274,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-145"
         >
           <div
@@ -84304,7 +84304,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-146"
         >
           <div
@@ -84334,7 +84334,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-147"
         >
           <div
@@ -84364,7 +84364,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-148"
         >
           <div
@@ -84394,7 +84394,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-149"
         >
           <div
@@ -84424,7 +84424,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-150"
         >
           <div
@@ -84465,7 +84465,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-151"
         >
           <div
@@ -84515,7 +84515,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-152"
         >
           <div
@@ -84545,7 +84545,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-153"
         >
           <div
@@ -84575,7 +84575,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-154"
         >
           <div
@@ -84605,7 +84605,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-155"
         >
           <div
@@ -84635,7 +84635,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-156"
         >
           <div
@@ -84665,7 +84665,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-157"
         >
           <div
@@ -84726,7 +84726,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-158"
         >
           <div
@@ -84756,7 +84756,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-159"
         >
           <div
@@ -84939,7 +84939,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-160"
         >
           <div
@@ -84969,7 +84969,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-161"
         >
           <div
@@ -85041,7 +85041,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-162"
         >
           <div
@@ -85071,7 +85071,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-163"
         >
           <div
@@ -85195,7 +85195,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-164"
         >
           <div
@@ -85225,7 +85225,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-165"
         >
           <div
@@ -85297,7 +85297,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-166"
         >
           <div
@@ -85327,7 +85327,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-167"
         >
           <div
@@ -85515,7 +85515,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-168"
         >
           <div
@@ -85545,7 +85545,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-169"
         >
           <div
@@ -85617,7 +85617,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-170"
         >
           <div
@@ -85647,7 +85647,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-171"
         >
           <div
@@ -85794,7 +85794,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
         }
       >
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-1"
         >
           <div
@@ -85868,7 +85868,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-2"
         >
           <div
@@ -85898,7 +85898,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-3"
         >
           <div
@@ -85963,7 +85963,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-4"
         >
           <div
@@ -85993,7 +85993,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-5"
         >
           <div
@@ -86088,7 +86088,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-6"
         >
           <div
@@ -86118,7 +86118,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-7"
         >
           <div
@@ -86217,7 +86217,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-8"
         >
           <div
@@ -86301,7 +86301,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-9"
         >
           <div
@@ -86405,7 +86405,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-10"
         >
           <div
@@ -86479,7 +86479,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-11"
         >
           <div
@@ -86578,7 +86578,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-12"
         >
           <div
@@ -86627,7 +86627,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-13"
         >
           <div
@@ -86657,7 +86657,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-14"
         >
           <div
@@ -86716,7 +86716,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-15"
         >
           <div
@@ -86851,7 +86851,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-16"
         >
           <div
@@ -86930,7 +86930,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-17"
         >
           <div
@@ -87004,7 +87004,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-18"
         >
           <div
@@ -87068,7 +87068,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-19"
         >
           <div
@@ -87132,7 +87132,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-20"
         >
           <div
@@ -87291,7 +87291,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
         }
       >
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-1"
         >
           <span
@@ -87353,7 +87353,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-2"
         >
           <span
@@ -87364,7 +87364,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-3"
         >
           <span
@@ -87447,7 +87447,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-4"
         >
           <span
@@ -87530,7 +87530,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-5"
         >
           <span
@@ -87613,7 +87613,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-6"
         >
           <span
@@ -87624,7 +87624,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-7"
         >
           <span
@@ -87739,7 +87739,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-8"
         >
           <span
@@ -87854,7 +87854,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-9"
         >
           <span
@@ -87969,7 +87969,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-10"
         >
           <span
@@ -87980,7 +87980,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-11"
         >
           <span
@@ -88051,7 +88051,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-12"
         >
           <span
@@ -88062,7 +88062,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-13"
         >
           <span
@@ -88229,7 +88229,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-14"
         >
           <span
@@ -88408,7 +88408,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-15"
         >
           <span
@@ -88544,7 +88544,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-16"
         >
           <span
@@ -88639,7 +88639,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-17"
         >
           <span
@@ -88709,7 +88709,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-18"
         >
           <span
@@ -88739,7 +88739,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-19"
         >
           <span
@@ -88750,7 +88750,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-20"
         >
           <span
@@ -88847,7 +88847,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-21"
         >
           <span
@@ -88877,7 +88877,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-22"
         >
           <span
@@ -89009,7 +89009,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-23"
         >
           <span
@@ -89076,7 +89076,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-24"
         >
           <span
@@ -89211,7 +89211,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-25"
         >
           <span
@@ -89308,7 +89308,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-26"
         >
           <span
@@ -89423,7 +89423,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-27"
         >
           <span
@@ -89493,7 +89493,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-28"
         >
           <span
@@ -89523,7 +89523,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-29"
         >
           <span
@@ -89553,7 +89553,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-30"
         >
           <span
@@ -89564,7 +89564,7 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
           </span>
         </div>
         <div
-          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 dsgsZc"
+          className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 bQiNip"
           id="line-31"
         >
           <span


### PR DESCRIPTION
## Proposed changes

Correct styling of syntax highlighter .section elements which causes unsightly rendering due to a global definition by bulma.

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [x] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [x] All new code/logic is implemented on the right spot / "Should this be done here?"
- [x] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [x] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [x] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
