### PR TITLE
fixed wrong indentation of extraVolumes and extraVolumeMounts

### DIFF
--- a/scm-packaging/helm/src/main/chart/templates/deployment.yaml
+++ b/scm-packaging/helm/src/main/chart/templates/deployment.yaml
@@ -97,9 +97,9 @@ spec:
             mountPath: /var/lib/scm
           - name: config
             mountPath: /opt/scm-server/conf
-            {{- with .Values.extraVolumeMounts }}
-            {{- tpl . $ | nindent 12 }}
-            {{- end }}
+          {{- with .Values.extraVolumeMounts }}
+          {{- tpl . $ | nindent 10 }}
+          {{- end }}
           env:
             {{- with .Values.extraEnv }}
             {{- tpl . $ | nindent 12 }}
@@ -125,7 +125,7 @@ spec:
           name: {{ include "scm-manager.fullname" . }}-scripts
       {{- end }}
       {{- with .Values.extraVolumes }}
-      {{- tpl . $ | nindent 8 }}
+      {{- tpl . $ | nindent 6 }}
       {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
## Proposed changes

It's not possible to use the extraVolumeMonts and extraVolumes feature because the template is using a wrong indentation which results in an invalid result.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
