### PR TITLE
Fix plugin wizard for foreign languages

### DIFF
--- a/gradle/changelog/plugin_wizard.yaml
+++ b/gradle/changelog/plugin_wizard.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Plugin wizard for foreign languages ([#2086](https://github.com/scm-manager/scm-manager/pull/2086))

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/PluginSetDtoMapper.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/PluginSetDtoMapper.java
@@ -59,6 +59,9 @@ public class PluginSetDtoMapper {
       .collect(Collectors.toList());
 
     PluginSet.Description description = pluginSet.getDescriptions().get(locale.getLanguage());
+    if (description == null) {
+      description = pluginSet.getDescriptions().get(Locale.ENGLISH.getLanguage());
+    }
 
     return new PluginSetDto(pluginSet.getId(), pluginSet.getSequence(), pluginDtos, description.getName(), description.getFeatures(), pluginSet.getImages());
   }

--- a/scm-webapp/src/test/java/sonia/scm/api/v2/resources/PluginSetDtoMapperTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/api/v2/resources/PluginSetDtoMapperTest.java
@@ -52,6 +52,35 @@ class PluginSetDtoMapperTest {
 
   @Test
   void shouldMap() {
+    List<AvailablePlugin> availablePlugins = createAvailablePlugins();
+    ImmutableSet<PluginSet> pluginSets = createPluginSets();
+
+    List<PluginSetDto> dtos = mapper.map(pluginSets, availablePlugins, Locale.ENGLISH);
+
+    assertThat(dtos).hasSize(2);
+    PluginSetDto first = dtos.get(0);
+    assertThat(first.getSequence()).isZero();
+    assertThat(first.getName()).isEqualTo("My Plugin Set 2");
+    assertThat(first.getFeatures()).contains("this is also awesome!");
+    assertThat(first.getImages()).isNotEmpty();
+    assertThat(first.getPlugins()).hasSize(2);
+
+    assertThat(dtos.get(1).getSequence()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldMapWithOtherLanguage() {
+    List<AvailablePlugin> availablePlugins = createAvailablePlugins();
+    ImmutableSet<PluginSet> pluginSets = createPluginSets();
+
+    List<PluginSetDto> dtos = mapper.map(pluginSets, availablePlugins, Locale.FRENCH);
+
+    assertThat(dtos).hasSize(2);
+    PluginSetDto first = dtos.get(0);
+    assertThat(first.getName()).isEqualTo("My Plugin Set 2");
+  }
+
+  private List<AvailablePlugin> createAvailablePlugins() {
     AvailablePlugin git = createAvailable("scm-git-plugin");
     AvailablePlugin svn = createAvailable("scm-svn-plugin");
     AvailablePlugin hg = createAvailable("scm-hg-plugin");
@@ -66,8 +95,10 @@ class PluginSetDtoMapperTest {
     when(pluginDtoMapper.mapAvailable(svn)).thenReturn(svnDto);
     when(pluginDtoMapper.mapAvailable(hg)).thenReturn(hgDto);
 
-    List<AvailablePlugin> availablePlugins = List.of(git, svn, hg);
+    return List.of(git, svn, hg);
+  }
 
+  private ImmutableSet<PluginSet> createPluginSets() {
     PluginSet pluginSet = new PluginSet(
       "my-plugin-set",
       1,
@@ -83,17 +114,6 @@ class PluginSetDtoMapperTest {
       ImmutableMap.of("en", new PluginSet.Description("My Plugin Set 2", List.of("this is also awesome!"))),
       ImmutableMap.of("standard", "base64image")
     );
-    ImmutableSet<PluginSet> pluginSets = ImmutableSet.of(pluginSet, pluginSet2);
-
-    List<PluginSetDto> dtos = mapper.map(pluginSets, availablePlugins, Locale.ENGLISH);
-    assertThat(dtos).hasSize(2);
-    PluginSetDto first = dtos.get(0);
-    assertThat(first.getSequence()).isZero();
-    assertThat(first.getName()).isEqualTo("My Plugin Set 2");
-    assertThat(first.getFeatures()).contains("this is also awesome!");
-    assertThat(first.getImages()).isNotEmpty();
-    assertThat(first.getPlugins()).hasSize(2);
-
-    assertThat(dtos.get(1).getSequence()).isEqualTo(1);
+    return ImmutableSet.of(pluginSet, pluginSet2);
   }
 }


### PR DESCRIPTION
## Proposed changes

This fixes the plugin wizard, that throws a NullPointerException for other languages then Englisch or German.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
