### PR TITLE
Resolve plugin installation conflict

### DIFF
--- a/gradle/changelog/plugin_installation_conflict.yaml
+++ b/gradle/changelog/plugin_installation_conflict.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Plugin installation conflict ([#2138](https://github.com/scm-manager/scm-manager/pull/2138))

--- a/scm-webapp/src/main/java/sonia/scm/plugin/DefaultPluginManager.java
+++ b/scm-webapp/src/main/java/sonia/scm/plugin/DefaultPluginManager.java
@@ -357,7 +357,13 @@ public class DefaultPluginManager implements PluginManager {
       }
     }
 
-    plugins.add(plugin);
+    if (pluginWasNotAddedYet(plugins, plugin)) {
+      plugins.add(plugin);
+    }
+  }
+
+  private static boolean pluginWasNotAddedYet(List<AvailablePlugin> plugins, AvailablePlugin plugin) {
+    return plugins.stream().noneMatch(p -> p.getDescriptor().getInformation().getName().equals(plugin.getDescriptor().getInformation().getName()));
   }
 
   private boolean isInstalledOrPending(String name) {


### PR DESCRIPTION
Resolve plugin installation conflict were the same plugin was tried to be installed multiple times for one single action.

The pending queue is updated after all the plugins to be installed are collected, then we already may have duplicate entries. Because of this we check right on the collecting step if the plugin was already added during this single action.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
