### PR TITLE
Notify user about results of manually executed health check

### DIFF
--- a/gradle/changelog/notify_current_user.yaml
+++ b/gradle/changelog/notify_current_user.yaml
@@ -1,0 +1,2 @@
+- type: changed
+  description: Notify user about results of manually executed health check ([#2044](https://github.com/scm-manager/scm-manager/pull/2044))

--- a/scm-webapp/src/main/resources/locales/de/plugins.json
+++ b/scm-webapp/src/main/resources/locales/de/plugins.json
@@ -480,7 +480,8 @@
   "notifications": {
     "exportFinished": "Der Repository Export wurde abgeschlossen.",
     "exportFailed": "Der Repository Export ist fehlgeschlagen. Versuchen Sie es erneut oder wenden Sie sich an einen Administrator.",
-    "healthCheckFailed": "Der Repository Health Check ist fehlgeschlagen."
+    "healthCheckFailed": "Der Repository Health Check ist fehlgeschlagen.",
+    "healthCheckSuccess": "Der Repository Health Check war erfolgreich."
   },
   "search": {
     "types": {

--- a/scm-webapp/src/main/resources/locales/en/plugins.json
+++ b/scm-webapp/src/main/resources/locales/en/plugins.json
@@ -424,7 +424,8 @@
   "notifications": {
     "exportFinished": "The repository export has been finished.",
     "exportFailed": "The repository export has failed. Try it again or contact your administrator.",
-    "healthCheckFailed": "The repository health check has failed."
+    "healthCheckFailed": "The repository health check has failed.",
+    "healthCheckSuccess": "The repository health check was successful."
   },
   "search": {
     "types": {

--- a/scm-webapp/src/test/java/sonia/scm/repository/HealthCheckerTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/repository/HealthCheckerTest.java
@@ -119,6 +119,7 @@ class HealthCheckerTest {
 
     @Test
     void shouldComputeLightChecks() {
+      when(subject.getPrincipal()).thenReturn("trillian");
       when(healthCheck1.check(repository)).thenReturn(HealthCheckResult.unhealthy(createFailure("error1")));
       when(healthCheck2.check(repository)).thenReturn(HealthCheckResult.unhealthy(createFailure("error2")));
 
@@ -261,8 +262,8 @@ class HealthCheckerTest {
 
         checker.fullCheck(repositoryId);
 
-        verify(notificationSender, never()).send(any());
-        verify(notificationSender,times(1)).send(any(), eq("trillian"));
+        verify(notificationSender, times(1)).send(any());
+        verify(notificationSender, never()).send(any(), eq("trillian"));
       }
 
       @Test
@@ -274,7 +275,7 @@ class HealthCheckerTest {
 
         checker.fullCheck(repositoryId);
 
-        verify(notificationSender).send(any(), eq("trillian"));
+        verify(notificationSender).send(any());
         verify(notificationSender).send(any(), eq("Arthur"));
       }
     }


### PR DESCRIPTION
## Proposed changes

When manually starting health checks, the user should always receive a notification about the status, whether successful or not.

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
