### PR TITLE
Omit default port in protocol urls

### DIFF
--- a/gradle/changelog/omit_default_port.yaml
+++ b/gradle/changelog/omit_default_port.yaml
@@ -1,0 +1,2 @@
+- type: changed
+  description: Omit default port in protocol urls ([#2014](https://github.com/scm-manager/scm-manager/pull/2014))

--- a/scm-webapp/src/main/java/sonia/scm/DefaultRootURL.java
+++ b/scm-webapp/src/main/java/sonia/scm/DefaultRootURL.java
@@ -24,6 +24,10 @@
 
 package sonia.scm;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.inject.OutOfScopeException;
 import com.google.inject.ProvisionException;
 import org.slf4j.Logger;
@@ -37,6 +41,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Default implementation of {@link RootURL}.
@@ -50,10 +55,18 @@ public class DefaultRootURL implements RootURL {
   private final Provider<HttpServletRequest> requestProvider;
   private final ScmConfiguration configuration;
 
+  private final LoadingCache<String, URL> urlCache;
+
   @Inject
   public DefaultRootURL(Provider<HttpServletRequest> requestProvider, ScmConfiguration configuration) {
+    this(requestProvider, configuration, new UrlFromString());
+  }
+
+  @VisibleForTesting
+  DefaultRootURL(Provider<HttpServletRequest> requestProvider, ScmConfiguration configuration, UrlFromString cacheLoader) {
     this.requestProvider = requestProvider;
     this.configuration = configuration;
+    this.urlCache = CacheBuilder.newBuilder().maximumSize(10).build(cacheLoader);
   }
 
   @Override
@@ -63,18 +76,10 @@ public class DefaultRootURL implements RootURL {
       throw new IllegalStateException("The configured base url is empty. This can only happened if SCM-Manager has not received any requests.");
     }
     try {
-      return createUrl(url);
-    } catch (MalformedURLException e) {
+      return urlCache.get(url);
+    } catch (ExecutionException e) {
       throw new IllegalStateException(String.format("base url \"%s\" is malformed", url), e);
     }
-  }
-
-  private URL createUrl(String urlString) throws MalformedURLException {
-    URL url = new URL(urlString);
-    if (url.getPort() == url.getDefaultPort()) {
-      return new URL(url.getProtocol(), url.getHost(), -1, url.getFile());
-    }
-    return url;
   }
 
   private Optional<String> fromRequest() {
@@ -87,6 +92,18 @@ public class DefaultRootURL implements RootURL {
         return Optional.empty();
       }
       throw ex;
+    }
+  }
+
+  @VisibleForTesting
+  static class UrlFromString extends CacheLoader<String, URL> {
+    @Override
+    public URL load(String urlString) throws MalformedURLException {
+      URL url = new URL(urlString);
+      if (url.getPort() == url.getDefaultPort()) {
+        return new URL(url.getProtocol(), url.getHost(), -1, url.getFile());
+      }
+      return url;
     }
   }
 }

--- a/scm-webapp/src/main/java/sonia/scm/DefaultRootURL.java
+++ b/scm-webapp/src/main/java/sonia/scm/DefaultRootURL.java
@@ -58,15 +58,23 @@ public class DefaultRootURL implements RootURL {
 
   @Override
   public URL get() {
-    String url = fromRequest().orElse(configuration.getBaseUrl());
+    String url = fromRequest().orElseGet(configuration::getBaseUrl);
     if (url == null) {
       throw new IllegalStateException("The configured base url is empty. This can only happened if SCM-Manager has not received any requests.");
     }
     try {
-      return new URL(url);
+      return createUrl(url);
     } catch (MalformedURLException e) {
       throw new IllegalStateException(String.format("base url \"%s\" is malformed", url), e);
     }
+  }
+
+  private URL createUrl(String urlString) throws MalformedURLException {
+    URL url = new URL(urlString);
+    if (url.getPort() == url.getDefaultPort()) {
+      return new URL(url.getProtocol(), url.getHost(), -1, url.getFile());
+    }
+    return url;
   }
 
   private Optional<String> fromRequest() {

--- a/scm-webapp/src/test/java/sonia/scm/DefaultRootURLTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/DefaultRootURLTest.java
@@ -84,6 +84,13 @@ class DefaultRootURLTest {
     assertThat(rootURL.getAsString()).isEqualTo(URL_CONFIG);
   }
 
+  @Test
+  void shouldSuppressDefaultPorts() {
+    bindNonHttpScope();
+    configuration.setBaseUrl("https://hitchhiker.com:443/from-configuration");
+    assertThat(rootURL.getAsString()).isEqualTo(URL_CONFIG);
+  }
+
   private void bindNonHttpScope() {
     when(requestProvider.get()).thenThrow(
       new ProvisionException("no request available", new OutOfScopeException("out of scope"))


### PR DESCRIPTION
## Proposed changes

This omits the port in the protocol urls when the port is the default port for the protocol.
So if you have your server `https://my.scm.net/scm` and the repository `admin/test`, the protocol url is no longer `https://my.scm.net:443/scm/repo/admin/test`, but simply `https://my.scm.net/scm/repo/admin/test` without the `:443`.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
