### PR TITLE
Keyboard shortcuts for global and repository-specific navigation

### DIFF
--- a/gradle/changelog/navigation_shortcuts.yaml
+++ b/gradle/changelog/navigation_shortcuts.yaml
@@ -1,0 +1,2 @@
+- type: added
+  description: Keyboard shortcuts for global and repository-specific navigation ([#2122](https://github.com/scm-manager/scm-manager/pull/2122))

--- a/scm-ui/ui-components/src/navigation/PrimaryNavigation.tsx
+++ b/scm-ui/ui-components/src/navigation/PrimaryNavigation.tsx
@@ -26,8 +26,6 @@ import PrimaryNavigationLink from "./PrimaryNavigationLink";
 import { Links } from "@scm-manager/ui-types";
 import { binder, ExtensionPoint, extensionPoints } from "@scm-manager/ui-extensions";
 import { useTranslation } from "react-i18next";
-import useShortcut from "@scm-manager/ui-webapp/src/shortcuts/useShortcut";
-import { useHistory } from "react-router-dom";
 
 type Props = {
   links: Links;
@@ -37,20 +35,6 @@ type Appender = (to: string, match: string, label: string, linkName: string) => 
 
 const PrimaryNavigation: FC<Props> = ({ links }) => {
   const [t] = useTranslation("commons");
-
-  const history = useHistory();
-  useShortcut("option+r", () => {
-    history.push("/repos/");
-  });
-  useShortcut("option+u", () => {
-    history.push("/users/");
-  });
-  useShortcut("option+g", () => {
-    history.push("/groups/");
-  });
-  useShortcut("option+a", () => {
-    history.push("/admin/");
-  });
 
   const createNavigationAppender = (navItems: ReactNode[]): Appender => {
     return (to: string, match: string, label: string, linkName: string) => {
@@ -76,7 +60,7 @@ const PrimaryNavigation: FC<Props> = ({ links }) => {
 
     const extensionProps = {
       links,
-      label: t("primary-navigation.first-menu"),
+      label: t("primary-navigation.first-menu")
     };
 
     const append = createNavigationAppender(navItems);
@@ -102,7 +86,7 @@ const PrimaryNavigation: FC<Props> = ({ links }) => {
         name="primary-navigation"
         renderAll={true}
         props={{
-          links,
+          links
         }}
       />
     );

--- a/scm-ui/ui-components/src/navigation/PrimaryNavigation.tsx
+++ b/scm-ui/ui-components/src/navigation/PrimaryNavigation.tsx
@@ -26,6 +26,8 @@ import PrimaryNavigationLink from "./PrimaryNavigationLink";
 import { Links } from "@scm-manager/ui-types";
 import { binder, ExtensionPoint, extensionPoints } from "@scm-manager/ui-extensions";
 import { useTranslation } from "react-i18next";
+import useShortcut from "@scm-manager/ui-webapp/src/shortcuts/useShortcut";
+import { useHistory } from "react-router-dom";
 
 type Props = {
   links: Links;
@@ -35,6 +37,20 @@ type Appender = (to: string, match: string, label: string, linkName: string) => 
 
 const PrimaryNavigation: FC<Props> = ({ links }) => {
   const [t] = useTranslation("commons");
+
+  const history = useHistory();
+  useShortcut("option+r", () => {
+    history.push("/repos/");
+  });
+  useShortcut("option+u", () => {
+    history.push("/users/");
+  });
+  useShortcut("option+g", () => {
+    history.push("/groups/");
+  });
+  useShortcut("option+a", () => {
+    history.push("/admin/");
+  });
 
   const createNavigationAppender = (navItems: ReactNode[]): Appender => {
     return (to: string, match: string, label: string, linkName: string) => {
@@ -60,7 +76,7 @@ const PrimaryNavigation: FC<Props> = ({ links }) => {
 
     const extensionProps = {
       links,
-      label: t("primary-navigation.first-menu")
+      label: t("primary-navigation.first-menu"),
     };
 
     const append = createNavigationAppender(navItems);
@@ -86,7 +102,7 @@ const PrimaryNavigation: FC<Props> = ({ links }) => {
         name="primary-navigation"
         renderAll={true}
         props={{
-          links
+          links,
         }}
       />
     );

--- a/scm-ui/ui-webapp/src/containers/App.tsx
+++ b/scm-ui/ui-webapp/src/containers/App.tsx
@@ -48,16 +48,24 @@ const App: FC = () => {
 
   const history = useHistory();
   useShortcut("option+r", () => {
-    history.push("/repos/");
+    if (index && index._links["repositories"]) {
+      history.push("/repos/");
+    }
   });
   useShortcut("option+u", () => {
-    history.push("/users/");
+    if (index && index._links["users"]) {
+      history.push("/users/");
+    }
   });
   useShortcut("option+g", () => {
-    history.push("/groups/");
+    if (index && index._links["groups"]) {
+      history.push("/groups/");
+    }
   });
   useShortcut("option+a", () => {
-    history.push("/admin/");
+    if (index && index._links["config"]) {
+      history.push("/admin/");
+    }
   });
 
   if (!index) {

--- a/scm-ui/ui-webapp/src/containers/App.tsx
+++ b/scm-ui/ui-webapp/src/containers/App.tsx
@@ -23,15 +23,17 @@
  */
 import React, { FC } from "react";
 import Main from "./Main";
+import { useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import styled from "styled-components";
+import { useIndex, useSubject } from "@scm-manager/ui-api";
 import { ErrorPage, Footer, Header, Loading } from "@scm-manager/ui-components";
 import { binder } from "@scm-manager/ui-extensions";
-import Login from "./Login";
-import { useIndex, useSubject } from "@scm-manager/ui-api";
-import NavigationBar from "./NavigationBar";
-import styled from "styled-components";
-import Feedback from "./Feedback";
 import usePauseShortcutsWhenModalsActive from "../shortcuts/usePauseShortcutsWhenModalsActive";
+import useShortcut from "../shortcuts/useShortcut";
+import Login from "./Login";
+import NavigationBar from "./NavigationBar";
+import Feedback from "./Feedback";
 
 const AppWrapper = styled.div`
   min-height: 100vh;
@@ -43,6 +45,20 @@ const App: FC = () => {
   const { isLoading, error, isAuthenticated, isAnonymous, me } = useSubject();
   const [t] = useTranslation("commons");
   usePauseShortcutsWhenModalsActive();
+
+  const history = useHistory();
+  useShortcut("option+r", () => {
+    history.push("/repos/");
+  });
+  useShortcut("option+u", () => {
+    history.push("/users/");
+  });
+  useShortcut("option+g", () => {
+    history.push("/groups/");
+  });
+  useShortcut("option+a", () => {
+    history.push("/admin/");
+  });
 
   if (!index) {
     return null;

--- a/scm-ui/ui-webapp/src/repos/containers/RepositoryRoot.tsx
+++ b/scm-ui/ui-webapp/src/repos/containers/RepositoryRoot.tsx
@@ -99,6 +99,24 @@ const RepositoryRoot = () => {
   const context = useNamespaceAndNameContext();
   const history = useHistory();
 
+  const url = urls.matchedUrlFromMatch(match);
+
+  useShortcut("g i", () => {
+    history.push(`${url}/info`);
+  });
+  useShortcut("g b", () => {
+    history.push(`${url}/branches/`);
+  });
+  useShortcut("g t", () => {
+    history.push(`${url}/tags/`);
+  });
+  useShortcut("g c", () => {
+    history.push(evaluateDestinationForCodeLink());
+  });
+  useShortcut("g s", () => {
+    history.push(`${url}/settings/general`);
+  });
+
   useEffect(() => {
     if (repository) {
       context.setNamespace(repository.namespace);
@@ -119,24 +137,6 @@ const RepositoryRoot = () => {
   if (!repository || isLoading) {
     return <Loading />;
   }
-
-  const url = urls.matchedUrlFromMatch(match);
-
-  useShortcut("g i", () => {
-    history.push(`${url}/info`);
-  });
-  useShortcut("g b", () => {
-    history.push(`${url}/branches/`);
-  });
-  useShortcut("g t", () => {
-    history.push(`${url}/tags/`);
-  });
-  useShortcut("g c", () => {
-    history.push(evaluateDestinationForCodeLink());
-  });
-  useShortcut("g s", () => {
-    history.push(`${url}/settings/general`);
-  });
 
   // props used for extensions
   // most of the props required for compatibility

--- a/scm-ui/ui-webapp/src/repos/containers/RepositoryRoot.tsx
+++ b/scm-ui/ui-webapp/src/repos/containers/RepositoryRoot.tsx
@@ -23,7 +23,7 @@
  */
 import React, { useEffect, useState } from "react";
 import { match as Match } from "react-router";
-import { Link as RouteLink, Redirect, Route, RouteProps, Switch, useRouteMatch } from "react-router-dom";
+import { Link as RouteLink, Redirect, Route, RouteProps, Switch, useHistory, useRouteMatch } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { binder, ExtensionPoint, extensionPoints } from "@scm-manager/ui-extensions";
 import { Changeset, Link } from "@scm-manager/ui-types";
@@ -62,6 +62,7 @@ import CompareRoot from "../compare/CompareRoot";
 import TagRoot from "../tags/container/TagRoot";
 import { useIndexLinks, useNamespaceAndNameContext, useRepository } from "@scm-manager/ui-api";
 import styled from "styled-components";
+import useShortcut from "../../shortcuts/useShortcut";
 
 const TagGroup = styled.span`
   & > * {
@@ -96,6 +97,7 @@ const RepositoryRoot = () => {
   const [showHealthCheck, setShowHealthCheck] = useState(false);
   const [t] = useTranslation("repos");
   const context = useNamespaceAndNameContext();
+  const history = useHistory();
 
   useEffect(() => {
     if (repository) {
@@ -119,6 +121,22 @@ const RepositoryRoot = () => {
   }
 
   const url = urls.matchedUrlFromMatch(match);
+
+  useShortcut("g i", () => {
+    history.push(`${url}/info`);
+  });
+  useShortcut("g b", () => {
+    history.push(`${url}/branches/`);
+  });
+  useShortcut("g t", () => {
+    history.push(`${url}/tags/`);
+  });
+  useShortcut("g c", () => {
+    history.push(evaluateDestinationForCodeLink());
+  });
+  useShortcut("g s", () => {
+    history.push(`${url}/settings/general`);
+  });
 
   // props used for extensions
   // most of the props required for compatibility

--- a/scm-ui/ui-webapp/src/repos/containers/RepositoryRoot.tsx
+++ b/scm-ui/ui-webapp/src/repos/containers/RepositoryRoot.tsx
@@ -105,13 +105,19 @@ const RepositoryRoot = () => {
     history.push(`${url}/info`);
   });
   useShortcut("g b", () => {
-    history.push(`${url}/branches/`);
+    if (repository && repository._links["branches"]) {
+      history.push(`${url}/branches/`);
+    }
   });
   useShortcut("g t", () => {
-    history.push(`${url}/tags/`);
+    if (repository && repository._links["tags"]) {
+      history.push(`${url}/tags/`);
+    }
   });
   useShortcut("g c", () => {
-    history.push(evaluateDestinationForCodeLink());
+    if (repository && repository._links[getCodeLinkname()]) {
+      history.push(evaluateDestinationForCodeLink());
+    }
   });
   useShortcut("g s", () => {
     history.push(`${url}/settings/general`);

--- a/scm-ui/ui-webapp/src/shortcuts/useShortcut.ts
+++ b/scm-ui/ui-webapp/src/shortcuts/useShortcut.ts
@@ -53,6 +53,7 @@ import Mousetrap from "mousetrap";
  * @example useShortcut("/", ...)
  * @example useShortcut("ctrl+shift+k", ...)
  * @see https://github.com/ccampbell/mousetrap
+ * @see https://craig.is/killing/mice
  */
 export default function useShortcut(key: string, callback: (e: KeyboardEvent) => void) {
   useEffect(() => {


### PR DESCRIPTION
## Proposed changes

The global navigation can be accessed with the following key combination:
* Option-R = Repositories
* Option-U = User
* Option-G = Groups
* Option-A = Administration

The navigation within a repository can be accessed with a combination with g:
* gi = Information
* gb = Branches
* gt = Tags
* gc = Code
* gs = Settings

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
