### PR TITLE
Git diff request correctly throws NotFoundException if target revision is non-existent

### DIFF
--- a/gradle/changelog/diff_handle_deleted_target_branch.yaml
+++ b/gradle/changelog/diff_handle_deleted_target_branch.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Git diff request correctly throws NotFoundException if target revision is non-existent ([#2141](https://github.com/scm-manager/scm-manager/pull/2141))

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/Differ.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/Differ.java
@@ -92,6 +92,9 @@ final class Differ implements AutoCloseable {
 
     if (!Strings.isNullOrEmpty(request.getAncestorChangeset())) {
       ObjectId otherRevision = repository.resolve(request.getAncestorChangeset());
+      if (otherRevision == null) {
+        throw new NotFoundException("Revision", request.getAncestorChangeset());
+      }
       ObjectId ancestorId = GitUtil.computeCommonAncestor(repository, revision, otherRevision);
       RevTree tree = walk.parseCommit(ancestorId).getTree();
       treeWalk.addTree(tree);

--- a/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/Differ.java
+++ b/scm-plugins/scm-git-plugin/src/main/java/sonia/scm/repository/spi/Differ.java
@@ -37,13 +37,14 @@ import org.eclipse.jgit.treewalk.AbstractTreeIterator;
 import org.eclipse.jgit.treewalk.EmptyTreeIterator;
 import org.eclipse.jgit.treewalk.TreeWalk;
 import org.eclipse.jgit.treewalk.filter.PathFilter;
-import sonia.scm.ContextEntry;
-import sonia.scm.NotFoundException;
 import sonia.scm.repository.GitUtil;
 import sonia.scm.util.Util;
 
 import java.io.IOException;
 import java.util.List;
+
+import static sonia.scm.ContextEntry.ContextBuilder.entity;
+import static sonia.scm.NotFoundException.notFound;
 
 final class Differ implements AutoCloseable {
 
@@ -70,13 +71,13 @@ final class Differ implements AutoCloseable {
 
     ObjectId revision = repository.resolve(request.getRevision());
     if (revision == null) {
-      throw NotFoundException.notFound(ContextEntry.ContextBuilder.entity("revision not found", request.getRevision()));
+      throw notFound(entity("Revision", request.getRevision()));
     }
     RevCommit commit;
     try {
       commit = walk.parseCommit(revision);
     } catch (MissingObjectException ex) {
-      throw NotFoundException.notFound(ContextEntry.ContextBuilder.entity("revision not found", request.getRevision()));
+      throw notFound(entity("Revision", request.getRevision()));
     }
 
     walk.markStart(commit);
@@ -93,7 +94,7 @@ final class Differ implements AutoCloseable {
     if (!Strings.isNullOrEmpty(request.getAncestorChangeset())) {
       ObjectId otherRevision = repository.resolve(request.getAncestorChangeset());
       if (otherRevision == null) {
-        throw new NotFoundException("Revision", request.getAncestorChangeset());
+        throw notFound(entity("Revision", request.getAncestorChangeset()));
       }
       ObjectId ancestorId = GitUtil.computeCommonAncestor(repository, revision, otherRevision);
       RevTree tree = walk.parseCommit(ancestorId).getTree();


### PR DESCRIPTION
## Proposed changes

Sometimes it happens that a git diff command request is performed with a non-existent target branch. This is usually fine but the underlying system might have already garbage-collected the revisions associated with that branch. In this case, the revision for that deleted branch might turn up `null` which currently causes a 500 error. We catch this specific corner-case and throw the correct NotFoundException instead.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`

**Reviewer**:
- [x] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [x] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [x] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [x] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
