### PR TITLE
improve visibility and contrast for focused line in syntax highlighting

### DIFF
--- a/gradle/changelog/focus_line_contrast.yml
+++ b/gradle/changelog/focus_line_contrast.yml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Improve visibility of focused line in source view ([#2031](https://github.com/scm-manager/scm-manager/pull/2031))

--- a/scm-ui/ui-components/src/SyntaxHighlighterRenderer.tsx
+++ b/scm-ui/ui-components/src/SyntaxHighlighterRenderer.tsx
@@ -48,7 +48,8 @@ const RowContainer = styled.div`
   &.focused > span.linenumber {
     box-shadow: inset -3px 0 0 var(--scm-sh-focus-line-contrast);
   }
-  &.focused {
+  &.focused,
+  &.focused > span:last-child {
     background: var(--scm-sh-focus-line-background);
   }
   i {

--- a/scm-ui/ui-components/src/SyntaxHighlighterRenderer.tsx
+++ b/scm-ui/ui-components/src/SyntaxHighlighterRenderer.tsx
@@ -34,10 +34,10 @@ const RowContainer = styled.div`
   .linenumber {
     display: inline-block;
     min-width: 3em;
-    padding-right: 1em;
+    padding-right: 0.75em;
     text-align: right;
     user-select: none;
-    color: rgb(154, 154, 154);
+    color: var(--scm-secondary-text);
   }
   span.linenumber:hover {
     cursor: pointer;
@@ -45,9 +45,11 @@ const RowContainer = styled.div`
   span.linenumber + span > span.linenumber {
     display: none !important;
   }
-  &.focused,
-  &.focused > span:last-child {
-    background-color: rgb(229, 245, 252);
+  &.focused > span.linenumber {
+    box-shadow: inset -3px 0 0 var(--scm-sh-focus-line-contrast);
+  }
+  &.focused {
+    background: var(--scm-sh-focus-line-background);
   }
   i {
     visibility: hidden;
@@ -61,6 +63,9 @@ const RowContainer = styled.div`
   // override bulma default styling of .section
   .section {
     padding: 0;
+  }
+  & > span:last-child {
+    margin-left: 0.75em;
   }
 `;
 

--- a/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
+++ b/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
@@ -4641,7 +4641,7 @@ exports[`Storyshots MarkdownView Code without Lang 1`] = `
           <code>
             <code>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-1"
               >
                 <div
@@ -5741,7 +5741,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
           <code>
             <code>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-1"
               >
                 <div
@@ -5766,7 +5766,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                 package main
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-2"
               >
                 <div
@@ -5791,7 +5791,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                 
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-3"
               >
                 <div
@@ -5816,7 +5816,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                 import (
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-4"
               >
                 <div
@@ -5841,7 +5841,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                     "fmt"
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-5"
               >
                 <div
@@ -5866,7 +5866,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                     "net/http"
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-6"
               >
                 <div
@@ -5891,7 +5891,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                 )
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-7"
               >
                 <div
@@ -5916,7 +5916,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                 
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-8"
               >
                 <div
@@ -5941,7 +5941,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                 func handler(w http.ResponseWriter, r *http.Request) {
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-9"
               >
                 <div
@@ -5966,7 +5966,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                     fmt.Fprintf(w, "Hi there, I love %s!", r.URL.Path[1:])
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-10"
               >
                 <div
@@ -5991,7 +5991,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                 }
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-11"
               >
                 <div
@@ -6016,7 +6016,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                 
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-12"
               >
                 <div
@@ -6041,7 +6041,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                 func main() {
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-13"
               >
                 <div
@@ -6066,7 +6066,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                     http.HandleFunc("/", handler)
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-14"
               >
                 <div
@@ -6091,7 +6091,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                     http.ListenAndServe(":8080", nil)
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-15"
               >
                 <div
@@ -14170,7 +14170,7 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
           <code>
             <code>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-1"
               >
                 <div
@@ -14195,7 +14195,7 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
                   [...]
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-2"
               >
                 <div
@@ -14220,7 +14220,7 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
                 
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-3"
               >
                 <div
@@ -14245,7 +14245,7 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
                   &lt;plugin&gt;
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-4"
               >
                 <div
@@ -14270,7 +14270,7 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
                     &lt;groupId&gt;org.apache.maven.plugins&lt;/groupId&gt;
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-5"
               >
                 <div
@@ -14295,7 +14295,7 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
                     &lt;artifactId&gt;maven-enforcer-plugin&lt;/artifactId&gt;
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-6"
               >
                 <div
@@ -14320,7 +14320,7 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
                   &lt;/plugin&gt;
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-7"
               >
                 <div
@@ -14345,7 +14345,7 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
                   &lt;plugin&gt;
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-8"
               >
                 <div
@@ -14370,7 +14370,7 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
                     &lt;groupId&gt;org.codehaus.mojo&lt;/groupId&gt;
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-9"
               >
                 <div
@@ -14395,7 +14395,7 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
                     &lt;artifactId&gt;animal-sniffer-maven-plugin&lt;/artifactId&gt;
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-10"
               >
                 <div
@@ -14420,7 +14420,7 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
                   &lt;/plugin&gt;
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-11"
               >
                 <div
@@ -15644,7 +15644,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
           <code>
             <code>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-1"
               >
                 <div
@@ -15669,7 +15669,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                 package main
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-2"
               >
                 <div
@@ -15694,7 +15694,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                 
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-3"
               >
                 <div
@@ -15719,7 +15719,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                 import (
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-4"
               >
                 <div
@@ -15744,7 +15744,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                     "fmt"
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-5"
               >
                 <div
@@ -15769,7 +15769,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                     "net/http"
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-6"
               >
                 <div
@@ -15794,7 +15794,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                 )
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-7"
               >
                 <div
@@ -15819,7 +15819,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                 
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-8"
               >
                 <div
@@ -15844,7 +15844,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                 func handler(w http.ResponseWriter, r *http.Request) {
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-9"
               >
                 <div
@@ -15869,7 +15869,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                     fmt.Fprintf(w, "Hi there, I love %s!", r.URL.Path[1:])
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-10"
               >
                 <div
@@ -15894,7 +15894,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                 }
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-11"
               >
                 <div
@@ -15919,7 +15919,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                 
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-12"
               >
                 <div
@@ -15944,7 +15944,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                 func main() {
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-13"
               >
                 <div
@@ -15969,7 +15969,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                     http.HandleFunc("/", handler)
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-14"
               >
                 <div
@@ -15994,7 +15994,7 @@ Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip
                     http.ListenAndServe(":8080", nil)
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-15"
               >
                 <div
@@ -16238,7 +16238,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
           <code>
             <code>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-1"
               >
                 <div
@@ -16263,7 +16263,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
                 &lt;project [...]&gt;
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-2"
               >
                 <div
@@ -16288,7 +16288,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
                 
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-3"
               >
                 <div
@@ -16313,7 +16313,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
                   [...]
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-4"
               >
                 <div
@@ -16338,7 +16338,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
                 
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-5"
               >
                 <div
@@ -16363,7 +16363,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
                   &lt;build&gt;
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-6"
               >
                 <div
@@ -16388,7 +16388,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
                     &lt;plugins&gt;
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-7"
               >
                 <div
@@ -16413,7 +16413,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
                 
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-8"
               >
                 <div
@@ -16438,7 +16438,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
                       [...]
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-9"
               >
                 <div
@@ -16463,7 +16463,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
                 
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-10"
               >
                 <div
@@ -16488,7 +16488,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
                       &lt;plugin&gt;
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-11"
               >
                 <div
@@ -16513,7 +16513,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
                         &lt;groupId&gt;org.apache.maven.plugins&lt;/groupId&gt;
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-12"
               >
                 <div
@@ -16538,7 +16538,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
                         &lt;artifactId&gt;maven-enforcer-plugin&lt;/artifactId&gt;
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-13"
               >
                 <div
@@ -16563,7 +16563,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
                       &lt;/plugin&gt;
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-14"
               >
                 <div
@@ -16588,7 +16588,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
                       &lt;plugin&gt;
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-15"
               >
                 <div
@@ -16613,7 +16613,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
                         &lt;groupId&gt;org.codehaus.mojo&lt;/groupId&gt;
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-16"
               >
                 <div
@@ -16638,7 +16638,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
                         &lt;artifactId&gt;animal-sniffer-maven-plugin&lt;/artifactId&gt;
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-17"
               >
                 <div
@@ -16663,7 +16663,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
                       &lt;/plugin&gt;
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-18"
               >
                 <div
@@ -16688,7 +16688,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
                     &lt;/plugins&gt;
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-19"
               >
                 <div
@@ -16713,7 +16713,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
                   &lt;/build&gt;
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-20"
               >
                 <div
@@ -16738,7 +16738,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
                 
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-21"
               >
                 <div
@@ -16763,7 +16763,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
                   [...]
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-22"
               >
                 <div
@@ -16788,7 +16788,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
                 
               </div>
               <div
-                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+                className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
                 id="line-23"
               >
                 <div
@@ -68995,7 +68995,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
       <code>
         <code>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-1"
           >
             <div
@@ -69020,7 +69020,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
             package main
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-2"
           >
             <div
@@ -69045,7 +69045,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-3"
           >
             <div
@@ -69070,7 +69070,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
             import (
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-4"
           >
             <div
@@ -69095,7 +69095,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
               "fmt"
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-5"
           >
             <div
@@ -69120,7 +69120,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
               "net/http"
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-6"
           >
             <div
@@ -69145,7 +69145,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
             )
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-7"
           >
             <div
@@ -69170,7 +69170,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-8"
           >
             <div
@@ -69195,7 +69195,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
             func main() {
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-9"
           >
             <div
@@ -69220,7 +69220,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
               http.HandleFunc("/", func (w http.ResponseWriter, r *http.Request) {
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-10"
           >
             <div
@@ -69245,7 +69245,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
                 fmt.Fprintf(w, "Welcome to my website!")
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-11"
           >
             <div
@@ -69270,7 +69270,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
               })
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-12"
           >
             <div
@@ -69295,7 +69295,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-13"
           >
             <div
@@ -69320,7 +69320,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
               fs := http.FileServer(http.Dir("static/"))
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-14"
           >
             <div
@@ -69345,7 +69345,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
               http.Handle("/static/", http.StripPrefix("/static/", fs))
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-15"
           >
             <div
@@ -69370,7 +69370,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-16"
           >
             <div
@@ -69395,7 +69395,7 @@ exports[`Storyshots SyntaxHighlighter Go 1`] = `
               http.ListenAndServe(":80", nil)
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-17"
           >
             <div
@@ -69451,7 +69451,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
       <code>
         <code>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-1"
           >
             <div
@@ -69476,7 +69476,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
             package com.example;
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-2"
           >
             <div
@@ -69501,7 +69501,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-3"
           >
             <div
@@ -69526,7 +69526,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
             import java.io.IOException;
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-4"
           >
             <div
@@ -69551,7 +69551,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
             import java.io.OutputStream;
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-5"
           >
             <div
@@ -69576,7 +69576,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
             import java.net.InetSocketAddress;
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-6"
           >
             <div
@@ -69601,7 +69601,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-7"
           >
             <div
@@ -69626,7 +69626,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
             import com.sun.net.httpserver.HttpExchange;
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-8"
           >
             <div
@@ -69651,7 +69651,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
             import com.sun.net.httpserver.HttpHandler;
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-9"
           >
             <div
@@ -69676,7 +69676,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
             import com.sun.net.httpserver.HttpServer;
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-10"
           >
             <div
@@ -69701,7 +69701,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-11"
           >
             <div
@@ -69726,7 +69726,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
             public class Test {
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-12"
           >
             <div
@@ -69751,7 +69751,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-13"
           >
             <div
@@ -69776,7 +69776,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
               public static void main(String[] args) throws Exception {
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-14"
           >
             <div
@@ -69801,7 +69801,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
                 HttpServer server = HttpServer.create(new InetSocketAddress(8000), 0);
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-15"
           >
             <div
@@ -69826,7 +69826,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
                 server.createContext("/test", new MyHandler());
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-16"
           >
             <div
@@ -69851,7 +69851,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
                 server.setExecutor(null); // creates a default executor
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-17"
           >
             <div
@@ -69876,7 +69876,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
                 server.start();
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-18"
           >
             <div
@@ -69901,7 +69901,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
               }
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-19"
           >
             <div
@@ -69926,7 +69926,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-20"
           >
             <div
@@ -69951,7 +69951,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
               static class MyHandler implements HttpHandler {
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-21"
           >
             <div
@@ -69976,7 +69976,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
                 @Override
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-22"
           >
             <div
@@ -70001,7 +70001,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
                 public void handle(HttpExchange t) throws IOException {
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-23"
           >
             <div
@@ -70026,7 +70026,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
                   String response = "This is the response";
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-24"
           >
             <div
@@ -70051,7 +70051,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
                   t.sendResponseHeaders(200, response.length());
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-25"
           >
             <div
@@ -70076,7 +70076,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
                   OutputStream os = t.getResponseBody();
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-26"
           >
             <div
@@ -70101,7 +70101,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
                   os.write(response.getBytes());
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-27"
           >
             <div
@@ -70126,7 +70126,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
                   os.close();
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-28"
           >
             <div
@@ -70151,7 +70151,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
                 }
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-29"
           >
             <div
@@ -70176,7 +70176,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
               }
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-30"
           >
             <div
@@ -70201,7 +70201,7 @@ exports[`Storyshots SyntaxHighlighter Java 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-31"
           >
             <div
@@ -70257,7 +70257,7 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
       <code>
         <code>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-1"
           >
             <div
@@ -70282,7 +70282,7 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
             var http = require('http');
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-2"
           >
             <div
@@ -70307,7 +70307,7 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-3"
           >
             <div
@@ -70332,7 +70332,7 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
             http.createServer(function (req, res) {
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-4"
           >
             <div
@@ -70357,7 +70357,7 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
               res.writeHead(200, {'Content-Type': 'text/plain'});
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-5"
           >
             <div
@@ -70382,7 +70382,7 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
               res.write('Hello World!');
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-6"
           >
             <div
@@ -70407,7 +70407,7 @@ exports[`Storyshots SyntaxHighlighter Javascript 1`] = `
               res.end();
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-7"
           >
             <div
@@ -70463,7 +70463,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
       <code>
         <code>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-1"
           >
             <div
@@ -70488,7 +70488,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             # &lt;a name="top"&gt;Markdown Test Page&lt;/a&gt;
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-2"
           >
             <div
@@ -70513,7 +70513,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-3"
           >
             <div
@@ -70538,7 +70538,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             * [Headings](#Headings)
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-4"
           >
             <div
@@ -70563,7 +70563,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             * [Paragraphs](#Paragraphs)
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-5"
           >
             <div
@@ -70588,7 +70588,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             * [Blockquotes](#Blockquotes)
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-6"
           >
             <div
@@ -70613,7 +70613,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             * [Lists](#Lists)
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-7"
           >
             <div
@@ -70638,7 +70638,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             * [Horizontal rule](#Horizontal)
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-8"
           >
             <div
@@ -70663,7 +70663,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             * [Table](#Table)
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-9"
           >
             <div
@@ -70688,7 +70688,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             * [Code](#Code)
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-10"
           >
             <div
@@ -70713,7 +70713,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             * [Inline elements](#Inline)
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-11"
           >
             <div
@@ -70738,7 +70738,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-12"
           >
             <div
@@ -70763,7 +70763,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             ***
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-13"
           >
             <div
@@ -70788,7 +70788,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-14"
           >
             <div
@@ -70813,7 +70813,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             # &lt;a name="Headings"&gt;Headings&lt;/a&gt;
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-15"
           >
             <div
@@ -70838,7 +70838,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-16"
           >
             <div
@@ -70863,7 +70863,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             # Heading one
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-17"
           >
             <div
@@ -70888,7 +70888,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-18"
           >
             <div
@@ -70913,7 +70913,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             Sint sit cillum pariatur eiusmod nulla pariatur ipsum. Sit laborum anim qui mollit tempor pariatur nisi minim dolor. Aliquip et adipisicing sit sit fugiat commodo id sunt. Nostrud enim ad commodo incididunt cupidatat in ullamco ullamco Lorem cupidatat velit enim et Lorem. Ut laborum cillum laboris fugiat culpa sint irure do reprehenderit culpa occaecat. Exercitation esse mollit tempor magna aliqua in occaecat aliquip veniam reprehenderit nisi dolor in laboris dolore velit.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-19"
           >
             <div
@@ -70938,7 +70938,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-20"
           >
             <div
@@ -70963,7 +70963,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             ## Heading two
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-21"
           >
             <div
@@ -70988,7 +70988,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-22"
           >
             <div
@@ -71013,7 +71013,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             Aute officia nulla deserunt do deserunt cillum velit magna. Officia veniam culpa anim minim dolore labore pariatur voluptate id ad est duis quis velit dolor pariatur enim. Incididunt enim excepteur do veniam consequat culpa do voluptate dolor fugiat ad adipisicing sit. Labore officia est adipisicing dolore proident eiusmod exercitation deserunt ullamco anim do occaecat velit. Elit dolor consectetur proident sunt aliquip est do tempor quis aliqua culpa aute. Duis in tempor exercitation pariatur et adipisicing mollit irure tempor ut enim esse commodo laboris proident. Do excepteur laborum anim esse aliquip eu sit id Lorem incididunt elit irure ea nulla dolor et. Nulla amet fugiat qui minim deserunt enim eu cupidatat aute officia do velit ea reprehenderit.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-23"
           >
             <div
@@ -71038,7 +71038,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-24"
           >
             <div
@@ -71063,7 +71063,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             ### Heading three
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-25"
           >
             <div
@@ -71088,7 +71088,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-26"
           >
             <div
@@ -71113,7 +71113,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             Voluptate cupidatat cillum elit quis ipsum eu voluptate fugiat consectetur enim. Quis ut voluptate culpa ex anim aute consectetur dolore proident voluptate exercitation eiusmod. Esse in do anim magna minim culpa sint. Adipisicing ipsum consectetur proident ullamco magna sit amet aliqua aute fugiat laborum exercitation duis et.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-27"
           >
             <div
@@ -71138,7 +71138,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-28"
           >
             <div
@@ -71163,7 +71163,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             #### Heading four
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-29"
           >
             <div
@@ -71188,7 +71188,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-30"
           >
             <div
@@ -71213,7 +71213,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             Commodo fugiat aliqua minim quis pariatur mollit id tempor. Non occaecat minim esse enim aliqua adipisicing nostrud duis consequat eu adipisicing qui. Minim aliquip sit excepteur ipsum consequat laborum pariatur excepteur. Veniam fugiat et amet ad elit anim laborum duis mollit occaecat et et ipsum et reprehenderit. Occaecat aliquip dolore adipisicing sint labore occaecat officia fugiat. Quis adipisicing exercitation exercitation eu amet est laboris sunt nostrud ipsum reprehenderit ullamco. Enim sint ut consectetur id anim aute voluptate exercitation mollit dolore magna magna est Lorem. Ut adipisicing adipisicing aliqua ullamco voluptate labore nisi tempor esse magna incididunt.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-31"
           >
             <div
@@ -71238,7 +71238,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-32"
           >
             <div
@@ -71263,7 +71263,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             ##### Heading five
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-33"
           >
             <div
@@ -71288,7 +71288,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-34"
           >
             <div
@@ -71313,7 +71313,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             Veniam enim esse amet veniam deserunt laboris amet enim consequat. Minim nostrud deserunt cillum consectetur commodo eu enim nostrud ullamco occaecat excepteur. Aliquip et ut est commodo enim dolor amet sint excepteur. Amet ad laboris laborum deserunt sint sunt aliqua commodo ex duis deserunt enim est ex labore ut. Duis incididunt velit adipisicing non incididunt adipisicing adipisicing. Ad irure duis nisi tempor eu dolor fugiat magna et consequat tempor eu ex dolore. Mollit esse nisi qui culpa ut nisi ex proident culpa cupidatat cillum culpa occaecat anim. Ut officia sit ea nisi ea excepteur nostrud ipsum et nulla.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-35"
           >
             <div
@@ -71338,7 +71338,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-36"
           >
             <div
@@ -71363,7 +71363,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             ###### Heading six
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-37"
           >
             <div
@@ -71388,7 +71388,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-38"
           >
             <div
@@ -71413,7 +71413,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-39"
           >
             <div
@@ -71438,7 +71438,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-40"
           >
             <div
@@ -71463,7 +71463,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-41"
           >
             <div
@@ -71488,7 +71488,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             [[Top]](#top)
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-42"
           >
             <div
@@ -71513,7 +71513,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-43"
           >
             <div
@@ -71538,7 +71538,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             # &lt;a name="Paragraphs"&gt;Paragraphs&lt;/a&gt;
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-44"
           >
             <div
@@ -71563,7 +71563,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-45"
           >
             <div
@@ -71588,7 +71588,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             Incididunt ex adipisicing ea ullamco consectetur in voluptate proident fugiat tempor deserunt reprehenderit ullamco id dolore laborum. Do laboris laboris minim incididunt qui consectetur exercitation adipisicing dolore et magna consequat magna anim sunt. Officia fugiat Lorem sunt pariatur incididunt Lorem reprehenderit proident irure. Dolore ipsum aliqua mollit ad officia fugiat sit eu aliquip cupidatat ipsum duis laborum laborum fugiat esse. Voluptate anim ex dolore deserunt ea ex eiusmod irure. Occaecat excepteur aliqua exercitation aliquip dolor esse eu eu.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-46"
           >
             <div
@@ -71613,7 +71613,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-47"
           >
             <div
@@ -71638,7 +71638,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             Officia dolore laborum aute incididunt commodo nisi velit est est elit et dolore elit exercitation. Enim aliquip magna id ipsum aliquip consectetur ad nulla quis. Incididunt pariatur dolor consectetur cillum enim velit cupidatat laborum quis ex.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-48"
           >
             <div
@@ -71663,7 +71663,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-49"
           >
             <div
@@ -71688,7 +71688,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             Officia irure in non voluptate adipisicing sit amet tempor duis dolore deserunt enim ut. Reprehenderit incididunt in ad anim et deserunt deserunt Lorem laborum quis. Enim aute anim labore proident laboris voluptate elit excepteur in. Ex labore nulla velit officia ullamco Lorem Lorem id do. Dolore ullamco ipsum magna dolor pariatur voluptate ipsum id occaecat ipsum. Dolore tempor quis duis commodo quis quis enim.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-50"
           >
             <div
@@ -71713,7 +71713,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-51"
           >
             <div
@@ -71738,7 +71738,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             [[Top]](#top)
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-52"
           >
             <div
@@ -71763,7 +71763,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-53"
           >
             <div
@@ -71788,7 +71788,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             # &lt;a name="Blockquotes"&gt;Blockquotes&lt;/a&gt;
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-54"
           >
             <div
@@ -71813,7 +71813,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-55"
           >
             <div
@@ -71838,7 +71838,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             Ad nisi laborum aute cupidatat magna deserunt eu id laboris id. Aliquip nulla cupidatat sint ex Lorem mollit laborum dolor amet est ut esse aute. Nostrud ex consequat id incididunt proident ipsum minim duis aliqua ut ex et ad quis. Laborum sint esse cillum anim nulla cillum consectetur aliqua sit. Nisi excepteur cillum labore amet excepteur commodo enim occaecat consequat ipsum proident exercitation duis id in.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-56"
           >
             <div
@@ -71863,7 +71863,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-57"
           >
             <div
@@ -71888,7 +71888,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             &gt; Ipsum et cupidatat mollit exercitation enim duis sunt irure aliqua reprehenderit mollit. Pariatur Lorem pariatur laboris do culpa do elit irure. Eiusmod amet nulla voluptate velit culpa et aliqua ad reprehenderit sit ut.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-58"
           >
             <div
@@ -71913,7 +71913,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-59"
           >
             <div
@@ -71938,7 +71938,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             Labore ea magna Lorem consequat aliquip consectetur cillum duis dolore. Et veniam dolor qui incididunt minim amet laboris sit. Dolore ad esse commodo et dolore amet est velit ut nisi ea. Excepteur ea nulla commodo dolore anim dolore adipisicing eiusmod labore id enim esse quis mollit deserunt est. Minim ea culpa voluptate nostrud commodo proident in duis aliquip minim.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-60"
           >
             <div
@@ -71963,7 +71963,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-61"
           >
             <div
@@ -71988,7 +71988,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             &gt; Qui est sit et reprehenderit aute est esse enim aliqua id aliquip ea anim. Pariatur sint reprehenderit mollit velit voluptate enim consectetur sint enim. Quis exercitation proident elit non id qui culpa dolore esse aliquip consequat.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-62"
           >
             <div
@@ -72013,7 +72013,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-63"
           >
             <div
@@ -72038,7 +72038,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             Ipsum excepteur cupidatat sunt minim ad eiusmod tempor sit.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-64"
           >
             <div
@@ -72063,7 +72063,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-65"
           >
             <div
@@ -72088,7 +72088,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             &gt; Deserunt excepteur adipisicing culpa pariatur cillum laboris ullamco nisi fugiat cillum officia. In cupidatat nulla aliquip tempor ad Lorem Lorem quis voluptate officia consectetur pariatur ex in est duis. Mollit id esse est elit exercitation voluptate nostrud nisi laborum magna dolore dolore tempor in est consectetur.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-66"
           >
             <div
@@ -72113,7 +72113,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-67"
           >
             <div
@@ -72138,7 +72138,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             Adipisicing voluptate ipsum culpa voluptate id aute laboris labore esse fugiat veniam ullamco occaecat do ut. Tempor et esse reprehenderit veniam proident ipsum irure sit ullamco et labore ea excepteur nulla labore ut. Ex aute minim quis tempor in eu id id irure ea nostrud dolor esse.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-68"
           >
             <div
@@ -72163,7 +72163,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-69"
           >
             <div
@@ -72188,7 +72188,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             [[Top]](#top)
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-70"
           >
             <div
@@ -72213,7 +72213,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-71"
           >
             <div
@@ -72238,7 +72238,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             # &lt;a name="Lists"&gt;Lists&lt;/a&gt;
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-72"
           >
             <div
@@ -72263,7 +72263,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-73"
           >
             <div
@@ -72288,7 +72288,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             ### Ordered List
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-74"
           >
             <div
@@ -72313,7 +72313,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-75"
           >
             <div
@@ -72338,7 +72338,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             1. Longan
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-76"
           >
             <div
@@ -72363,7 +72363,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             2. Lychee
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-77"
           >
             <div
@@ -72388,7 +72388,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             3. Excepteur ad cupidatat do elit laborum amet cillum reprehenderit consequat quis.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-78"
           >
             <div
@@ -72413,7 +72413,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
                 Deserunt officia esse aliquip consectetur duis ut labore laborum commodo aliquip aliquip velit pariatur dolore.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-79"
           >
             <div
@@ -72438,7 +72438,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             4. Marionberry
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-80"
           >
             <div
@@ -72463,7 +72463,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             5. Melon
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-81"
           >
             <div
@@ -72488,7 +72488,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
                 - Cantaloupe
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-82"
           >
             <div
@@ -72513,7 +72513,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
                 - Honeydew
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-83"
           >
             <div
@@ -72538,7 +72538,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
                 - Watermelon
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-84"
           >
             <div
@@ -72563,7 +72563,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             6. Miracle fruit
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-85"
           >
             <div
@@ -72588,7 +72588,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             7. Mulberry
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-86"
           >
             <div
@@ -72613,7 +72613,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-87"
           >
             <div
@@ -72638,7 +72638,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             ### Unordered List
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-88"
           >
             <div
@@ -72663,7 +72663,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-89"
           >
             <div
@@ -72688,7 +72688,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             - Olive
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-90"
           >
             <div
@@ -72713,7 +72713,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             - Orange
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-91"
           >
             <div
@@ -72738,7 +72738,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
                 - Blood orange
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-92"
           >
             <div
@@ -72763,7 +72763,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
                 - Clementine
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-93"
           >
             <div
@@ -72788,7 +72788,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             - Papaya
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-94"
           >
             <div
@@ -72813,7 +72813,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             - Ut aute ipsum occaecat nisi culpa Lorem id occaecat cupidatat id id magna laboris ad duis. Fugiat cillum dolore veniam nostrud proident sint consectetur eiusmod irure adipisicing.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-95"
           >
             <div
@@ -72838,7 +72838,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             - Passionfruit
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-96"
           >
             <div
@@ -72863,7 +72863,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-97"
           >
             <div
@@ -72888,7 +72888,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             [[Top]](#top)
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-98"
           >
             <div
@@ -72913,7 +72913,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-99"
           >
             <div
@@ -72938,7 +72938,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             # &lt;a name="Horizontal"&gt;Horizontal rule&lt;/a&gt;
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-100"
           >
             <div
@@ -72963,7 +72963,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-101"
           >
             <div
@@ -72988,7 +72988,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             In dolore velit aliquip labore mollit minim tempor veniam eu veniam ad in sint aliquip mollit mollit. Ex occaecat non deserunt elit laborum sunt tempor sint consequat culpa culpa qui sit. Irure ad commodo eu voluptate mollit cillum cupidatat veniam proident amet minim reprehenderit.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-102"
           >
             <div
@@ -73013,7 +73013,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-103"
           >
             <div
@@ -73038,7 +73038,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             ***
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-104"
           >
             <div
@@ -73063,7 +73063,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-105"
           >
             <div
@@ -73088,7 +73088,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             In laboris eiusmod reprehenderit aliquip sit proident occaecat. Non sit labore anim elit veniam Lorem minim commodo eiusmod irure do minim nisi. Dolor amet cillum excepteur consequat sint non sint.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-106"
           >
             <div
@@ -73113,7 +73113,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-107"
           >
             <div
@@ -73138,7 +73138,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             [[Top]](#top)
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-108"
           >
             <div
@@ -73163,7 +73163,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-109"
           >
             <div
@@ -73188,7 +73188,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             # &lt;a name="Table"&gt;Table&lt;/a&gt;
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-110"
           >
             <div
@@ -73213,7 +73213,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-111"
           >
             <div
@@ -73238,7 +73238,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             Duis sunt ut pariatur reprehenderit mollit mollit magna dolore in pariatur nulla commodo sit dolor ad fugiat. Laboris amet ea occaecat duis eu enim exercitation deserunt ea laborum occaecat reprehenderit. Et incididunt dolor commodo consequat mollit nisi proident non pariatur in et incididunt id. Eu ut et Lorem ea ex magna minim ipsum ipsum do.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-112"
           >
             <div
@@ -73263,7 +73263,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-113"
           >
             <div
@@ -73288,7 +73288,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             | Table Heading 1 | Table Heading 2 | Center align    | Right align     | Table Heading 5 |
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-114"
           >
             <div
@@ -73313,7 +73313,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             | :-------------- | :-------------- | :-------------: | --------------: | :-------------- |
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-115"
           >
             <div
@@ -73338,7 +73338,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             | Item 1          | Item 2          | Item 3          | Item 4          | Item 5          |
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-116"
           >
             <div
@@ -73363,7 +73363,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             | Item 1          | Item 2          | Item 3          | Item 4          | Item 5          |
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-117"
           >
             <div
@@ -73388,7 +73388,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             | Item 1          | Item 2          | Item 3          | Item 4          | Item 5          |
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-118"
           >
             <div
@@ -73413,7 +73413,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             | Item 1          | Item 2          | Item 3          | Item 4          | Item 5          |
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-119"
           >
             <div
@@ -73438,7 +73438,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             | Item 1          | Item 2          | Item 3          | Item 4          | Item 5          |
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-120"
           >
             <div
@@ -73463,7 +73463,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-121"
           >
             <div
@@ -73488,7 +73488,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             Minim id consequat adipisicing cupidatat laborum culpa veniam non consectetur et duis pariatur reprehenderit eu ex consectetur. Sunt nisi qui eiusmod ut cillum laborum Lorem officia aliquip laboris ullamco nostrud laboris non irure laboris. Cillum dolore labore Lorem deserunt mollit voluptate esse incididunt ex dolor.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-122"
           >
             <div
@@ -73513,7 +73513,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-123"
           >
             <div
@@ -73538,7 +73538,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             [[Top]](#top)
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-124"
           >
             <div
@@ -73563,7 +73563,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-125"
           >
             <div
@@ -73588,7 +73588,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             # &lt;a name="Code"&gt;Code&lt;/a&gt;
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-126"
           >
             <div
@@ -73613,7 +73613,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-127"
           >
             <div
@@ -73638,7 +73638,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             ## Inline code
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-128"
           >
             <div
@@ -73663,7 +73663,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-129"
           >
             <div
@@ -73688,7 +73688,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             Ad amet irure est magna id mollit Lorem in do duis enim. Excepteur velit nisi magna ea pariatur pariatur ullamco fugiat deserunt sint non sint. Duis duis est \`code in text\` velit velit aute culpa ex quis pariatur pariatur laborum aute pariatur duis tempor sunt ad. Irure magna voluptate dolore consectetur consectetur irure esse. Anim magna \`&lt;strong&gt;in culpa qui officia&lt;/strong&gt;\` dolor eiusmod esse amet aute cupidatat aliqua do id voluptate cupidatat reprehenderit amet labore deserunt.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-130"
           >
             <div
@@ -73713,7 +73713,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-131"
           >
             <div
@@ -73738,7 +73738,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             ## Highlighted
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-132"
           >
             <div
@@ -73763,7 +73763,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-133"
           >
             <div
@@ -73788,7 +73788,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             Et fugiat ad nisi amet magna labore do cillum fugiat occaecat cillum Lorem proident. In sint dolor ullamco ad do adipisicing amet id excepteur Lorem aliquip sit irure veniam laborum duis cillum. Aliqua occaecat minim cillum deserunt magna sunt laboris do do irure ea nostrud consequat ut voluptate ex.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-134"
           >
             <div
@@ -73813,7 +73813,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-135"
           >
             <div
@@ -73838,7 +73838,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             \`\`\`go
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-136"
           >
             <div
@@ -73863,7 +73863,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             package main
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-137"
           >
             <div
@@ -73888,7 +73888,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-138"
           >
             <div
@@ -73913,7 +73913,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             import (
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-139"
           >
             <div
@@ -73938,7 +73938,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
                 "fmt"
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-140"
           >
             <div
@@ -73963,7 +73963,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
                 "net/http"
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-141"
           >
             <div
@@ -73988,7 +73988,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             )
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-142"
           >
             <div
@@ -74013,7 +74013,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-143"
           >
             <div
@@ -74038,7 +74038,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             func handler(w http.ResponseWriter, r *http.Request) {
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-144"
           >
             <div
@@ -74063,7 +74063,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
                 fmt.Fprintf(w, "Hi there, I love %s!", r.URL.Path[1:])
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-145"
           >
             <div
@@ -74088,7 +74088,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             }
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-146"
           >
             <div
@@ -74113,7 +74113,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-147"
           >
             <div
@@ -74138,7 +74138,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             func main() {
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-148"
           >
             <div
@@ -74163,7 +74163,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
                 http.HandleFunc("/", handler)
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-149"
           >
             <div
@@ -74188,7 +74188,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
                 http.ListenAndServe(":8080", nil)
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-150"
           >
             <div
@@ -74213,7 +74213,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             }
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-151"
           >
             <div
@@ -74238,7 +74238,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             \`\`\`
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-152"
           >
             <div
@@ -74263,7 +74263,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-153"
           >
             <div
@@ -74288,7 +74288,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             Ex amet id ex aliquip id do laborum excepteur exercitation elit sint commodo occaecat nostrud est. Nostrud pariatur esse veniam laborum non sint magna sit laboris minim in id. Aliqua pariatur pariatur excepteur adipisicing irure culpa consequat commodo et ex id ad.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-154"
           >
             <div
@@ -74313,7 +74313,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-155"
           >
             <div
@@ -74338,7 +74338,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             [[Top]](#top)
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-156"
           >
             <div
@@ -74363,7 +74363,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-157"
           >
             <div
@@ -74388,7 +74388,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             # &lt;a name="Inline"&gt;Inline elements&lt;/a&gt;
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-158"
           >
             <div
@@ -74413,7 +74413,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-159"
           >
             <div
@@ -74438,7 +74438,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             Sint ea anim ipsum ad commodo cupidatat do **exercitation** incididunt et minim ad labore sunt. Minim deserunt labore laboris velit nulla incididunt ipsum nulla. Ullamco ad laborum ea qui et anim in laboris exercitation tempor sit officia laborum reprehenderit culpa velit quis. **Consequat commodo** reprehenderit duis [irure](#!) esse esse exercitation minim enim Lorem dolore duis irure. Nisi Lorem reprehenderit ea amet excepteur dolor excepteur magna labore proident voluptate ipsum. Reprehenderit ex esse deserunt aliqua ea officia mollit Lorem nulla magna enim. Et ad ipsum labore enim ipsum **cupidatat consequat**. Commodo non ea cupidatat magna deserunt dolore ipsum velit nulla elit veniam nulla eiusmod proident officia.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-160"
           >
             <div
@@ -74463,7 +74463,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-161"
           >
             <div
@@ -74488,7 +74488,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             ![Super wide](http://placekitten.com/1280/800)
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-162"
           >
             <div
@@ -74513,7 +74513,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-163"
           >
             <div
@@ -74538,7 +74538,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             *Proident sit veniam in est proident officia adipisicing* ea tempor cillum non cillum velit deserunt. Voluptate laborum incididunt sit consectetur Lorem irure incididunt voluptate nostrud. Commodo ut eiusmod tempor cupidatat esse enim minim ex anim consequat. Mollit sint culpa qui laboris quis consectetur ad sint esse. Amet anim anim minim ullamco et duis non irure. Sit tempor adipisicing ea laboris \`culpa ex duis sint\` anim aute reprehenderit id eu ea. Aute [excepteur proident](#!) Lorem minim adipisicing nostrud mollit ad ut voluptate do nulla esse occaecat aliqua sint anim.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-164"
           >
             <div
@@ -74563,7 +74563,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-165"
           >
             <div
@@ -74588,7 +74588,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             ![Not so big](http://placekitten.com/480/400)
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-166"
           >
             <div
@@ -74613,7 +74613,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-167"
           >
             <div
@@ -74638,7 +74638,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             Incididunt in culpa cupidatat mollit cillum qui proident sit. In cillum aliquip incididunt voluptate magna amet cupidatat cillum pariatur sint aliqua est _enim **anim** voluptate_. Magna aliquip proident incididunt id duis pariatur eiusmod incididunt commodo culpa dolore sit. Culpa do nostrud elit ad exercitation anim pariatur non minim nisi **adipisicing sunt _officia_**. Do deserunt magna mollit Lorem commodo ipsum do cupidatat mollit enim ut elit veniam ea voluptate.
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-168"
           >
             <div
@@ -74663,7 +74663,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-169"
           >
             <div
@@ -74688,7 +74688,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             [![Manny Pacquiao](https://img.youtube.com/vi/s6bCmZmy9aQ/0.jpg)](https://youtu.be/s6bCmZmy9aQ)
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-170"
           >
             <div
@@ -74713,7 +74713,7 @@ exports[`Storyshots SyntaxHighlighter Markdown 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-171"
           >
             <div
@@ -74769,7 +74769,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
       <code>
         <code>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-1"
           >
             <div
@@ -74794,7 +74794,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
             from BaseHTTPServer import BaseHTTPRequestHandler,HTTPServer
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-2"
           >
             <div
@@ -74819,7 +74819,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-3"
           >
             <div
@@ -74844,7 +74844,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
             PORT_NUMBER = 8080
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-4"
           >
             <div
@@ -74869,7 +74869,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-5"
           >
             <div
@@ -74894,7 +74894,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
             class myHandler(BaseHTTPRequestHandler):
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-6"
           >
             <div
@@ -74919,7 +74919,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-7"
           >
             <div
@@ -74944,7 +74944,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
               def do_GET(self):
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-8"
           >
             <div
@@ -74969,7 +74969,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
                 self.send_response(200)
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-9"
           >
             <div
@@ -74994,7 +74994,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
                 self.send_header('Content-type','text/html')
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-10"
           >
             <div
@@ -75019,7 +75019,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
                 self.end_headers()
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-11"
           >
             <div
@@ -75044,7 +75044,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
                 self.wfile.write("Hello World !")
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-12"
           >
             <div
@@ -75069,7 +75069,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
                 return
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-13"
           >
             <div
@@ -75094,7 +75094,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-14"
           >
             <div
@@ -75119,7 +75119,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
             try:
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-15"
           >
             <div
@@ -75144,7 +75144,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
               server = HTTPServer(('', PORT_NUMBER), myHandler)
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-16"
           >
             <div
@@ -75169,7 +75169,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
               print 'Started httpserver on port ' , PORT_NUMBER
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-17"
           >
             <div
@@ -75194,7 +75194,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
               server.serve_forever()
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-18"
           >
             <div
@@ -75219,7 +75219,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
             except KeyboardInterrupt:
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-19"
           >
             <div
@@ -75244,7 +75244,7 @@ exports[`Storyshots SyntaxHighlighter Python 1`] = `
               print '^C received, shutting down the web server'
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-20"
           >
             <div
@@ -75300,187 +75300,187 @@ exports[`Storyshots SyntaxHighlighter Without line numbers 1`] = `
       <code>
         <code>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-1"
           >
             package com.example;
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-2"
           >
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-3"
           >
             import java.io.IOException;
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-4"
           >
             import java.io.OutputStream;
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-5"
           >
             import java.net.InetSocketAddress;
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-6"
           >
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-7"
           >
             import com.sun.net.httpserver.HttpExchange;
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-8"
           >
             import com.sun.net.httpserver.HttpHandler;
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-9"
           >
             import com.sun.net.httpserver.HttpServer;
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-10"
           >
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-11"
           >
             public class Test {
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-12"
           >
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-13"
           >
               public static void main(String[] args) throws Exception {
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-14"
           >
                 HttpServer server = HttpServer.create(new InetSocketAddress(8000), 0);
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-15"
           >
                 server.createContext("/test", new MyHandler());
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-16"
           >
                 server.setExecutor(null); // creates a default executor
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-17"
           >
                 server.start();
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-18"
           >
               }
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-19"
           >
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-20"
           >
               static class MyHandler implements HttpHandler {
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-21"
           >
                 @Override
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-22"
           >
                 public void handle(HttpExchange t) throws IOException {
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-23"
           >
                   String response = "This is the response";
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-24"
           >
                   t.sendResponseHeaders(200, response.length());
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-25"
           >
                   OutputStream os = t.getResponseBody();
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-26"
           >
                   os.write(response.getBytes());
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-27"
           >
                   os.close();
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-28"
           >
                 }
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-29"
           >
               }
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-30"
           >
             
           </div>
           <div
-            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 llYGhU"
+            className="SyntaxHighlighterRenderer__RowContainer-sc-12li0bg-0 hvuihW"
             id="line-31"
           >
             }

--- a/scm-ui/ui-styles/src/dark.scss
+++ b/scm-ui/ui-styles/src/dark.scss
@@ -195,6 +195,8 @@ $danger-25: scale-color($danger, $lightness: -75%);
   --scm-secondary-text: #{$white};
   --scm-hover-color: #{$grey};
   --scm-column-selection: #{$link-dark};
+  --scm-sh-focus-line-background: hsl(0, 0%, 18%);
+  --scm-sh-focus-line-contrast: hsl(0, 0%, 60%);
 
   --sh-base-color: #{$white};
   --sh-font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;

--- a/scm-ui/ui-styles/src/highcontrast.scss
+++ b/scm-ui/ui-styles/src/highcontrast.scss
@@ -93,6 +93,8 @@ $tooltip-color: $scheme-main;
   --scm-secondary-text: #{$white};
   --scm-hover-color: #{$grey};
   --scm-column-selection: #{$link-dark};
+  --scm-sh-focus-line-background: hsl(0, 0%, 10%);
+  --scm-sh-focus-line-contrast: hsl(0, 0%, 60%);
 
   --sh-base-color: #fff;
   --sh-font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;

--- a/scm-ui/ui-styles/src/light.scss
+++ b/scm-ui/ui-styles/src/light.scss
@@ -58,6 +58,8 @@ $popover-background-color: $grey-light;
   --scm-secondary-text: #{$black};
   --scm-hover-color: #{$black-ter};
   --scm-column-selection: #{$link-25};
+  --scm-sh-focus-line-background: hsl(0, 0%, 95%);
+  --scm-sh-focus-line-contrast: hsl(0, 0%, 70%);
 
   --sh-base-color: #363636;
   --sh-font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;


### PR DESCRIPTION
## Proposed changes

The styling for the focused line (e.g. permalink) in the source view with syntax highlighting was hard-coded and did not meet accessibility standards, especially in high-contrast mode. This pull request introduces two new css variables that are fine-tuned to meet contrast requirements for each theme. An additional "bar" with specifically high contrast has been added to the left of the focused line, because it was impossible to find one background color that would provide sufficient contrast with both the page background as well as all highlighting colors.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
