### PR TITLE
Fix handling of illegal lfs pointers

### DIFF
--- a/gradle/changelog/lfs_exception.yaml
+++ b/gradle/changelog/lfs_exception.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Handling of illegal lfs pointers ([#1994](https://github.com/scm-manager/scm-manager/pull/1994))

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/GitUtil.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/GitUtil.java
@@ -73,6 +73,7 @@ import java.util.concurrent.TimeUnit;
 
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
+import static java.util.Optional.ofNullable;
 
 //~--- JDK imports ------------------------------------------------------------
 
@@ -648,7 +649,7 @@ public final class GitUtil {
     Attribute filter = attributes.get("filter");
     if (filter != null && "lfs".equals(filter.getValue())) {
       try (InputStream is = repo.open(blobId, Constants.OBJ_BLOB).openStream()) {
-        return of(LfsPointer.parseLfsPointer(is));
+        return ofNullable(LfsPointer.parseLfsPointer(is));
       }
     } else {
       return empty();


### PR DESCRIPTION
## Proposed changes

When using lfs, it could happen that there are files
committed before the `.gitattributes` file was updated.
In these cases, it could occure that we find files, that
are no lfs pointers, although they are marked as lfs files
in the attributes. In these cases we just want to handle
such files just as normal blobs and ignore the fact and
do not fail.
Before, a null pointer exception was thrown, because the
LfsPointer class from jgit returned null, which did raise
the exception in the Optional#of method.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
