### PR TITLE
Missing profile link in footer

### DIFF
--- a/gradle/changelog/add_profile_link.yaml
+++ b/gradle/changelog/add_profile_link.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Missing profile link in footer ([#2057](https://github.com/scm-manager/scm-manager/pull/2057))

--- a/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
+++ b/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
@@ -1486,10 +1486,20 @@ exports[`Storyshots Footer Default 1`] = `
             <a
               className=""
               data-testid="footer-user-profile"
-              href="/me/settings/theme"
+              href="/me"
               onClick={[Function]}
             >
               footer.user.profile
+            </a>
+          </li>
+          <li>
+            <a
+              className=""
+              data-testid="footer-user-theme"
+              href="/me/settings/theme"
+              onClick={[Function]}
+            >
+              footer.user.theme
             </a>
           </li>
         </ul>
@@ -1613,10 +1623,20 @@ exports[`Storyshots Footer Full 1`] = `
             <a
               className=""
               data-testid="footer-user-profile"
-              href="/me/settings/theme"
+              href="/me"
               onClick={[Function]}
             >
               footer.user.profile
+            </a>
+          </li>
+          <li>
+            <a
+              className=""
+              data-testid="footer-user-theme"
+              href="/me/settings/theme"
+              onClick={[Function]}
+            >
+              footer.user.theme
             </a>
           </li>
           <li>
@@ -1779,10 +1799,20 @@ exports[`Storyshots Footer With Avatar 1`] = `
             <a
               className=""
               data-testid="footer-user-profile"
-              href="/me/settings/theme"
+              href="/me"
               onClick={[Function]}
             >
               footer.user.profile
+            </a>
+          </li>
+          <li>
+            <a
+              className=""
+              data-testid="footer-user-theme"
+              href="/me/settings/theme"
+              onClick={[Function]}
+            >
+              footer.user.theme
             </a>
           </li>
         </ul>
@@ -1898,10 +1928,20 @@ exports[`Storyshots Footer With Plugin Links 1`] = `
             <a
               className=""
               data-testid="footer-user-profile"
-              href="/me/settings/theme"
+              href="/me"
               onClick={[Function]}
             >
               footer.user.profile
+            </a>
+          </li>
+          <li>
+            <a
+              className=""
+              data-testid="footer-user-theme"
+              href="/me/settings/theme"
+              onClick={[Function]}
+            >
+              footer.user.theme
             </a>
           </li>
           <li>

--- a/scm-ui/ui-components/src/layout/Footer.tsx
+++ b/scm-ui/ui-components/src/layout/Footer.tsx
@@ -97,7 +97,8 @@ const Footer: FC<Props> = ({ me, version, links }) => {
         <div className="columns is-size-7">
           {me ? (
             <FooterSection title={meSectionTile}>
-              <NavLink to="/me/settings/theme" label={t("footer.user.profile")} testId="footer-user-profile" />
+              <NavLink to="/me" label={t("footer.user.profile")} testId="footer-user-profile" />
+              <NavLink to="/me/settings/theme" label={t("footer.user.theme")} testId="footer-user-theme" />
               {me?._links?.password && (
                 <NavLink to="/me/settings/password" label={t("profile.changePasswordNavLink")} />
               )}

--- a/scm-ui/ui-webapp/public/locales/de/commons.json
+++ b/scm-ui/ui-webapp/public/locales/de/commons.json
@@ -135,7 +135,8 @@
   },
   "footer": {
     "user": {
-      "profile": "Profil"
+      "profile": "Profil",
+      "theme": "Theme"
     },
     "information": {
       "title": "Information"

--- a/scm-ui/ui-webapp/public/locales/de/commons.json
+++ b/scm-ui/ui-webapp/public/locales/de/commons.json
@@ -99,13 +99,13 @@
     "theme": {
       "nav": {
         "label": "Design",
-        "title": "Wähle dein Design"
+        "title": "Design wählen"
       },
-      "subtitle": "Wähle dein Design",
+      "subtitle": "Design wählen",
       "submit": "Anwenden",
       "light": {
         "displayName": "Hell",
-        "description": "„Hell“ is das Standard-Design des SCM-Managers"
+        "description": "„Hell“ ist das Standard-Design des SCM-Managers"
       },
       "highcontrast": {
         "displayName": "Hoher Kontrast",
@@ -136,7 +136,7 @@
   "footer": {
     "user": {
       "profile": "Profil",
-      "theme": "Theme"
+      "theme": "Design"
     },
     "information": {
       "title": "Information"

--- a/scm-ui/ui-webapp/public/locales/en/commons.json
+++ b/scm-ui/ui-webapp/public/locales/en/commons.json
@@ -136,7 +136,8 @@
   },
   "footer": {
     "user": {
-      "profile": "Profile"
+      "profile": "Profile",
+      "theme": "Theme"
     },
     "information": {
       "title": "Information"


### PR DESCRIPTION
## Proposed changes

Currently there is a link to `Theme` with the name `Profile` in the footer. Another link should be added which is called `Theme` and points to `Theme`. In addition, `Profile` should now point to `Information`.

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
