### PR TITLE
Handle missing encoding of square brackets in filenames

### DIFF
--- a/gradle/changelog/square_brackets_in_filename.yaml
+++ b/gradle/changelog/square_brackets_in_filename.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Handle missing encoding of square brackets in filenames ([#2117](https://github.com/scm-manager/scm-manager/pull/2117))

--- a/scm-ui/ui-api/src/sources.test.ts
+++ b/scm-ui/ui-api/src/sources.test.ts
@@ -135,8 +135,8 @@ describe("Test sources hooks", () => {
     };
 
     it("should return file from url with revision and path", () => testPath("README.md", "README.md"));
-    it("should encode square brackets in path", () => testPath("[...nextauth].ts", "%5B...nextauth%5D.ts/"));
-    it("should not double-encode path", () => testPath("Datei#42.txt", "Datei#42.txt"));
+    it("should encode square brackets in path", () => testPath("[...nextauth].ts", "%5B...nextauth%5D.ts"));
+    it("should not double-encode path", () => testPath("%7BDatei%7D#42.txt", "%7BDatei%7D#42.txt"));
 
     it("should return root directory", async () => {
       const queryClient = createInfiniteCachingClient();

--- a/scm-ui/ui-api/src/sources.test.ts
+++ b/scm-ui/ui-api/src/sources.test.ts
@@ -135,7 +135,8 @@ describe("Test sources hooks", () => {
     };
 
     it("should return file from url with revision and path", () => testPath("README.md", "README.md"));
-    it("should encode square brackets in path", () => testPath("[...nextauth].ts", "%5B...nextauth%5D.ts"));
+    it("should encode square brackets in path", () =>
+      testPath("[...nextauth][...other].ts", "%5B...nextauth%5D%5B...other%5D.ts"));
     it("should not double-encode path", () => testPath("%7BDatei%7D#42.txt", "%7BDatei%7D#42.txt"));
 
     it("should return root directory", async () => {

--- a/scm-ui/ui-api/src/sources.ts
+++ b/scm-ui/ui-api/src/sources.ts
@@ -93,7 +93,7 @@ const createSourcesLink = (repository: Repository, options: UseSourcesOptions) =
     link = urls.concat(link, encodeURIComponent(options.revision));
 
     if (options.path) {
-      link = urls.concat(link, options.path);
+      link = urls.concat(link, encodeInvalidCharacters(options.path));
     }
   }
   if (options.collapse) {
@@ -101,6 +101,8 @@ const createSourcesLink = (repository: Repository, options: UseSourcesOptions) =
   }
   return link;
 };
+
+const encodeInvalidCharacters = (input: string) => input.replace(/\[/g, "%5B").replace(/]/g, "%5D");
 
 const merge = (files?: File[]): File | undefined => {
   if (!files || files.length === 0) {


### PR DESCRIPTION
## Proposed changes

Due to unexpected and largely unchangeable behavior by both react-router and the browser, square brackets are not correctly encoded in the url when clicking a file link in the source view where the filename contains either of these characters. The source view then tries to use the `useSources` hook to get the file content but fails, because the path param for the file path it gets from the url has unencoded square brackets in them which are illegal in urls except for declaring IPv6 addresses. We have created a catch for exactly this scenario at the latest possible point before the actual http request is fired, which is in the `useSources` hook. It seems like the square brackets are the only affected special characters so we force encoding on them specifically. Only the path portion of the URL is checked so the host portion of the url may still contain unencoded square brackets which are left untouched.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`

**Reviewer**:
- [x] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [x] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [x] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [x] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
