### PR TITLE
Fix lazy loading in the source view

### DIFF
--- a/gradle/changelog/lasy_loading.yaml
+++ b/gradle/changelog/lasy_loading.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Lazy loading in the source view ([#2120](https://github.com/scm-manager/scm-manager/pull/2120))

--- a/scm-core/src/main/java/sonia/scm/repository/api/RepositoryService.java
+++ b/scm-core/src/main/java/sonia/scm/repository/api/RepositoryService.java
@@ -205,7 +205,7 @@ public final class RepositoryService implements Closeable {
     LOG.debug("create browse command for repository {}", repository);
 
     return new BrowseCommandBuilder(cacheManager, provider.getBrowseCommand(),
-      repository, preProcessorUtil);
+      repository, preProcessorUtil, provider::getBrowseCommand);
   }
 
   /**


### PR DESCRIPTION
## Proposed changes

The lazy loading feature implemented for git was broken, because the repeated usage in the BrowserResultCollapser has overwritten the request in the command. Therefore the command could no longer update the cache in the BrowseCommandBuilder.

To fix this, we now use a browse command factory (represented by a simple supplier) that will create a dedicated command implementation for each request issued in the collapser.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
