### PR TITLE
Fix media-query to keep white space between button group and border

### DIFF
--- a/gradle/changelog/code_action_bar_at_769px.yaml
+++ b/gradle/changelog/code_action_bar_at_769px.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: White space next to button group in code action bar missing at screen size 769px ([#2005](https://github.com/scm-manager/scm-manager/issues/2005))

--- a/gradle/changelog/code_action_bar_at_769px.yaml
+++ b/gradle/changelog/code_action_bar_at_769px.yaml
@@ -1,2 +1,2 @@
 - type: fixed
-  description: White space next to button group in code action bar missing at screen size 769px ([#2005](https://github.com/scm-manager/scm-manager/issues/2005))
+  description: White space next to button group in code action bar missing at screen size 769px ([#2006](https://github.com/scm-manager/scm-manager/pull/2006))

--- a/gradle/changelog/fix_breaking_code_table.yaml
+++ b/gradle/changelog/fix_breaking_code_table.yaml
@@ -1,2 +1,2 @@
 - type: fixed
-  description: Table in code view breaks at certain screensizes ([#1992](https://github.com/scm-manager/scm-manager/issues/1992))
+  description: Table in code view breaks at certain screensizes ([#1995](https://github.com/scm-manager/scm-manager/pull/1995))

--- a/scm-ui/ui-webapp/src/repos/codeSection/components/CodeActionBar.tsx
+++ b/scm-ui/ui-webapp/src/repos/codeSection/components/CodeActionBar.tsx
@@ -37,7 +37,7 @@ const ActionBar = styled.div`
   line-height: 1.25;
   padding: 0.5em 0.75em;
   margin-bottom: 1em;
-  @media screen and (max-width: ${devices.tablet.width}px) {
+  @media screen and (max-width: ${devices.tablet.width}-1px) {
     padding: 0.5rem 0.25rem;
   }
 `;
@@ -50,7 +50,7 @@ const FlexShrinkLevel = styled(Level)`
   .level-item {
     justify-content: flex-end;
   }
-  @media screen and (max-width: ${devices.tablet.width}px) {
+  @media screen and (max-width: ${devices.tablet.width}-1px) {
     .level-left {
       margin-right: 0;
     }


### PR DESCRIPTION
## Proposed changes

Fix media queries to ensure that layout wraps consistently. Resolves #2005 

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
