### PR TITLE
Fix open file handle prevent deleting a repository on Windows

### DIFF
--- a/gradle/changelog/fix_open_file_handles.yaml
+++ b/gradle/changelog/fix_open_file_handles.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Open file handle prevent deleting a repository on Windows ([#2008](https://github.com/scm-manager/scm-manager/pull/2008))

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/web/GitRepositoryResolver.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/web/GitRepositoryResolver.java
@@ -30,16 +30,14 @@ import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import org.eclipse.jgit.errors.RepositoryNotFoundException;
 import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.lib.RepositoryCache;
-import org.eclipse.jgit.lib.RepositoryCache.FileKey;
 import org.eclipse.jgit.transport.resolver.RepositoryResolver;
 import org.eclipse.jgit.transport.resolver.ServiceNotAuthorizedException;
 import org.eclipse.jgit.transport.resolver.ServiceNotEnabledException;
-import org.eclipse.jgit.util.FS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sonia.scm.repository.GitConfig;
 import sonia.scm.repository.GitRepositoryHandler;
+import sonia.scm.repository.GitUtil;
 import sonia.scm.repository.RepositoryProvider;
 
 import javax.servlet.http.HttpServletRequest;
@@ -103,7 +101,7 @@ public class GitRepositoryResolver implements RepositoryResolver<HttpServletRequ
 
         logger.debug("try to open git repository at {}", gitdir);
 
-        return RepositoryCache.open(FileKey.lenient(gitdir, FS.DETECTED), true);
+        return GitUtil.open(gitdir);
       }
       else
       {


### PR DESCRIPTION
## Proposed changes

Fixes the problem of unclosed file handles which occur when a repository or pack file is accessed (e.g. asynchronously in a post receive hook) after the file had already been closed. Such open file handle prevents deleting a repositories on Windows.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
