### PR TITLE
Limit scopes and rename bean in cli

### DIFF
--- a/scm-webapp/src/main/java/sonia/scm/repository/cli/RepositoryCommandBean.java
+++ b/scm-webapp/src/main/java/sonia/scm/repository/cli/RepositoryCommandBean.java
@@ -31,7 +31,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-public class RepositoryCommandDto {
+class RepositoryCommandBean {
   private String name;
   private String namespace;
   private String type;

--- a/scm-webapp/src/main/java/sonia/scm/repository/cli/RepositoryCreateCommand.java
+++ b/scm-webapp/src/main/java/sonia/scm/repository/cli/RepositoryCreateCommand.java
@@ -40,7 +40,7 @@ import javax.validation.constraints.Email;
 
 @CommandLine.Command(name = "create")
 @ParentCommand(value = RepositoryCommand.class)
-public class RepositoryCreateCommand implements Runnable {
+class RepositoryCreateCommand implements Runnable {
 
   @CommandLine.Mixin
   private final RepositoryTemplateRenderer templateRenderer;

--- a/scm-webapp/src/main/java/sonia/scm/repository/cli/RepositoryDeleteCommand.java
+++ b/scm-webapp/src/main/java/sonia/scm/repository/cli/RepositoryDeleteCommand.java
@@ -36,7 +36,7 @@ import java.util.Collections;
 
 @CommandLine.Command(name = "delete", aliases = "rm")
 @ParentCommand(RepositoryCommand.class)
-public class RepositoryDeleteCommand implements Runnable {
+class RepositoryDeleteCommand implements Runnable {
 
   private static final String PROMPT_TEMPLATE = "{{i18n.repoDeletePrompt}}";
 

--- a/scm-webapp/src/main/java/sonia/scm/repository/cli/RepositoryGetCommand.java
+++ b/scm-webapp/src/main/java/sonia/scm/repository/cli/RepositoryGetCommand.java
@@ -35,7 +35,7 @@ import javax.inject.Inject;
 
 @ParentCommand(value = RepositoryCommand.class)
 @CommandLine.Command(name = "get")
-public class RepositoryGetCommand implements Runnable {
+class RepositoryGetCommand implements Runnable {
 
   @CommandLine.Parameters(paramLabel = "namespace/name", index = "0")
   private String repository;

--- a/scm-webapp/src/main/java/sonia/scm/repository/cli/RepositoryListCommand.java
+++ b/scm-webapp/src/main/java/sonia/scm/repository/cli/RepositoryListCommand.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 
 @ParentCommand(value = RepositoryCommand.class)
 @CommandLine.Command(name = "list", aliases = "ls")
-public class RepositoryListCommand implements Runnable {
+class RepositoryListCommand implements Runnable {
 
   @CommandLine.Mixin
   private final TemplateRenderer templateRenderer;
@@ -69,16 +69,16 @@ public class RepositoryListCommand implements Runnable {
 
   @Override
   public void run() {
-    Collection<RepositoryCommandDto> dtos = manager.getAll().stream().map(mapper::map).collect(Collectors.toList());
+    Collection<RepositoryCommandBean> beans = manager.getAll().stream().map(mapper::map).collect(Collectors.toList());
     if (useShortTemplate) {
-      templateRenderer.renderToStdout(SHORT_TEMPLATE, ImmutableMap.of("repos", dtos));
+      templateRenderer.renderToStdout(SHORT_TEMPLATE, ImmutableMap.of("repos", beans));
     } else {
       Table table = templateRenderer.createTable();
       table.addHeader("repoName", "repoType", "repoUrl");
-      for (RepositoryCommandDto dto : dtos) {
-        table.addRow(dto.getNamespace() + "/" + dto.getName(), dto.getType(), dto.getUrl());
+      for (RepositoryCommandBean bean : beans) {
+        table.addRow(bean.getNamespace() + "/" + bean.getName(), bean.getType(), bean.getUrl());
       }
-      templateRenderer.renderToStdout(TABLE_TEMPLATE, ImmutableMap.of("rows", table, "repos", dtos));
+      templateRenderer.renderToStdout(TABLE_TEMPLATE, ImmutableMap.of("rows", table, "repos", beans));
     }
   }
 

--- a/scm-webapp/src/main/java/sonia/scm/repository/cli/RepositoryModifyCommand.java
+++ b/scm-webapp/src/main/java/sonia/scm/repository/cli/RepositoryModifyCommand.java
@@ -37,7 +37,7 @@ import javax.validation.constraints.Email;
 
 @ParentCommand(value = RepositoryCommand.class)
 @CommandLine.Command(name = "modify")
-public class RepositoryModifyCommand implements Runnable {
+class RepositoryModifyCommand implements Runnable {
 
   @CommandLine.Mixin
   private final RepositoryTemplateRenderer templateRenderer;

--- a/scm-webapp/src/main/java/sonia/scm/repository/cli/RepositoryTemplateRenderer.java
+++ b/scm-webapp/src/main/java/sonia/scm/repository/cli/RepositoryTemplateRenderer.java
@@ -35,7 +35,7 @@ import sonia.scm.template.TemplateEngineFactory;
 import javax.inject.Inject;
 import java.util.Collections;
 
-public class RepositoryTemplateRenderer extends TemplateRenderer {
+class RepositoryTemplateRenderer extends TemplateRenderer {
 
   private static final String DETAILS_TABLE_TEMPLATE = String.join("\n",
     "{{#rows}}",
@@ -57,16 +57,16 @@ public class RepositoryTemplateRenderer extends TemplateRenderer {
 
   public void render(Repository repository) {
     Table table = createTable();
-    RepositoryCommandDto dto = mapper.map(repository);
-    table.addLabelValueRow("repoNamespace", dto.getNamespace());
-    table.addLabelValueRow("repoName", dto.getName());
-    table.addLabelValueRow("repoType", dto.getType());
-    table.addLabelValueRow("repoContact", dto.getContact());
-    table.addLabelValueRow("repoCreationDate", dto.getCreationDate());
-    table.addLabelValueRow("repoLastModified", dto.getLastModified());
-    table.addLabelValueRow("repoUrl", dto.getUrl());
-    table.addLabelValueRow("repoDescription", dto.getDescription());
-    renderToStdout(DETAILS_TABLE_TEMPLATE, ImmutableMap.of("rows", table, "repo", dto));
+    RepositoryCommandBean bean = mapper.map(repository);
+    table.addLabelValueRow("repoNamespace", bean.getNamespace());
+    table.addLabelValueRow("repoName", bean.getName());
+    table.addLabelValueRow("repoType", bean.getType());
+    table.addLabelValueRow("repoContact", bean.getContact());
+    table.addLabelValueRow("repoCreationDate", bean.getCreationDate());
+    table.addLabelValueRow("repoLastModified", bean.getLastModified());
+    table.addLabelValueRow("repoUrl", bean.getUrl());
+    table.addLabelValueRow("repoDescription", bean.getDescription());
+    renderToStdout(DETAILS_TABLE_TEMPLATE, ImmutableMap.of("rows", table, "repo", bean));
   }
 
   public void renderInvalidInputError() {

--- a/scm-webapp/src/main/java/sonia/scm/repository/cli/RepositoryToRepositoryCommandDtoMapper.java
+++ b/scm-webapp/src/main/java/sonia/scm/repository/cli/RepositoryToRepositoryCommandDtoMapper.java
@@ -26,6 +26,7 @@ package sonia.scm.repository.cli;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.ObjectFactory;
 import sonia.scm.repository.Repository;
 import sonia.scm.repository.api.RepositoryService;
@@ -43,16 +44,17 @@ public abstract class RepositoryToRepositoryCommandDtoMapper {
   @Inject
   private RepositoryServiceFactory serviceFactory;
 
-  public abstract RepositoryCommandDto map(Repository modelObject);
+  @Mapping(target = "url", ignore = true)
+  abstract RepositoryCommandBean map(Repository modelObject);
 
   @ObjectFactory
-  RepositoryCommandDto createDto(Repository repository) {
-    RepositoryCommandDto dto = new RepositoryCommandDto();
+  RepositoryCommandBean createBean(Repository repository) {
+    RepositoryCommandBean bean = new RepositoryCommandBean();
     try (RepositoryService service = serviceFactory.create(repository)) {
       Optional<ScmProtocol> protocolUrl = service.getSupportedProtocols().filter(p -> p.getType().equals("http")).findFirst();
-      protocolUrl.ifPresent(scmProtocol -> dto.setUrl(scmProtocol.getUrl()));
+      protocolUrl.ifPresent(scmProtocol -> bean.setUrl(scmProtocol.getUrl()));
     }
-    return dto;
+    return bean;
   }
 
   String mapTimestampToISODate(Long timestamp) {

--- a/scm-webapp/src/test/java/sonia/scm/repository/cli/RepositoryToRepositoryCommandBeanMapperTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/repository/cli/RepositoryToRepositoryCommandBeanMapperTest.java
@@ -28,7 +28,6 @@ import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import sonia.scm.repository.Repository;
@@ -42,7 +41,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class RepositoryToRepositoryCommandDtoMapperTest {
+class RepositoryToRepositoryCommandBeanMapperTest {
 
   @Mock
   private RepositoryServiceFactory serviceFactory;
@@ -61,7 +60,7 @@ class RepositoryToRepositoryCommandDtoMapperTest {
   void shouldMapAttributes() {
     Repository testRepo = RepositoryTestData.create42Puzzle();
     when(serviceFactory.create(testRepo)).thenReturn(service);
-    RepositoryCommandDto dto = mapper.map(testRepo);
+    RepositoryCommandBean dto = mapper.map(testRepo);
 
     assertThat(dto.getNamespace()).isEqualTo(testRepo.getNamespace());
     assertThat(dto.getName()).isEqualTo(testRepo.getName());
@@ -88,7 +87,7 @@ class RepositoryToRepositoryCommandDtoMapperTest {
     when(serviceFactory.create(testRepo)).thenReturn(service);
     when(service.getSupportedProtocols()).thenReturn(ImmutableList.of(scmProtocol).stream());
 
-    RepositoryCommandDto dto = mapper.map(testRepo);
+    RepositoryCommandBean dto = mapper.map(testRepo);
 
     assertThat(dto.getUrl()).isEqualTo("http://localhost:8081/scm");
   }


### PR DESCRIPTION
## Proposed changes

This limits the scope of all cli related classes, so that
they cannot be used outside of cli context and therefore
cannot confuse other developers.

Secondly, we rename RepositoryCommandDto to
RepositoryCommandBean, because we have no data transfers
here and the name might be confusing otherwise.

We have no funcitonal changes whatsoever.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
