### PR TITLE
Feedback button does not mask warp menu in EcoSystem

### DIFF
--- a/gradle/changelog/feedback_overlaps_warp_menu.yaml
+++ b/gradle/changelog/feedback_overlaps_warp_menu.yaml
@@ -1,0 +1,2 @@
+- type: changed
+  description: feedback button should not mask warp menu in when SCM-Manager is used as a dogu in Cloudogu EcoSystem ([#2051](https://github.com/scm-manager/scm-manager/pull/2062))

--- a/scm-ui/ui-webapp/src/containers/App.tsx
+++ b/scm-ui/ui-webapp/src/containers/App.tsx
@@ -66,11 +66,11 @@ const App: FC = () => {
 
   return (
     <AppWrapper className="App">
-      {isAuthenticated ? <Feedback index={index} /> : null}
       <Header authenticated={authenticatedOrAnonymous}>
         <NavigationBar links={index._links} />
       </Header>
       <div className="is-flex-grow-1">{content}</div>
+      {isAuthenticated ? <Feedback index={index} /> : null}
       <Footer me={me} version={index.version} links={index._links} />
     </AppWrapper>
   );

--- a/scm-ui/ui-webapp/src/containers/Feedback.tsx
+++ b/scm-ui/ui-webapp/src/containers/Feedback.tsx
@@ -88,7 +88,7 @@ const Feedback: FC<Props> = ({ index }) => {
 
 const TriggerButton = styled(Button)`
   position: fixed;
-  z-index: 2;
+  z-index: 5;
   left: 1rem;
   right: unset;
   bottom: -1px;

--- a/scm-ui/ui-webapp/src/containers/Feedback.tsx
+++ b/scm-ui/ui-webapp/src/containers/Feedback.tsx
@@ -24,7 +24,7 @@
 
 import React, { FC, useMemo, useState } from "react";
 import styled from "styled-components";
-import { apiClient, Button, Modal } from "@scm-manager/ui-components";
+import { apiClient, Button, Modal, devices } from "@scm-manager/ui-components";
 import { HalRepresentation, IndexResources, Link } from "@scm-manager/ui-types";
 import { useTranslation } from "react-i18next";
 import { ApiResult, createQueryString } from "@scm-manager/ui-api";
@@ -88,10 +88,15 @@ const Feedback: FC<Props> = ({ index }) => {
 
 const TriggerButton = styled(Button)`
   position: fixed;
-  z-index: 9999999;
-  right: 1rem;
+  z-index: 2;
+  left: 1rem;
+  right: unset;
   bottom: -1px;
   border-radius: 0.2rem 0.2rem 0 0;
+  @media screen and (min-width: ${devices.desktop.width}px) {
+    right: 1rem;
+    left: unset;
+  }
 `;
 
 const ModalWrapper = styled(Modal)`


### PR DESCRIPTION
## Proposed changes

The feedback button overlaps the warp menu when the SCM-Manager is used as a dogu in a Cloudogu EcoSystem on small screens. The default position is changed to avoid masking the warp menu. The z-index of the feedback button is reduced to avoid masking the open warp menu. 
The DOM-sequence is changed to ensure users with keyboard navigation can access important parts of the page before the feedback button.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [x] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [x] All new code/logic is implemented on the right spot / "Should this be done here?"
- [x] UI changes fits into the layout
- [x] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [x] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [x] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
