### PR TITLE
Arrow icon of secondary navigation is inconsistent

### DIFF
--- a/gradle/changelog/secondary_nav_toogle_icon.yaml
+++ b/gradle/changelog/secondary_nav_toogle_icon.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Arrow icon of secondary navigation is inconsistent ([#2060](https://github.com/scm-manager/scm-manager/pull/2060))

--- a/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
+++ b/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
@@ -70404,7 +70404,7 @@ exports[`Storyshots Secondary Navigation Active when match 1`] = `
             className="SecondaryNavigation__Icon-sc-8p1rgi-1 hDCYCs is-medium"
           >
             <i
-              className="fas fa-caret-right"
+              className="fas fa-caret-down"
             />
           </i>
           Hitchhiker
@@ -70466,7 +70466,7 @@ exports[`Storyshots Secondary Navigation Default 1`] = `
             className="SecondaryNavigation__Icon-sc-8p1rgi-1 hDCYCs is-medium"
           >
             <i
-              className="fas fa-caret-right"
+              className="fas fa-caret-down"
             />
           </i>
           Hitchhiker
@@ -70528,7 +70528,7 @@ exports[`Storyshots Secondary Navigation Extension Point 1`] = `
             className="SecondaryNavigation__Icon-sc-8p1rgi-1 hDCYCs is-medium"
           >
             <i
-              className="fas fa-caret-right"
+              className="fas fa-caret-down"
             />
           </i>
           Hitchhiker
@@ -70616,7 +70616,7 @@ exports[`Storyshots Secondary Navigation Sub Navigation 1`] = `
             className="SecondaryNavigation__Icon-sc-8p1rgi-1 hDCYCs is-medium"
           >
             <i
-              className="fas fa-caret-right"
+              className="fas fa-caret-down"
             />
           </i>
           Hitchhiker

--- a/scm-ui/ui-components/src/navigation/SecondaryNavigation.tsx
+++ b/scm-ui/ui-components/src/navigation/SecondaryNavigation.tsx
@@ -78,7 +78,7 @@ const SecondaryNavigation: FC<Props> = ({ label, children, collapsible = true })
     }
   };
 
-  const arrowIcon = isCollapsed ? <i className="fas fa-caret-down" /> : <i className="fas fa-caret-right" />;
+  const arrowIcon = isCollapsed ? <i className="fas fa-caret-left" /> : <i className="fas fa-caret-down" />;
   const menuAriaLabel = isCollapsed ? t("secondaryNavigation.showContent") : t("secondaryNavigation.hideContent");
 
   return (


### PR DESCRIPTION
## Proposed changes

The toggle icon in the secondary navigation points in the wrong direction.
In the changeset and code view, the current status is displayed with the icon. This should also be the case for this component.

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
