### PR TITLE
Do not close hg context for diff as string

### DIFF
--- a/gradle/changelog/diff_hg_context.yaml
+++ b/gradle/changelog/diff_hg_context.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Do not close hg context for diff as string ([#2067](https://github.com/scm-manager/scm-manager/pull/2067))

--- a/scm-core/src/main/java/sonia/scm/repository/api/DiffCommandBuilder.java
+++ b/scm-core/src/main/java/sonia/scm/repository/api/DiffCommandBuilder.java
@@ -110,8 +110,12 @@ public final class DiffCommandBuilder extends AbstractDiffCommandBuilder<DiffCom
    * @throws IOException
    */
   public String getContent() throws IOException {
+    checkArguments();
+
+    logger.debug("create diff content for {}", request);
+
     try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-      getDiffResult().accept(baos);
+      diffCommand.getDiffResultInternal(request).accept(baos);
       return baos.toString(StandardCharsets.UTF_8);
     }
   }
@@ -147,12 +151,16 @@ public final class DiffCommandBuilder extends AbstractDiffCommandBuilder<DiffCom
    * @return
    */
   private OutputStreamConsumer getDiffResult() throws IOException {
-    Preconditions.checkArgument(request.isValid(),
-      "path and/or revision is required");
+    checkArguments();
 
     logger.debug("create diff for {}", request);
 
     return diffCommand.getDiffResult(request);
+  }
+
+  private void checkArguments() {
+    Preconditions.checkArgument(request.isValid(),
+      "path and/or revision is required");
   }
 
   @Override

--- a/scm-core/src/main/java/sonia/scm/repository/spi/DiffCommand.java
+++ b/scm-core/src/main/java/sonia/scm/repository/spi/DiffCommand.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-    
+
 package sonia.scm.repository.spi;
 
 import sonia.scm.repository.api.DiffCommandBuilder;
@@ -37,13 +37,25 @@ public interface DiffCommand
 {
 
   /**
-   * Method description
+   * Implementations of this method have to ensure, that all resources are released when the stream ends.
+   * This implementation is used for streaming results, where there are no more requests with the same
+   * context will be expected, whatsoever.
    *
-   *
-   * @param request
-   * @throws IOException
-   * @throws RuntimeException
-   * @return
+   * <b>If</b> this closes resources that will prevent further commands from execution, you have to override
+   * {@link #getDiffResultInternal(DiffCommandRequest)} that will return the same as this functions, but
+   * must not release these resources so that subsequent commands will still function.
    */
   DiffCommandBuilder.OutputStreamConsumer getDiffResult(DiffCommandRequest request) throws IOException;
+
+  /**
+   * Override this if {@link #getDiffResult(DiffCommandRequest)} releases resources that will prevent other
+   * commands from execution, so that these resources are not released with this function.
+   *
+   * Defaults to a simple call to {@link #getDiffResult(DiffCommandRequest)}.
+   *
+   * @since 2.36.0
+   */
+  default DiffCommandBuilder.OutputStreamConsumer getDiffResultInternal(DiffCommandRequest request) throws IOException {
+    return getDiffResult(request);
+  }
 }

--- a/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/spi/HgDiffCommand.java
+++ b/scm-plugins/scm-hg-plugin/src/main/java/sonia/scm/repository/spi/HgDiffCommand.java
@@ -58,7 +58,14 @@ public class HgDiffCommand extends AbstractCommand implements DiffCommand {
     };
   }
 
-  @SuppressWarnings("UnstableApiUsage")
+  @Override
+  public DiffCommandBuilder.OutputStreamConsumer getDiffResultInternal(DiffCommandRequest request) {
+    return output -> {
+      Repository hgRepo = open();
+      diff(hgRepo, request, output);
+    };
+  }
+
   private void diff(Repository hgRepo, DiffCommandRequest request, OutputStream output) throws IOException {
     HgDiffInternalCommand cmd = createDiffCommand(hgRepo, request);
     try (InputStream inputStream = streamDiff(hgRepo, cmd, request.getPath())) {


### PR DESCRIPTION
## Proposed changes

Normally, all resources (like the hg process) will be released after
the stream of the diff has finished. But this may lead to errors, when
DiffCommandBuilder#getContent is used and other commands are executed
afterwards.

So with this we introduce a new interface method in the DiffCommand
that can be implemented without closing resources. This method is
used for the computation of the diff as string.

We use this to distinguish between the computation of diffs as a
stream like in rest calls, and the computation as a single string
result that may we followed by other commands using the same context.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
