### PR TITLE
Fix modal de-registration firing twice

### DIFF
--- a/gradle/changelog/fix_modal_registration.yaml
+++ b/gradle/changelog/fix_modal_registration.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Keyboard shortcuts should be inactive when modals are open ([#2145](https://github.com/scm-manager/scm-manager/pull/2145))

--- a/scm-ui/ui-components/src/modals/useRegisterModal.test.tsx
+++ b/scm-ui/ui-components/src/modals/useRegisterModal.test.tsx
@@ -72,7 +72,7 @@ describe("useRegisterModal", () => {
     expect(increment).not.toHaveBeenCalled();
   });
 
-  it("should decrement on active de-registration", () => {
+  it("should decrement once on active de-registration", () => {
     const increment = jest.fn();
     const decrement = jest.fn();
 
@@ -82,7 +82,22 @@ describe("useRegisterModal", () => {
 
     result.unmount();
 
-    expect(decrement).toHaveBeenCalled();
+    expect(decrement).toHaveBeenCalledTimes(1);
     expect(increment).not.toHaveBeenCalled();
+  });
+
+  it("should decrement once when switching from active to inactive", () => {
+    const increment = jest.fn();
+    const decrement = jest.fn();
+
+    const result = renderHook(({ active }: { active: boolean }) => useRegisterModal(active), {
+      wrapper: createWrapper({ value: 0, increment, decrement }),
+      initialProps: { active: true },
+    });
+
+    result.rerender({ active: false });
+
+    expect(decrement).toHaveBeenCalledTimes(1);
+    expect(increment).toHaveBeenCalledTimes(1);
   });
 });

--- a/scm-ui/ui-components/src/modals/useRegisterModal.ts
+++ b/scm-ui/ui-components/src/modals/useRegisterModal.ts
@@ -47,6 +47,7 @@ export default function useRegisterModal(active: boolean, initialValue: boolean 
     return () => {
       if (previousActiveState.current) {
         decrement();
+        previousActiveState.current = null;
       }
     };
   }, [active, decrement, increment]);


### PR DESCRIPTION
## Proposed changes

Global Modals as components, and as a result their registration hooks, have a lifecycle that spans the whole application. Because of this, they never get unmounted. The registration hook will simply be re-rendered with an updated "active" flag. Because the hook did not reset to its initial state when switching from "active" to "deactive", it decremented the modal count twice. Once in the cleanup of the previous hook render and once in the else block ("inactive").

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [x] Changelog entry 

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
