### PR TITLE
Remove superfluous user theme link properties

### DIFF
--- a/gradle/changelog/theme_nav_item.yaml
+++ b/gradle/changelog/theme_nav_item.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Remove superfluous user theme link properties ([#2058](https://github.com/scm-manager/scm-manager/pull/2058))

--- a/scm-ui/ui-webapp/public/locales/de/commons.json
+++ b/scm-ui/ui-webapp/public/locales/de/commons.json
@@ -97,10 +97,7 @@
     "error": "Fehler",
     "error-message": "'me' ist nicht definiert",
     "theme": {
-      "nav": {
-        "label": "Design",
-        "title": "Design wählen"
-      },
+      "navLink": "Design",
       "subtitle": "Design wählen",
       "submit": "Anwenden",
       "light": {

--- a/scm-ui/ui-webapp/public/locales/en/commons.json
+++ b/scm-ui/ui-webapp/public/locales/en/commons.json
@@ -98,10 +98,7 @@
     "error": "Error",
     "error-message": "'me' is undefined",
     "theme": {
-      "nav": {
-        "label": "Theme",
-        "title": "Choose your Theme"
-      },
+      "navLink": "Theme",
       "subtitle": "Choose your Theme",
       "submit": "Activate",
       "light": {

--- a/scm-ui/ui-webapp/src/containers/Profile.tsx
+++ b/scm-ui/ui-webapp/src/containers/Profile.tsx
@@ -119,12 +119,7 @@ const Profile: FC = () => {
                 label={t("profile.settingsNavLink")}
                 title={t("profile.settingsNavLink")}
               >
-                <NavLink
-                  to={`${url}/settings/theme`}
-                  icon="fas fa-palette"
-                  label={t("profile.theme.nav.label")}
-                  title={t("profile.theme.nav.title")}
-                />
+                <NavLink to={`${url}/settings/theme`} label={t("profile.theme.navLink")} />
                 {mayChangePassword && (
                   <NavLink to={`${url}/settings/password`} label={t("profile.changePasswordNavLink")} />
                 )}


### PR DESCRIPTION
## Proposed changes

By definition, the NavItem has an icon, which can/should not be rendered. Depending on the browser, only a small margin is visible. The icon is therefore removed. The same applies to the hover-title, which would only be displayed for collapsed menus, but does not apply to submenu entries.

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [x] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [x] All new code/logic is implemented on the right spot / "Should this be done here?"
- [x] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [x] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [x] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
