### PR TITLE
Fix NPE on synchronous repository export

### DIFF
--- a/gradle/changelog/npe_on_export.yaml
+++ b/gradle/changelog/npe_on_export.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: NPE on synchronous repository export ([#2040](https://github.com/scm-manager/scm-manager/pull/2040))

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/RepositoryExportResource.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/RepositoryExportResource.java
@@ -457,8 +457,6 @@ public class RepositoryExportResource {
       return Response.status(204).build();
     } else {
       StreamingOutput output = os -> fullScmRepositoryExporter.export(repository, os, password);
-      exportService.setExportFinished(repository);
-
       return Response
         .ok(output, "application/x-gzip")
         .header("content-disposition", createContentDispositionHeaderValue(repository, fileExtension))


### PR DESCRIPTION
## Proposed changes

When a repository was exported synchronously with metadata,
the server ran into a NullPointerException. The was because
the resource tried to write an export result to a stored
export item, that does not exist for synchronous exports.

This simply removes this call.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
