### PR TITLE
Fix creating a repository permission without a name breaking the repository

### DIFF
--- a/gradle/changelog/repository_permission_without_name.yaml
+++ b/gradle/changelog/repository_permission_without_name.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Creating a repository permission without a name breaks the repository ([#2126](https://github.com/scm-manager/scm-manager/pull/2126))

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/RepositoryPermissionDto.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/RepositoryPermissionDto.java
@@ -33,6 +33,7 @@ import lombok.ToString;
 import javax.validation.constraints.NotEmpty;
 import sonia.scm.util.ValidationUtil;
 
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
 import java.util.Collection;
@@ -43,6 +44,7 @@ public class RepositoryPermissionDto extends HalRepresentation implements Update
 
   public static final String GROUP_PREFIX = "@";
 
+  @NotNull
   @Pattern(regexp = ValidationUtil.REGEX_NAME)
   private String name;
 

--- a/scm-webapp/src/test/java/sonia/scm/api/v2/resources/RepositoryPermissionRootResourceTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/api/v2/resources/RepositoryPermissionRootResourceTest.java
@@ -276,6 +276,21 @@ public class RepositoryPermissionRootResourceTest extends RepositoryTestBase {
   }
 
   @Test
+  public void shouldGet400OnCreatingNewPermissionWithoutName() throws URISyntaxException {
+    createUserWithRepository("user");
+    String permissionJson = "{ \"verbs\": [\"*\"] }";
+    MockHttpRequest request = MockHttpRequest
+      .post("/" + RepositoryRootResource.REPOSITORIES_PATH_V2 + PATH_OF_ALL_PERMISSIONS)
+      .content(permissionJson.getBytes())
+      .contentType(VndMediaType.REPOSITORY_PERMISSION);
+    MockHttpResponse response = new MockHttpResponse();
+
+    dispatcher.invoke(request, response);
+
+    assertEquals(400, response.getStatus());
+  }
+
+  @Test
   public void shouldGetCreatedPermissions() throws URISyntaxException {
     createUserWithRepositoryAndPermissions(TEST_PERMISSIONS, PERMISSION_WRITE);
     RepositoryPermission newPermission = new RepositoryPermission("new_group_perm", asList("read", "pull", "push"), true);


### PR DESCRIPTION
## Proposed changes

If a POST request is submitted to the rest api for repostory permissions, the regex validator ignores the name field if it is null, which leads to an internal server error and breaks any further attempts to interact with that repository. An additional not-null constraint resolves this problem.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
