### PR TITLE
Remove forced word break from markdown view

### DIFF
--- a/gradle/changelog/markdown_table_header_wrap.yaml
+++ b/gradle/changelog/markdown_table_header_wrap.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Remove forced word break from markdown view ([#2142](https://github.com/scm-manager/scm-manager/pull/2142))

--- a/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
+++ b/scm-ui/ui-components/src/__snapshots__/storyshots.test.ts.snap
@@ -4877,7 +4877,7 @@ exports[`Storyshots MarkdownView Code without Lang 1`] = `
   className="MarkdownViewstories__Spacing-sc-1lofakk-0 isVeYs"
 >
   <div
-    className="content is-word-break"
+    className="LazyMarkdownView__HorizontalScrollDiv-sc-w02jj8-0 iAcXxX content"
   >
     <div>
       <p>
@@ -4946,7 +4946,7 @@ exports[`Storyshots MarkdownView Commit Links 1`] = `
   className="MarkdownViewstories__Spacing-sc-1lofakk-0 isVeYs"
 >
   <div
-    className="content is-word-break"
+    className="LazyMarkdownView__HorizontalScrollDiv-sc-w02jj8-0 iAcXxX content"
   >
     <div>
       <h1
@@ -5057,7 +5057,7 @@ exports[`Storyshots MarkdownView Custom code renderer 1`] = `
   className="MarkdownViewstories__Spacing-sc-1lofakk-0 isVeYs"
 >
   <div
-    className="content is-word-break"
+    className="LazyMarkdownView__HorizontalScrollDiv-sc-w02jj8-0 iAcXxX content"
   >
     <div>
       <h1
@@ -5103,7 +5103,7 @@ exports[`Storyshots MarkdownView Default 1`] = `
   className="MarkdownViewstories__Spacing-sc-1lofakk-0 isVeYs"
 >
   <div
-    className="content is-word-break"
+    className="LazyMarkdownView__HorizontalScrollDiv-sc-w02jj8-0 iAcXxX content"
   >
     <div>
       <h1
@@ -6525,7 +6525,7 @@ exports[`Storyshots MarkdownView Header Anchor Links 1`] = `
   className="MarkdownViewstories__Spacing-sc-1lofakk-0 isVeYs"
 >
   <div
-    className="content is-word-break"
+    className="LazyMarkdownView__HorizontalScrollDiv-sc-w02jj8-0 iAcXxX content"
   >
     <div>
       <a
@@ -14394,7 +14394,7 @@ exports[`Storyshots MarkdownView Inline Xml 1`] = `
     Inline xml outside of a code block is not supported
   </h2>
   <div
-    className="content is-word-break"
+    className="LazyMarkdownView__HorizontalScrollDiv-sc-w02jj8-0 iAcXxX content"
   >
     <div>
       <h1
@@ -14738,7 +14738,7 @@ exports[`Storyshots MarkdownView Links 1`] = `
   className="MarkdownViewstories__Spacing-sc-1lofakk-0 isVeYs"
 >
   <div
-    className="content is-word-break"
+    className="LazyMarkdownView__HorizontalScrollDiv-sc-w02jj8-0 iAcXxX content"
   >
     <div>
       <h1
@@ -14866,7 +14866,7 @@ exports[`Storyshots MarkdownView Links without Base Path 1`] = `
   className="MarkdownViewstories__Spacing-sc-1lofakk-0 isVeYs"
 >
   <div
-    className="content is-word-break"
+    className="LazyMarkdownView__HorizontalScrollDiv-sc-w02jj8-0 iAcXxX content"
   >
     <div>
       <h1
@@ -14993,7 +14993,7 @@ exports[`Storyshots MarkdownView Skip Html 1`] = `
   className="MarkdownViewstories__Spacing-sc-1lofakk-0 isVeYs"
 >
   <div
-    className="content is-word-break"
+    className="LazyMarkdownView__HorizontalScrollDiv-sc-w02jj8-0 iAcXxX content"
   >
     <div>
       <h1
@@ -16334,7 +16334,7 @@ exports[`Storyshots MarkdownView XSS Prevention 1`] = `
   className="MarkdownViewstories__Spacing-sc-1lofakk-0 isVeYs"
 >
   <div
-    className="content is-word-break"
+    className="LazyMarkdownView__HorizontalScrollDiv-sc-w02jj8-0 iAcXxX content"
   >
     <div>
       <h1
@@ -16386,7 +16386,7 @@ exports[`Storyshots MarkdownView Xml Code Block 1`] = `
   className="MarkdownViewstories__Spacing-sc-1lofakk-0 isVeYs"
 >
   <div
-    className="content is-word-break"
+    className="LazyMarkdownView__HorizontalScrollDiv-sc-w02jj8-0 iAcXxX content"
   >
     <div>
       <h1

--- a/scm-ui/ui-components/src/markdown/LazyMarkdownView.tsx
+++ b/scm-ui/ui-components/src/markdown/LazyMarkdownView.tsx
@@ -47,6 +47,7 @@ import slug from "rehype-slug";
 import merge from "deepmerge";
 import { createComponentList } from "./createComponentList";
 import { ProtocolLinkRendererExtension, ProtocolLinkRendererExtensionMap } from "./markdownExtensions";
+import styled from "styled-components";
 
 export type MarkdownProps = {
   content: string;
@@ -95,18 +96,22 @@ const MarkdownErrorNotification: FC = () => {
   );
 };
 
+const HorizontalScrollDiv = styled.div`
+  overflow-x: auto;
+`;
+
 class LazyMarkdownView extends React.Component<Props, State> {
   static contextType = BinderContext;
 
   static defaultProps: Partial<Props> = {
     enableAnchorHeadings: false,
-    skipHtml: false
+    skipHtml: false,
   };
 
   constructor(props: Props) {
     super(props);
     this.state = {
-      contentRef: null
+      contentRef: null,
     };
   }
 
@@ -150,7 +155,7 @@ class LazyMarkdownView extends React.Component<Props, State> {
       basePath,
       permalink,
       t,
-      mdastPlugins = []
+      mdastPlugins = [],
     } = this.props;
 
     const rendererFactory = this.context.getExtension("markdown-renderer-factory");
@@ -207,27 +212,27 @@ class LazyMarkdownView extends React.Component<Props, State> {
         sanitize,
         merge(gh, {
           attributes: {
-            code: ["className"] // Allow className for code elements, this is necessary to extract the code language
+            code: ["className"], // Allow className for code elements, this is necessary to extract the code language
           },
           clobberPrefix: "", // Do not prefix user-provided ids and class names,
           protocols: {
-            href: Object.keys(protocolLinkRendererExtensions)
-          }
+            href: Object.keys(protocolLinkRendererExtensions),
+          },
         })
       )
       .use(rehype2react, {
         createElement: React.createElement,
         passNode: true,
-        components: createComponentList(remarkRendererList, { permalink })
+        components: createComponentList(remarkRendererList, { permalink }),
       });
 
     const renderedMarkdown: any = processor.processSync(content).result;
 
     return (
       <ErrorBoundary fallback={MarkdownErrorNotification}>
-        <div ref={el => this.setState({ contentRef: el })} className="content">
+        <HorizontalScrollDiv ref={(el) => this.setState({ contentRef: el })} className="content">
           {renderedMarkdown}
-        </div>
+        </HorizontalScrollDiv>
       </ErrorBoundary>
     );
   }

--- a/scm-ui/ui-components/src/markdown/LazyMarkdownView.tsx
+++ b/scm-ui/ui-components/src/markdown/LazyMarkdownView.tsx
@@ -225,7 +225,7 @@ class LazyMarkdownView extends React.Component<Props, State> {
 
     return (
       <ErrorBoundary fallback={MarkdownErrorNotification}>
-        <div ref={el => this.setState({ contentRef: el })} className="content is-word-break">
+        <div ref={el => this.setState({ contentRef: el })} className="content">
           {renderedMarkdown}
         </div>
       </ErrorBoundary>


### PR DESCRIPTION
## Proposed changes

In 751343fa8b5189819296a832a2db06a77040fc1a we forced words to wrap in a variety of places in the SCM-Manager to prevent unintentional overflow breaking the layout. This was also added to the markdown view which had implications for tables in these views including long headers that would now break in a not so pretty fashion. After investigating potential implications and checking other usages of the markdown view, we removed the problematic class again in this particular instance as it was seemingly not serving any positive purpose and removing it had no negative impact.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`

**Reviewer**:
- [x] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [x] All new code/logic is implemented on the right spot / "Should this be done here?"
- [x] UI changes fits into the layout
- [x] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [x] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [x] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
