### PR TITLE
Fix character encoding for basic authentication

### DIFF
--- a/gradle/changelog/basic_auth.yaml
+++ b/gradle/changelog/basic_auth.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: character encoding for basic authentication ([#2038](https://github.com/scm-manager/scm-manager/pull/2038))

--- a/scm-core/src/main/java/sonia/scm/web/UserAgent.java
+++ b/scm-core/src/main/java/sonia/scm/web/UserAgent.java
@@ -264,7 +264,7 @@ public final class UserAgent
     private boolean scmClient = false;
 
     /** basic authentication charset */
-    private Charset basicAuthenticationCharset = StandardCharsets.ISO_8859_1;
+    private Charset basicAuthenticationCharset = StandardCharsets.UTF_8;
   }
 
 

--- a/scm-core/src/test/java/sonia/scm/web/UserAgentParserTest.java
+++ b/scm-core/src/test/java/sonia/scm/web/UserAgentParserTest.java
@@ -88,7 +88,7 @@ public class UserAgentParserTest
   {
     UserAgent ua = parser.parse(UA_1);
 
-    assertEquals(Charsets.ISO_8859_1, ua.getBasicAuthenticationCharset());
+    assertEquals(Charsets.UTF_8, ua.getBasicAuthenticationCharset());
     assertFalse(ua.isBrowser());
   }
 


### PR DESCRIPTION
## Proposed changes

Regarding to RFC 7617 (see
https://datatracker.ietf.org/doc/html/rfc7617), the default
encoding for basic auth strings should be UTF-8.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
