### PR TITLE
Improve plugin center error feedback and cache invalidation

### DIFF
--- a/gradle/changelog/config_change_plugin_center_invalidation.yaml
+++ b/gradle/changelog/config_change_plugin_center_invalidation.yaml
@@ -1,4 +1,4 @@
 - type: fixed
   description: Invalidate plugin center cache on global configuration change ([#2147](https://github.com/scm-manager/scm-manager/pull/2147))
 - type: changed
-  description: Display error notification while plugin center is not available ([#2147](https://github.com/scm-manager/scm-manager/pull/2147))
+  description: Provide feedback on plugin center status ([#2147](https://github.com/scm-manager/scm-manager/pull/2147))

--- a/gradle/changelog/config_change_plugin_center_invalidation.yaml
+++ b/gradle/changelog/config_change_plugin_center_invalidation.yaml
@@ -1,0 +1,4 @@
+- type: fixed
+  description: Invalidate plugin center cache on global configuration change ([#2147](https://github.com/scm-manager/scm-manager/pull/2147))
+- type: changed
+  description: Display error notification while plugin center is not available ([#2147](https://github.com/scm-manager/scm-manager/pull/2147))

--- a/scm-core/src/main/java/sonia/scm/plugin/PluginCenterStatus.java
+++ b/scm-core/src/main/java/sonia/scm/plugin/PluginCenterStatus.java
@@ -24,25 +24,11 @@
 
 package sonia.scm.plugin;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-import java.util.Collections;
-import java.util.Set;
-
-@AllArgsConstructor
-@Getter
-class PluginCenterResult {
-  private Set<AvailablePlugin> plugins;
-  private Set<PluginSet> pluginSets;
-  private PluginCenterStatus status;
-
-  public PluginCenterResult(PluginCenterStatus status) {
-    this(Collections.emptySet(), Collections.emptySet(), status);
-  }
-
-  public PluginCenterResult(Set<AvailablePlugin> plugins, Set<PluginSet> pluginSets) {
-    this(plugins, pluginSets, PluginCenterStatus.OK);
-  }
-
+/**
+ * @since 2.40.0
+ */
+public enum PluginCenterStatus {
+  OK,
+  ERROR,
+  DEACTIVATED
 }

--- a/scm-core/src/main/java/sonia/scm/plugin/PluginManager.java
+++ b/scm-core/src/main/java/sonia/scm/plugin/PluginManager.java
@@ -24,6 +24,8 @@
 
 package sonia.scm.plugin;
 
+import lombok.Value;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -56,6 +58,13 @@ public interface PluginManager {
    * @return a list of installed plugins.
    */
   List<InstalledPlugin> getInstalled();
+
+  /**
+   * @since 2.40.0
+   */
+  default PluginResult getPlugins() {
+    return new PluginResult(getInstalled(), getAvailable(), false);
+  }
 
   /**
    * Returns all available plugins. The list contains the plugins which are loaded from the plugin center, but without
@@ -127,4 +136,21 @@ public interface PluginManager {
    * Update all installed plugins.
    */
   void updateAll();
+
+  @Value
+  class PluginResult {
+    List<InstalledPlugin> installedPlugins;
+    List<AvailablePlugin> availablePlugins;
+    boolean pluginCenterError;
+
+    public PluginResult(List<InstalledPlugin> installedPlugins, List<AvailablePlugin> availablePlugins, boolean pluginCenterError) {
+      this.installedPlugins = installedPlugins;
+      this.availablePlugins = availablePlugins;
+      this.pluginCenterError = pluginCenterError;
+    }
+
+    public PluginResult(List<InstalledPlugin> installedPlugins, List<AvailablePlugin> availablePlugins) {
+      this(installedPlugins, availablePlugins, false);
+    }
+  }
 }

--- a/scm-core/src/main/java/sonia/scm/plugin/PluginManager.java
+++ b/scm-core/src/main/java/sonia/scm/plugin/PluginManager.java
@@ -148,17 +148,12 @@ public interface PluginManager {
   class PluginResult {
     List<InstalledPlugin> installedPlugins;
     List<AvailablePlugin> availablePlugins;
-    Status status;
+    PluginCenterStatus pluginCenterStatus;
 
     @VisibleForTesting
     public PluginResult(List<InstalledPlugin> installedPlugins, List<AvailablePlugin> availablePlugins) {
-      this(installedPlugins, availablePlugins, Status.OK);
+      this(installedPlugins, availablePlugins, PluginCenterStatus.OK);
     }
 
-    public enum Status {
-      OK,
-      ERROR,
-      DEACTIVATED
-    }
   }
 }

--- a/scm-core/src/main/java/sonia/scm/plugin/PluginManager.java
+++ b/scm-core/src/main/java/sonia/scm/plugin/PluginManager.java
@@ -25,6 +25,7 @@
 package sonia.scm.plugin;
 
 import com.google.common.annotations.VisibleForTesting;
+import lombok.AllArgsConstructor;
 import lombok.Value;
 
 import java.util.List;
@@ -64,7 +65,7 @@ public interface PluginManager {
    * @since 2.40.0
    */
   default PluginResult getPlugins() {
-    return new PluginResult(getInstalled(), getAvailable(), false);
+    return new PluginResult(getInstalled(), getAvailable());
   }
 
   /**
@@ -143,20 +144,21 @@ public interface PluginManager {
    * @since 2.40.0
    */
   @Value
+  @AllArgsConstructor
   class PluginResult {
     List<InstalledPlugin> installedPlugins;
     List<AvailablePlugin> availablePlugins;
-    boolean pluginCenterError;
-
-    public PluginResult(List<InstalledPlugin> installedPlugins, List<AvailablePlugin> availablePlugins, boolean pluginCenterError) {
-      this.installedPlugins = installedPlugins;
-      this.availablePlugins = availablePlugins;
-      this.pluginCenterError = pluginCenterError;
-    }
+    Status status;
 
     @VisibleForTesting
     public PluginResult(List<InstalledPlugin> installedPlugins, List<AvailablePlugin> availablePlugins) {
-      this(installedPlugins, availablePlugins, false);
+      this(installedPlugins, availablePlugins, Status.OK);
+    }
+
+    public enum Status {
+      OK,
+      ERROR,
+      DEACTIVATED
     }
   }
 }

--- a/scm-core/src/main/java/sonia/scm/plugin/PluginManager.java
+++ b/scm-core/src/main/java/sonia/scm/plugin/PluginManager.java
@@ -24,6 +24,7 @@
 
 package sonia.scm.plugin;
 
+import com.google.common.annotations.VisibleForTesting;
 import lombok.Value;
 
 import java.util.List;
@@ -137,6 +138,10 @@ public interface PluginManager {
    */
   void updateAll();
 
+  /**
+   * Returned by {@link #getPlugins()}.
+   * @since 2.40.0
+   */
   @Value
   class PluginResult {
     List<InstalledPlugin> installedPlugins;
@@ -149,6 +154,7 @@ public interface PluginManager {
       this.pluginCenterError = pluginCenterError;
     }
 
+    @VisibleForTesting
     public PluginResult(List<InstalledPlugin> installedPlugins, List<AvailablePlugin> availablePlugins) {
       this(installedPlugins, availablePlugins, false);
     }

--- a/scm-ui/ui-api/src/plugins.test.ts
+++ b/scm-ui/ui-api/src/plugins.test.ts
@@ -114,6 +114,7 @@ describe("Test plugin hooks", () => {
     _embedded: {
       plugins,
     },
+    pluginCenterError: false,
   });
 
   const createPendingPlugins = (

--- a/scm-ui/ui-api/src/plugins.test.ts
+++ b/scm-ui/ui-api/src/plugins.test.ts
@@ -114,7 +114,7 @@ describe("Test plugin hooks", () => {
     _embedded: {
       plugins,
     },
-    pluginCenterError: false,
+    pluginCenterStatus: "OK",
   });
 
   const createPendingPlugins = (

--- a/scm-ui/ui-types/src/Plugin.ts
+++ b/scm-ui/ui-types/src/Plugin.ts
@@ -51,9 +51,11 @@ export type Plugin = HalRepresentation & {
   optionalDependencies: string[];
 };
 
+export type PluginCenterStatus = "OK" | "ERROR" | "DEACTIVATED";
+
 export type PluginCollection = HalRepresentationWithEmbedded<{
   plugins: Plugin[];
-}> & { pluginCenterError?: boolean };
+}> & { status?: PluginCenterStatus };
 
 export const isPluginCollection = (input: HalRepresentation): input is PluginCollection =>
   input._embedded ? "plugins" in input._embedded : false;

--- a/scm-ui/ui-types/src/Plugin.ts
+++ b/scm-ui/ui-types/src/Plugin.ts
@@ -55,7 +55,7 @@ export type PluginCenterStatus = "OK" | "ERROR" | "DEACTIVATED";
 
 export type PluginCollection = HalRepresentationWithEmbedded<{
   plugins: Plugin[];
-}> & { status?: PluginCenterStatus };
+}> & { pluginCenterStatus: PluginCenterStatus };
 
 export const isPluginCollection = (input: HalRepresentation): input is PluginCollection =>
   input._embedded ? "plugins" in input._embedded : false;

--- a/scm-ui/ui-types/src/Plugin.ts
+++ b/scm-ui/ui-types/src/Plugin.ts
@@ -53,7 +53,7 @@ export type Plugin = HalRepresentation & {
 
 export type PluginCollection = HalRepresentationWithEmbedded<{
   plugins: Plugin[];
-}> & { pluginCenterError: boolean };
+}> & { pluginCenterError?: boolean };
 
 export const isPluginCollection = (input: HalRepresentation): input is PluginCollection =>
   input._embedded ? "plugins" in input._embedded : false;

--- a/scm-ui/ui-types/src/Plugin.ts
+++ b/scm-ui/ui-types/src/Plugin.ts
@@ -53,7 +53,7 @@ export type Plugin = HalRepresentation & {
 
 export type PluginCollection = HalRepresentationWithEmbedded<{
   plugins: Plugin[];
-}>;
+}> & { pluginCenterError: boolean };
 
 export const isPluginCollection = (input: HalRepresentation): input is PluginCollection =>
   input._embedded ? "plugins" in input._embedded : false;

--- a/scm-ui/ui-webapp/public/locales/de/admin.json
+++ b/scm-ui/ui-webapp/public/locales/de/admin.json
@@ -44,6 +44,7 @@
     "updateAll": "Alle Plugins aktualisieren",
     "cancelPending": "Änderungen abbrechen",
     "noPlugins": "Keine Plugins gefunden.",
+    "pluginCenterError": "Das Plugin Center ist nicht verfügbar. Plugins können weder installiert noch aktualisiert werden.",
     "modal": {
       "title": {
         "install": "{{name}} Plugin installieren",

--- a/scm-ui/ui-webapp/public/locales/de/admin.json
+++ b/scm-ui/ui-webapp/public/locales/de/admin.json
@@ -44,7 +44,10 @@
     "updateAll": "Alle Plugins aktualisieren",
     "cancelPending": "Änderungen abbrechen",
     "noPlugins": "Keine Plugins gefunden.",
-    "pluginCenterError": "Das Plugin Center ist nicht verfügbar. Plugins können weder installiert noch aktualisiert werden.",
+    "pluginCenterStatus": {
+      "ERROR": "Das Plugin Center ist nicht verfügbar. Plugins können weder installiert noch aktualisiert werden.",
+      "DEACTIVATED": "Das Plugin Center wurde in der Konfiguration deaktiviert. Plugins können weder installiert noch aktualisiert werden."
+    },
     "modal": {
       "title": {
         "install": "{{name}} Plugin installieren",

--- a/scm-ui/ui-webapp/public/locales/en/admin.json
+++ b/scm-ui/ui-webapp/public/locales/en/admin.json
@@ -44,6 +44,7 @@
     "updateAll": "Update All Plugins",
     "cancelPending": "Cancel Changes",
     "noPlugins": "No plugins found.",
+    "pluginCenterError": "The Plugin Center is not available. Plugins can neither be installed nor updated.",
     "modal": {
       "title": {
         "install": "Install {{name}} Plugin",

--- a/scm-ui/ui-webapp/public/locales/en/admin.json
+++ b/scm-ui/ui-webapp/public/locales/en/admin.json
@@ -44,7 +44,10 @@
     "updateAll": "Update All Plugins",
     "cancelPending": "Cancel Changes",
     "noPlugins": "No plugins found.",
-    "pluginCenterError": "The Plugin Center is not available. Plugins can neither be installed nor updated.",
+    "pluginCenterStatus": {
+      "ERROR": "The Plugin Center is not available. Plugins can neither be installed nor updated.",
+      "DEACTIVATED": "The Plugin Center is disabled in the configuration. Plugins can neither be installed nor updated."
+    },
     "modal": {
       "title": {
         "install": "Install {{name}} Plugin",

--- a/scm-ui/ui-webapp/src/admin/plugins/containers/PluginsOverview.tsx
+++ b/scm-ui/ui-webapp/src/admin/plugins/containers/PluginsOverview.tsx
@@ -182,17 +182,17 @@ const PluginsOverview: FC<Props> = ({ installed }) => {
   };
 
   const renderPluginsList = () => {
-    let pluginCenterErrorNotification: React.ReactNode;
-    if (collection?.status && collection.status !== "OK") {
-      const type = collection.status === "DEACTIVATED" ? "info" : "danger";
-      pluginCenterErrorNotification = (
-        <Notification type={type}>{t(`plugins.pluginCenterStatus.${collection.status}`)}</Notification>
+    let pluginCenterStatusNotification: React.ReactNode;
+    if (collection && collection.pluginCenterStatus !== "OK") {
+      const type = collection.pluginCenterStatus === "DEACTIVATED" ? "info" : "danger";
+      pluginCenterStatusNotification = (
+        <Notification type={type}>{t(`plugins.pluginCenterStatus.${collection.pluginCenterStatus}`)}</Notification>
       );
     }
     if (collection?._embedded && collection._embedded.plugins.length > 0) {
       return (
         <>
-          {pluginCenterErrorNotification}
+          {pluginCenterStatusNotification}
           <PluginsList
             plugins={collection._embedded.plugins}
             openModal={setPluginModalContent}
@@ -201,7 +201,7 @@ const PluginsOverview: FC<Props> = ({ installed }) => {
         </>
       );
     }
-    return pluginCenterErrorNotification ?? <Notification type="info">{t("plugins.noPlugins")}</Notification>;
+    return pluginCenterStatusNotification ?? <Notification type="info">{t("plugins.noPlugins")}</Notification>;
   };
 
   const renderModals = () => {

--- a/scm-ui/ui-webapp/src/admin/plugins/containers/PluginsOverview.tsx
+++ b/scm-ui/ui-webapp/src/admin/plugins/containers/PluginsOverview.tsx
@@ -183,8 +183,11 @@ const PluginsOverview: FC<Props> = ({ installed }) => {
 
   const renderPluginsList = () => {
     let pluginCenterErrorNotification: React.ReactNode;
-    if (collection?.pluginCenterError) {
-      pluginCenterErrorNotification = <Notification type="danger">{t("plugins.pluginCenterError")}</Notification>;
+    if (collection?.status && collection.status !== "OK") {
+      const type = collection.status === "DEACTIVATED" ? "info" : "danger";
+      pluginCenterErrorNotification = (
+        <Notification type={type}>{t(`plugins.pluginCenterStatus.${collection.status}`)}</Notification>
+      );
     }
     if (collection?._embedded && collection._embedded.plugins.length > 0) {
       return (

--- a/scm-ui/ui-webapp/src/admin/plugins/containers/PluginsOverview.tsx
+++ b/scm-ui/ui-webapp/src/admin/plugins/containers/PluginsOverview.tsx
@@ -32,7 +32,7 @@ import {
   Loading,
   Notification,
   Subtitle,
-  Title
+  Title,
 } from "@scm-manager/ui-components";
 import PluginsList from "../components/PluginList";
 import PluginTopActions from "../components/PluginTopActions";
@@ -45,7 +45,7 @@ import {
   useAvailablePlugins,
   useInstalledPlugins,
   usePendingPlugins,
-  usePluginCenterAuthInfo
+  usePluginCenterAuthInfo,
 } from "@scm-manager/ui-api";
 import PluginModal from "../components/PluginModal";
 import MyCloudoguBanner from "../components/MyCloudoguBanner";
@@ -55,7 +55,7 @@ export enum PluginAction {
   INSTALL = "install",
   UPDATE = "update",
   UNINSTALL = "uninstall",
-  CLOUDOGU = "cloudoguInstall"
+  CLOUDOGU = "cloudoguInstall",
 }
 
 export type PluginModalContent = {
@@ -72,12 +72,12 @@ const PluginsOverview: FC<Props> = ({ installed }) => {
   const {
     data: availablePlugins,
     isLoading: isLoadingAvailablePlugins,
-    error: availablePluginsError
+    error: availablePluginsError,
   } = useAvailablePlugins({ enabled: !installed });
   const {
     data: installedPlugins,
     isLoading: isLoadingInstalledPlugins,
-    error: installedPluginsError
+    error: installedPluginsError,
   } = useInstalledPlugins({ enabled: installed });
   const { data: pendingPlugins, isLoading: isLoadingPendingPlugins, error: pendingPluginsError } = usePendingPlugins();
   const pluginCenterAuthInfo = usePluginCenterAuthInfo();
@@ -177,21 +177,28 @@ const PluginsOverview: FC<Props> = ({ installed }) => {
   const computeUpdateAllSize = () => {
     const outdatedPlugins = collection?._embedded?.plugins.filter((p: Plugin) => p._links.update).length;
     return t("plugins.outdatedPlugins", {
-      count: outdatedPlugins
+      count: outdatedPlugins,
     });
   };
 
   const renderPluginsList = () => {
+    let pluginCenterErrorNotification: React.ReactNode;
+    if (collection?.pluginCenterError) {
+      pluginCenterErrorNotification = <Notification type="danger">{t("plugins.pluginCenterError")}</Notification>;
+    }
     if (collection?._embedded && collection._embedded.plugins.length > 0) {
       return (
-        <PluginsList
-          plugins={collection._embedded.plugins}
-          openModal={setPluginModalContent}
-          pluginCenterAuthInfo={pluginCenterAuthInfo.data}
-        />
+        <>
+          {pluginCenterErrorNotification}
+          <PluginsList
+            plugins={collection._embedded.plugins}
+            openModal={setPluginModalContent}
+            pluginCenterAuthInfo={pluginCenterAuthInfo.data}
+          />
+        </>
       );
     }
-    return <Notification type="info">{t("plugins.noPlugins")}</Notification>;
+    return pluginCenterErrorNotification ?? <Notification type="info">{t("plugins.noPlugins")}</Notification>;
   };
 
   const renderModals = () => {

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/AvailablePluginResource.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/AvailablePluginResource.java
@@ -95,10 +95,10 @@ public class AvailablePluginResource {
   @Produces(VndMediaType.PLUGIN_COLLECTION)
   public Response getAvailablePlugins() {
     PluginPermissions.read().check();
-    List<InstalledPlugin> installed = pluginManager.getInstalled();
-    List<AvailablePlugin> available = pluginManager.getAvailable().stream().filter(a -> notInstalled(a, installed)).collect(Collectors.toList());
+    PluginManager.PluginResult plugins = pluginManager.getPlugins();
+    List<AvailablePlugin> available = plugins.getAvailablePlugins().stream().filter(a -> notInstalled(a, plugins.getInstalledPlugins())).collect(Collectors.toList());
 
-    return Response.ok(collectionMapper.mapAvailable(available)).build();
+    return Response.ok(collectionMapper.mapAvailable(available, plugins.isPluginCenterError())).build();
   }
 
   private boolean notInstalled(AvailablePlugin a, List<InstalledPlugin> installed) {

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/AvailablePluginResource.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/AvailablePluginResource.java
@@ -98,7 +98,7 @@ public class AvailablePluginResource {
     PluginManager.PluginResult plugins = pluginManager.getPlugins();
     List<AvailablePlugin> available = plugins.getAvailablePlugins().stream().filter(a -> notInstalled(a, plugins.getInstalledPlugins())).collect(Collectors.toList());
 
-    return Response.ok(collectionMapper.mapAvailable(available, plugins.getStatus())).build();
+    return Response.ok(collectionMapper.mapAvailable(available, plugins.getPluginCenterStatus())).build();
   }
 
   private boolean notInstalled(AvailablePlugin a, List<InstalledPlugin> installed) {

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/AvailablePluginResource.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/AvailablePluginResource.java
@@ -98,7 +98,7 @@ public class AvailablePluginResource {
     PluginManager.PluginResult plugins = pluginManager.getPlugins();
     List<AvailablePlugin> available = plugins.getAvailablePlugins().stream().filter(a -> notInstalled(a, plugins.getInstalledPlugins())).collect(Collectors.toList());
 
-    return Response.ok(collectionMapper.mapAvailable(available, plugins.isPluginCenterError())).build();
+    return Response.ok(collectionMapper.mapAvailable(available, plugins.getStatus())).build();
   }
 
   private boolean notInstalled(AvailablePlugin a, List<InstalledPlugin> installed) {

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/InstalledPluginResource.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/InstalledPluginResource.java
@@ -95,9 +95,8 @@ public class InstalledPluginResource {
   )
   public Response getInstalledPlugins() {
     PluginPermissions.read().check();
-    List<InstalledPlugin> plugins = pluginManager.getInstalled();
-    List<AvailablePlugin> available = pluginManager.getAvailable();
-    return Response.ok(collectionMapper.mapInstalled(plugins, available)).build();
+    PluginManager.PluginResult plugins = pluginManager.getPlugins();
+    return Response.ok(collectionMapper.mapInstalled(plugins)).build();
   }
 
   /**

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/PluginCollectionDto.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/PluginCollectionDto.java
@@ -29,16 +29,16 @@ import de.otto.edison.hal.HalRepresentation;
 import de.otto.edison.hal.Links;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import sonia.scm.plugin.PluginManager;
+import sonia.scm.plugin.PluginCenterStatus;
 
 @Getter
 @NoArgsConstructor
 public class PluginCollectionDto extends HalRepresentation {
 
-  private PluginManager.PluginResult.Status status;
+  private PluginCenterStatus pluginCenterStatus;
 
-  public PluginCollectionDto(Links links, Embedded embedded, PluginManager.PluginResult.Status status) {
+  public PluginCollectionDto(Links links, Embedded embedded, PluginCenterStatus pluginCenterStatus) {
     super(links, embedded);
-    this.status = status;
+    this.pluginCenterStatus = pluginCenterStatus;
   }
 }

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/PluginCollectionDto.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/PluginCollectionDto.java
@@ -34,6 +34,10 @@ public class PluginCollectionDto extends HalRepresentation {
 
   private final boolean pluginCenterError;
 
+  public PluginCollectionDto() {
+    this(null, null, false);
+  }
+
   public PluginCollectionDto(Links links, Embedded embedded, boolean pluginCenterError) {
     super(links, embedded);
     this.pluginCenterError = pluginCenterError;

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/PluginCollectionDto.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/PluginCollectionDto.java
@@ -28,18 +28,17 @@ import de.otto.edison.hal.Embedded;
 import de.otto.edison.hal.HalRepresentation;
 import de.otto.edison.hal.Links;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sonia.scm.plugin.PluginManager;
 
 @Getter
+@NoArgsConstructor
 public class PluginCollectionDto extends HalRepresentation {
 
-  private final boolean pluginCenterError;
+  private PluginManager.PluginResult.Status status;
 
-  public PluginCollectionDto() {
-    this(null, null, false);
-  }
-
-  public PluginCollectionDto(Links links, Embedded embedded, boolean pluginCenterError) {
+  public PluginCollectionDto(Links links, Embedded embedded, PluginManager.PluginResult.Status status) {
     super(links, embedded);
-    this.pluginCenterError = pluginCenterError;
+    this.status = status;
   }
 }

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/PluginCollectionDto.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/PluginCollectionDto.java
@@ -22,22 +22,20 @@
  * SOFTWARE.
  */
 
-package sonia.scm.plugin;
+package sonia.scm.api.v2.resources;
 
-import lombok.AllArgsConstructor;
+import de.otto.edison.hal.Embedded;
+import de.otto.edison.hal.HalRepresentation;
+import de.otto.edison.hal.Links;
 import lombok.Getter;
 
-import java.util.Set;
-
-@AllArgsConstructor
 @Getter
-class PluginCenterResult {
-  private Set<AvailablePlugin> plugins;
-  private Set<PluginSet> pluginSets;
-  private boolean isError;
+public class PluginCollectionDto extends HalRepresentation {
 
-  public PluginCenterResult(Set<AvailablePlugin> plugins, Set<PluginSet> pluginSets) {
-    this.plugins = plugins;
-    this.pluginSets = pluginSets;
+  private final boolean pluginCenterError;
+
+  public PluginCollectionDto(Links links, Embedded embedded, boolean pluginCenterError) {
+    super(links, embedded);
+    this.pluginCenterError = pluginCenterError;
   }
 }

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/PluginDtoCollectionMapper.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/PluginDtoCollectionMapper.java
@@ -57,12 +57,12 @@ public class PluginDtoCollectionMapper {
       .stream()
       .map(i -> mapper.mapInstalled(i, plugins.getAvailablePlugins()))
       .collect(toList());
-    return new PluginCollectionDto(createInstalledPluginsLinks(), embedDtos(dtos), plugins.isPluginCenterError());
+    return new PluginCollectionDto(createInstalledPluginsLinks(), embedDtos(dtos), plugins.getStatus());
   }
 
-  public PluginCollectionDto mapAvailable(List<AvailablePlugin> plugins, boolean isPluginCenterError) {
+  public PluginCollectionDto mapAvailable(List<AvailablePlugin> plugins, PluginManager.PluginResult.Status status) {
     List<PluginDto> dtos = plugins.stream().map(mapper::mapAvailable).collect(toList());
-    return new PluginCollectionDto(createAvailablePluginsLinks(plugins), embedDtos(dtos), isPluginCenterError);
+    return new PluginCollectionDto(createAvailablePluginsLinks(plugins), embedDtos(dtos), status);
   }
 
   private Links createInstalledPluginsLinks() {

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/PluginDtoCollectionMapper.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/PluginDtoCollectionMapper.java
@@ -26,7 +26,6 @@ package sonia.scm.api.v2.resources;
 
 import com.google.inject.Inject;
 import de.otto.edison.hal.Embedded;
-import de.otto.edison.hal.HalRepresentation;
 import de.otto.edison.hal.Links;
 import sonia.scm.plugin.AvailablePlugin;
 import sonia.scm.plugin.PluginManager;
@@ -52,7 +51,7 @@ public class PluginDtoCollectionMapper {
     this.manager = manager;
   }
 
-  public HalRepresentation mapInstalled(PluginManager.PluginResult plugins) {
+  public PluginCollectionDto mapInstalled(PluginManager.PluginResult plugins) {
     List<PluginDto> dtos = plugins
       .getInstalledPlugins()
       .stream()
@@ -61,7 +60,7 @@ public class PluginDtoCollectionMapper {
     return new PluginCollectionDto(createInstalledPluginsLinks(), embedDtos(dtos), plugins.isPluginCenterError());
   }
 
-  public HalRepresentation mapAvailable(List<AvailablePlugin> plugins, boolean isPluginCenterError) {
+  public PluginCollectionDto mapAvailable(List<AvailablePlugin> plugins, boolean isPluginCenterError) {
     List<PluginDto> dtos = plugins.stream().map(mapper::mapAvailable).collect(toList());
     return new PluginCollectionDto(createAvailablePluginsLinks(plugins), embedDtos(dtos), isPluginCenterError);
   }

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/PluginDtoCollectionMapper.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/PluginDtoCollectionMapper.java
@@ -29,7 +29,6 @@ import de.otto.edison.hal.Embedded;
 import de.otto.edison.hal.HalRepresentation;
 import de.otto.edison.hal.Links;
 import sonia.scm.plugin.AvailablePlugin;
-import sonia.scm.plugin.InstalledPlugin;
 import sonia.scm.plugin.PluginManager;
 import sonia.scm.plugin.PluginPermissions;
 
@@ -53,17 +52,18 @@ public class PluginDtoCollectionMapper {
     this.manager = manager;
   }
 
-  public HalRepresentation mapInstalled(List<InstalledPlugin> plugins, List<AvailablePlugin> availablePlugins) {
+  public HalRepresentation mapInstalled(PluginManager.PluginResult plugins) {
     List<PluginDto> dtos = plugins
+      .getInstalledPlugins()
       .stream()
-      .map(i -> mapper.mapInstalled(i, availablePlugins))
+      .map(i -> mapper.mapInstalled(i, plugins.getAvailablePlugins()))
       .collect(toList());
-    return new HalRepresentation(createInstalledPluginsLinks(), embedDtos(dtos));
+    return new PluginCollectionDto(createInstalledPluginsLinks(), embedDtos(dtos), plugins.isPluginCenterError());
   }
 
-  public HalRepresentation mapAvailable(List<AvailablePlugin> plugins) {
+  public HalRepresentation mapAvailable(List<AvailablePlugin> plugins, boolean isPluginCenterError) {
     List<PluginDto> dtos = plugins.stream().map(mapper::mapAvailable).collect(toList());
-    return new HalRepresentation(createAvailablePluginsLinks(plugins), embedDtos(dtos));
+    return new PluginCollectionDto(createAvailablePluginsLinks(plugins), embedDtos(dtos), isPluginCenterError);
   }
 
   private Links createInstalledPluginsLinks() {

--- a/scm-webapp/src/main/java/sonia/scm/api/v2/resources/PluginDtoCollectionMapper.java
+++ b/scm-webapp/src/main/java/sonia/scm/api/v2/resources/PluginDtoCollectionMapper.java
@@ -28,6 +28,7 @@ import com.google.inject.Inject;
 import de.otto.edison.hal.Embedded;
 import de.otto.edison.hal.Links;
 import sonia.scm.plugin.AvailablePlugin;
+import sonia.scm.plugin.PluginCenterStatus;
 import sonia.scm.plugin.PluginManager;
 import sonia.scm.plugin.PluginPermissions;
 
@@ -57,12 +58,12 @@ public class PluginDtoCollectionMapper {
       .stream()
       .map(i -> mapper.mapInstalled(i, plugins.getAvailablePlugins()))
       .collect(toList());
-    return new PluginCollectionDto(createInstalledPluginsLinks(), embedDtos(dtos), plugins.getStatus());
+    return new PluginCollectionDto(createInstalledPluginsLinks(), embedDtos(dtos), plugins.getPluginCenterStatus());
   }
 
-  public PluginCollectionDto mapAvailable(List<AvailablePlugin> plugins, PluginManager.PluginResult.Status status) {
+  public PluginCollectionDto mapAvailable(List<AvailablePlugin> plugins, PluginCenterStatus pluginCenterStatus) {
     List<PluginDto> dtos = plugins.stream().map(mapper::mapAvailable).collect(toList());
-    return new PluginCollectionDto(createAvailablePluginsLinks(plugins), embedDtos(dtos), status);
+    return new PluginCollectionDto(createAvailablePluginsLinks(plugins), embedDtos(dtos), pluginCenterStatus);
   }
 
   private Links createInstalledPluginsLinks() {

--- a/scm-webapp/src/main/java/sonia/scm/plugin/DefaultPluginManager.java
+++ b/scm-webapp/src/main/java/sonia/scm/plugin/DefaultPluginManager.java
@@ -108,6 +108,16 @@ public class DefaultPluginManager implements PluginManager {
   }
 
   @Override
+  public PluginResult getPlugins() {
+    PluginCenterResult pluginCenterResult = center.getPluginResult();
+    return new PluginResult(
+      getInstalled(),
+      filterAvailablePlugins(pluginCenterResult.getPlugins()),
+      pluginCenterResult.isError()
+    );
+  }
+
+  @Override
   public Optional<AvailablePlugin> getAvailable(String name) {
     PluginPermissions.read().check();
     return center.getAvailablePlugins()
@@ -144,7 +154,11 @@ public class DefaultPluginManager implements PluginManager {
   @Override
   public List<AvailablePlugin> getAvailable() {
     PluginPermissions.read().check();
-    return center.getAvailablePlugins()
+    return filterAvailablePlugins(center.getAvailablePlugins());
+  }
+
+  private List<AvailablePlugin> filterAvailablePlugins(Set<AvailablePlugin> availablePlugins) {
+    return availablePlugins
       .stream()
       .filter(this::isNotInstalledOrMoreUpToDate)
       .map(p -> getPending(p.getDescriptor().getInformation().getName()).orElse(p))

--- a/scm-webapp/src/main/java/sonia/scm/plugin/DefaultPluginManager.java
+++ b/scm-webapp/src/main/java/sonia/scm/plugin/DefaultPluginManager.java
@@ -109,10 +109,11 @@ public class DefaultPluginManager implements PluginManager {
 
   @Override
   public PluginResult getPlugins() {
+    PluginPermissions.read().check();
     PluginCenterResult pluginCenterResult = center.getPluginResult();
     return new PluginResult(
       getInstalled(),
-      filterAvailablePlugins(pluginCenterResult.getPlugins()),
+      filterNotInstalledOrMoreUpToDate(pluginCenterResult.getPlugins()),
       pluginCenterResult.isError()
     );
   }
@@ -154,10 +155,10 @@ public class DefaultPluginManager implements PluginManager {
   @Override
   public List<AvailablePlugin> getAvailable() {
     PluginPermissions.read().check();
-    return filterAvailablePlugins(center.getAvailablePlugins());
+    return filterNotInstalledOrMoreUpToDate(center.getAvailablePlugins());
   }
 
-  private List<AvailablePlugin> filterAvailablePlugins(Set<AvailablePlugin> availablePlugins) {
+  private List<AvailablePlugin> filterNotInstalledOrMoreUpToDate(Set<AvailablePlugin> availablePlugins) {
     return availablePlugins
       .stream()
       .filter(this::isNotInstalledOrMoreUpToDate)

--- a/scm-webapp/src/main/java/sonia/scm/plugin/DefaultPluginManager.java
+++ b/scm-webapp/src/main/java/sonia/scm/plugin/DefaultPluginManager.java
@@ -114,7 +114,7 @@ public class DefaultPluginManager implements PluginManager {
     return new PluginResult(
       getInstalled(),
       filterNotInstalledOrMoreUpToDate(pluginCenterResult.getPlugins()),
-      pluginCenterResult.isError()
+      pluginCenterResult.getStatus()
     );
   }
 

--- a/scm-webapp/src/main/java/sonia/scm/plugin/PluginCenter.java
+++ b/scm-webapp/src/main/java/sonia/scm/plugin/PluginCenter.java
@@ -32,6 +32,7 @@ import sonia.scm.SCMContextProvider;
 import sonia.scm.cache.Cache;
 import sonia.scm.cache.CacheManager;
 import sonia.scm.config.ScmConfiguration;
+import sonia.scm.config.ScmConfigurationChangedEvent;
 import sonia.scm.util.HttpUtil;
 import sonia.scm.util.SystemUtil;
 
@@ -61,6 +62,12 @@ public class PluginCenter {
 
   @Subscribe
   public void handle(PluginCenterAuthenticationEvent event) {
+    LOG.debug("clear plugin center cache, because of {}", event);
+    pluginCenterResultCache.clear();
+  }
+
+  @Subscribe
+  public void handleEvent(ScmConfigurationChangedEvent event) {
     LOG.debug("clear plugin center cache, because of {}", event);
     pluginCenterResultCache.clear();
   }

--- a/scm-webapp/src/main/java/sonia/scm/plugin/PluginCenter.java
+++ b/scm-webapp/src/main/java/sonia/scm/plugin/PluginCenter.java
@@ -82,6 +82,11 @@ public class PluginCenter {
     return getPluginCenterResult(url).getPluginSets();
   }
 
+  synchronized PluginCenterResult getPluginResult() {
+    String url = buildPluginUrl(configuration.getPluginUrl());
+    return getPluginCenterResult(url);
+  }
+
   private PluginCenterResult getPluginCenterResult(String url) {
     PluginCenterResult pluginCenterResult = pluginCenterResultCache.get(url);
     if (pluginCenterResult == null) {

--- a/scm-webapp/src/main/java/sonia/scm/plugin/PluginCenter.java
+++ b/scm-webapp/src/main/java/sonia/scm/plugin/PluginCenter.java
@@ -67,7 +67,7 @@ public class PluginCenter {
   }
 
   @Subscribe
-  public void handleEvent(ScmConfigurationChangedEvent event) {
+  public void handle(ScmConfigurationChangedEvent event) {
     LOG.debug("clear plugin center cache, because of {}", event);
     pluginCenterResultCache.clear();
   }

--- a/scm-webapp/src/main/java/sonia/scm/plugin/PluginCenterDtoMapper.java
+++ b/scm-webapp/src/main/java/sonia/scm/plugin/PluginCenterDtoMapper.java
@@ -64,7 +64,7 @@ public abstract class PluginCenterDtoMapper {
       );
       plugins.add(new AvailablePlugin(descriptor));
     }
-    return new PluginCenterResult(plugins, pluginSets, false);
+    return new PluginCenterResult(plugins, pluginSets);
   }
 
   private String getInstallLink(PluginCenterDto.Plugin plugin) {

--- a/scm-webapp/src/main/java/sonia/scm/plugin/PluginCenterDtoMapper.java
+++ b/scm-webapp/src/main/java/sonia/scm/plugin/PluginCenterDtoMapper.java
@@ -64,7 +64,7 @@ public abstract class PluginCenterDtoMapper {
       );
       plugins.add(new AvailablePlugin(descriptor));
     }
-    return new PluginCenterResult(plugins, pluginSets);
+    return new PluginCenterResult(plugins, pluginSets, false);
   }
 
   private String getInstallLink(PluginCenterDto.Plugin plugin) {

--- a/scm-webapp/src/main/java/sonia/scm/plugin/PluginCenterLoader.java
+++ b/scm-webapp/src/main/java/sonia/scm/plugin/PluginCenterLoader.java
@@ -75,7 +75,7 @@ class PluginCenterLoader {
     } catch (Exception ex) {
       LOG.error("failed to load plugins from plugin center, returning empty list", ex);
       eventBus.post(new PluginCenterErrorEvent());
-      return new PluginCenterResult(Collections.emptySet(), Collections.emptySet());
+      return new PluginCenterResult(Collections.emptySet(), Collections.emptySet(), true);
     }
   }
 }

--- a/scm-webapp/src/main/java/sonia/scm/plugin/PluginCenterLoader.java
+++ b/scm-webapp/src/main/java/sonia/scm/plugin/PluginCenterLoader.java
@@ -33,7 +33,6 @@ import sonia.scm.net.ahc.AdvancedHttpClient;
 import sonia.scm.net.ahc.AdvancedHttpRequest;
 
 import javax.inject.Inject;
-import java.util.Collections;
 
 import static sonia.scm.plugin.Tracing.SPAN_KIND;
 
@@ -68,7 +67,7 @@ class PluginCenterLoader {
     try {
       if (Strings.isNullOrEmpty(url)) {
         LOG.info("plugin center is deactivated, returning empty list");
-        return new PluginCenterResult(PluginManager.PluginResult.Status.DEACTIVATED);
+        return new PluginCenterResult(PluginCenterStatus.DEACTIVATED);
       }
       LOG.info("fetch plugins from {}", url);
       AdvancedHttpRequest request = client.get(url).spanKind(SPAN_KIND);
@@ -80,7 +79,7 @@ class PluginCenterLoader {
     } catch (Exception ex) {
       LOG.error("failed to load plugins from plugin center, returning empty list", ex);
       eventBus.post(new PluginCenterErrorEvent());
-      return new PluginCenterResult(PluginManager.PluginResult.Status.ERROR);
+      return new PluginCenterResult(PluginCenterStatus.ERROR);
     }
   }
 }

--- a/scm-webapp/src/main/java/sonia/scm/plugin/PluginCenterLoader.java
+++ b/scm-webapp/src/main/java/sonia/scm/plugin/PluginCenterLoader.java
@@ -25,6 +25,7 @@
 package sonia.scm.plugin;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sonia.scm.event.ScmEventBus;
@@ -65,6 +66,10 @@ class PluginCenterLoader {
 
   PluginCenterResult load(String url) {
     try {
+      if (Strings.isNullOrEmpty(url)) {
+        LOG.info("plugin center is deactivated, returning empty list");
+        return new PluginCenterResult(PluginManager.PluginResult.Status.DEACTIVATED);
+      }
       LOG.info("fetch plugins from {}", url);
       AdvancedHttpRequest request = client.get(url).spanKind(SPAN_KIND);
       if (authenticator.isAuthenticated()) {
@@ -75,7 +80,7 @@ class PluginCenterLoader {
     } catch (Exception ex) {
       LOG.error("failed to load plugins from plugin center, returning empty list", ex);
       eventBus.post(new PluginCenterErrorEvent());
-      return new PluginCenterResult(Collections.emptySet(), Collections.emptySet(), true);
+      return new PluginCenterResult(PluginManager.PluginResult.Status.ERROR);
     }
   }
 }

--- a/scm-webapp/src/main/java/sonia/scm/plugin/PluginCenterResult.java
+++ b/scm-webapp/src/main/java/sonia/scm/plugin/PluginCenterResult.java
@@ -27,6 +27,7 @@ package sonia.scm.plugin;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.Collections;
 import java.util.Set;
 
 @AllArgsConstructor
@@ -34,10 +35,14 @@ import java.util.Set;
 class PluginCenterResult {
   private Set<AvailablePlugin> plugins;
   private Set<PluginSet> pluginSets;
-  private boolean isError;
+  private PluginManager.PluginResult.Status status;
+
+  public PluginCenterResult(PluginManager.PluginResult.Status status) {
+    this(Collections.emptySet(), Collections.emptySet(), status);
+  }
 
   public PluginCenterResult(Set<AvailablePlugin> plugins, Set<PluginSet> pluginSets) {
-    this.plugins = plugins;
-    this.pluginSets = pluginSets;
+    this(plugins, pluginSets, PluginManager.PluginResult.Status.OK);
   }
+
 }

--- a/scm-webapp/src/main/java/sonia/scm/plugin/PluginCenterResult.java
+++ b/scm-webapp/src/main/java/sonia/scm/plugin/PluginCenterResult.java
@@ -37,6 +37,10 @@ class PluginCenterResult {
   private Set<PluginSet> pluginSets;
   private PluginCenterStatus status;
 
+  public PluginCenterResult() {
+    this(Collections.emptySet(), Collections.emptySet(), PluginCenterStatus.OK);
+  }
+
   public PluginCenterResult(PluginCenterStatus status) {
     this(Collections.emptySet(), Collections.emptySet(), status);
   }

--- a/scm-webapp/src/test/java/sonia/scm/api/v2/resources/AvailablePluginResourceTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/api/v2/resources/AvailablePluginResourceTest.java
@@ -260,7 +260,7 @@ class AvailablePluginResourceTest {
     }
   }
 
-  public class MockedResultDto extends HalRepresentation {
+  public class MockedResultDto extends PluginCollectionDto {
     public String getMarker() {
       return "x";
     }

--- a/scm-webapp/src/test/java/sonia/scm/api/v2/resources/AvailablePluginResourceTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/api/v2/resources/AvailablePluginResourceTest.java
@@ -24,7 +24,6 @@
 
 package sonia.scm.api.v2.resources;
 
-import de.otto.edison.hal.HalRepresentation;
 import org.apache.shiro.authz.UnauthorizedException;
 import org.apache.shiro.subject.Subject;
 import org.apache.shiro.util.ThreadContext;
@@ -42,6 +41,7 @@ import sonia.scm.plugin.AvailablePlugin;
 import sonia.scm.plugin.AvailablePluginDescriptor;
 import sonia.scm.plugin.InstalledPlugin;
 import sonia.scm.plugin.InstalledPluginDescriptor;
+import sonia.scm.plugin.PluginCenterStatus;
 import sonia.scm.plugin.PluginCondition;
 import sonia.scm.plugin.PluginInformation;
 import sonia.scm.plugin.PluginManager;
@@ -118,7 +118,7 @@ class AvailablePluginResourceTest {
 
       when(pluginManager.getPlugins()).thenReturn(new PluginManager.PluginResult(Collections.emptyList(), Collections.singletonList(plugin)));
 
-      when(collectionMapper.mapAvailable(Collections.singletonList(plugin), PluginManager.PluginResult.Status.OK)).thenReturn(new MockedResultDto());
+      when(collectionMapper.mapAvailable(Collections.singletonList(plugin), PluginCenterStatus.OK)).thenReturn(new MockedResultDto());
 
       MockHttpRequest request = MockHttpRequest.get("/v2/plugins/available");
       request.accept(VndMediaType.PLUGIN_COLLECTION);
@@ -136,7 +136,7 @@ class AvailablePluginResourceTest {
       InstalledPlugin installedPlugin = createInstalledPlugin();
 
       when(pluginManager.getPlugins()).thenReturn(new PluginManager.PluginResult(Collections.singletonList(installedPlugin), Collections.singletonList(availablePlugin)));
-      lenient().when(collectionMapper.mapAvailable(Collections.singletonList(availablePlugin), PluginManager.PluginResult.Status.OK)).thenReturn(new MockedResultDto());
+      lenient().when(collectionMapper.mapAvailable(Collections.singletonList(availablePlugin), PluginCenterStatus.OK)).thenReturn(new MockedResultDto());
 
       MockHttpRequest request = MockHttpRequest.get("/v2/plugins/available");
       request.accept(VndMediaType.PLUGIN_COLLECTION);

--- a/scm-webapp/src/test/java/sonia/scm/api/v2/resources/AvailablePluginResourceTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/api/v2/resources/AvailablePluginResourceTest.java
@@ -118,7 +118,7 @@ class AvailablePluginResourceTest {
 
       when(pluginManager.getPlugins()).thenReturn(new PluginManager.PluginResult(Collections.emptyList(), Collections.singletonList(plugin)));
 
-      when(collectionMapper.mapAvailable(Collections.singletonList(plugin), false)).thenReturn(new MockedResultDto());
+      when(collectionMapper.mapAvailable(Collections.singletonList(plugin), PluginManager.PluginResult.Status.OK)).thenReturn(new MockedResultDto());
 
       MockHttpRequest request = MockHttpRequest.get("/v2/plugins/available");
       request.accept(VndMediaType.PLUGIN_COLLECTION);
@@ -136,7 +136,7 @@ class AvailablePluginResourceTest {
       InstalledPlugin installedPlugin = createInstalledPlugin();
 
       when(pluginManager.getPlugins()).thenReturn(new PluginManager.PluginResult(Collections.singletonList(installedPlugin), Collections.singletonList(availablePlugin)));
-      lenient().when(collectionMapper.mapAvailable(Collections.singletonList(availablePlugin), false)).thenReturn(new MockedResultDto());
+      lenient().when(collectionMapper.mapAvailable(Collections.singletonList(availablePlugin), PluginManager.PluginResult.Status.OK)).thenReturn(new MockedResultDto());
 
       MockHttpRequest request = MockHttpRequest.get("/v2/plugins/available");
       request.accept(VndMediaType.PLUGIN_COLLECTION);

--- a/scm-webapp/src/test/java/sonia/scm/api/v2/resources/AvailablePluginResourceTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/api/v2/resources/AvailablePluginResourceTest.java
@@ -116,9 +116,9 @@ class AvailablePluginResourceTest {
     void getAvailablePlugins() throws URISyntaxException, UnsupportedEncodingException {
       AvailablePlugin plugin = createAvailablePlugin();
 
-      when(pluginManager.getAvailable()).thenReturn(Collections.singletonList(plugin));
-      when(pluginManager.getInstalled()).thenReturn(Collections.emptyList());
-      when(collectionMapper.mapAvailable(Collections.singletonList(plugin))).thenReturn(new MockedResultDto());
+      when(pluginManager.getPlugins()).thenReturn(new PluginManager.PluginResult(Collections.emptyList(), Collections.singletonList(plugin)));
+
+      when(collectionMapper.mapAvailable(Collections.singletonList(plugin), false)).thenReturn(new MockedResultDto());
 
       MockHttpRequest request = MockHttpRequest.get("/v2/plugins/available");
       request.accept(VndMediaType.PLUGIN_COLLECTION);
@@ -135,9 +135,8 @@ class AvailablePluginResourceTest {
       AvailablePlugin availablePlugin = createAvailablePlugin();
       InstalledPlugin installedPlugin = createInstalledPlugin();
 
-      when(pluginManager.getAvailable()).thenReturn(Collections.singletonList(availablePlugin));
-      when(pluginManager.getInstalled()).thenReturn(Collections.singletonList(installedPlugin));
-      lenient().when(collectionMapper.mapAvailable(Collections.singletonList(availablePlugin))).thenReturn(new MockedResultDto());
+      when(pluginManager.getPlugins()).thenReturn(new PluginManager.PluginResult(Collections.singletonList(installedPlugin), Collections.singletonList(availablePlugin)));
+      lenient().when(collectionMapper.mapAvailable(Collections.singletonList(availablePlugin), false)).thenReturn(new MockedResultDto());
 
       MockHttpRequest request = MockHttpRequest.get("/v2/plugins/available");
       request.accept(VndMediaType.PLUGIN_COLLECTION);

--- a/scm-webapp/src/test/java/sonia/scm/api/v2/resources/InstalledPluginResourceTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/api/v2/resources/InstalledPluginResourceTest.java
@@ -110,8 +110,9 @@ class InstalledPluginResourceTest {
     @Test
     void getInstalledPlugins() throws URISyntaxException, UnsupportedEncodingException {
       InstalledPlugin installedPlugin = createInstalled("");
-      when(pluginManager.getInstalled()).thenReturn(Collections.singletonList(installedPlugin));
-      when(collectionMapper.mapInstalled(Collections.singletonList(installedPlugin), Collections.emptyList())).thenReturn(new MockedResultDto());
+      PluginManager.PluginResult pluginResult = new PluginManager.PluginResult(Collections.singletonList(installedPlugin), emptyList());
+      when(pluginManager.getPlugins()).thenReturn(pluginResult);
+      when(collectionMapper.mapInstalled(pluginResult)).thenReturn(new MockedResultDto());
 
       MockHttpRequest request = MockHttpRequest.get("/v2/plugins/installed");
       request.accept(VndMediaType.PLUGIN_COLLECTION);

--- a/scm-webapp/src/test/java/sonia/scm/api/v2/resources/InstalledPluginResourceTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/api/v2/resources/InstalledPluginResourceTest.java
@@ -24,7 +24,6 @@
     
 package sonia.scm.api.v2.resources;
 
-import de.otto.edison.hal.HalRepresentation;
 import org.apache.shiro.authz.UnauthorizedException;
 import org.apache.shiro.subject.Subject;
 import org.apache.shiro.util.ThreadContext;
@@ -185,7 +184,8 @@ class InstalledPluginResourceTest {
     }
   }
 
-  public class MockedResultDto extends HalRepresentation {
+  public class MockedResultDto extends PluginCollectionDto {
+
     public String getMarker() {
       return "x";
     }

--- a/scm-webapp/src/test/java/sonia/scm/api/v2/resources/PluginDtoCollectionMapperTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/api/v2/resources/PluginDtoCollectionMapperTest.java
@@ -41,6 +41,7 @@ import sonia.scm.plugin.AvailablePlugin;
 import sonia.scm.plugin.AvailablePluginDescriptor;
 import sonia.scm.plugin.InstalledPlugin;
 import sonia.scm.plugin.InstalledPluginDescriptor;
+import sonia.scm.plugin.PluginCenterStatus;
 import sonia.scm.plugin.PluginInformation;
 import sonia.scm.plugin.PluginManager;
 
@@ -92,10 +93,10 @@ class PluginDtoCollectionMapperTest {
   void shouldMapErrorStatus() {
     PluginDtoCollectionMapper mapper = new PluginDtoCollectionMapper(resourceLinks, pluginDtoMapper, manager);
 
-    assertThat(mapper.mapInstalled(emptyPluginResult(PluginManager.PluginResult.Status.ERROR)).getStatus()).isEqualTo(PluginManager.PluginResult.Status.ERROR);
-    assertThat(mapper.mapInstalled(emptyPluginResult(PluginManager.PluginResult.Status.OK)).getStatus()).isEqualTo(PluginManager.PluginResult.Status.OK);
-    assertThat(mapper.mapAvailable(emptyList(), PluginManager.PluginResult.Status.ERROR).getStatus()).isEqualTo(PluginManager.PluginResult.Status.ERROR);
-    assertThat(mapper.mapAvailable(emptyList(), PluginManager.PluginResult.Status.OK).getStatus()).isEqualTo(PluginManager.PluginResult.Status.OK);
+    assertThat(mapper.mapInstalled(emptyPluginResult(PluginCenterStatus.ERROR)).getPluginCenterStatus()).isEqualTo(PluginCenterStatus.ERROR);
+    assertThat(mapper.mapInstalled(emptyPluginResult(PluginCenterStatus.OK)).getPluginCenterStatus()).isEqualTo(PluginCenterStatus.OK);
+    assertThat(mapper.mapAvailable(emptyList(), PluginCenterStatus.ERROR).getPluginCenterStatus()).isEqualTo(PluginCenterStatus.ERROR);
+    assertThat(mapper.mapAvailable(emptyList(), PluginCenterStatus.OK).getPluginCenterStatus()).isEqualTo(PluginCenterStatus.OK);
   }
 
   @Test
@@ -233,7 +234,7 @@ class PluginDtoCollectionMapperTest {
     return plugin;
   }
 
-  private static PluginManager.PluginResult emptyPluginResult(PluginManager.PluginResult.Status status) {
+  private static PluginManager.PluginResult emptyPluginResult(PluginCenterStatus status) {
     return new PluginManager.PluginResult(
       emptyList(),
       emptyList(),

--- a/scm-webapp/src/test/java/sonia/scm/api/v2/resources/PluginDtoCollectionMapperTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/api/v2/resources/PluginDtoCollectionMapperTest.java
@@ -44,7 +44,6 @@ import sonia.scm.plugin.InstalledPluginDescriptor;
 import sonia.scm.plugin.PluginInformation;
 import sonia.scm.plugin.PluginManager;
 
-import javax.annotation.Nonnull;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -93,10 +92,10 @@ class PluginDtoCollectionMapperTest {
   void shouldMapErrorStatus() {
     PluginDtoCollectionMapper mapper = new PluginDtoCollectionMapper(resourceLinks, pluginDtoMapper, manager);
 
-    assertThat(mapper.mapInstalled(emptyPluginResult(true)).isPluginCenterError()).isTrue();
-    assertThat(mapper.mapInstalled(emptyPluginResult(false)).isPluginCenterError()).isFalse();
-    assertThat(mapper.mapAvailable(emptyList(), true).isPluginCenterError()).isTrue();
-    assertThat(mapper.mapAvailable(emptyList(), false).isPluginCenterError()).isFalse();
+    assertThat(mapper.mapInstalled(emptyPluginResult(PluginManager.PluginResult.Status.ERROR)).getStatus()).isEqualTo(PluginManager.PluginResult.Status.ERROR);
+    assertThat(mapper.mapInstalled(emptyPluginResult(PluginManager.PluginResult.Status.OK)).getStatus()).isEqualTo(PluginManager.PluginResult.Status.OK);
+    assertThat(mapper.mapAvailable(emptyList(), PluginManager.PluginResult.Status.ERROR).getStatus()).isEqualTo(PluginManager.PluginResult.Status.ERROR);
+    assertThat(mapper.mapAvailable(emptyList(), PluginManager.PluginResult.Status.OK).getStatus()).isEqualTo(PluginManager.PluginResult.Status.OK);
   }
 
   @Test
@@ -234,11 +233,11 @@ class PluginDtoCollectionMapperTest {
     return plugin;
   }
 
-  private static PluginManager.PluginResult emptyPluginResult(boolean pluginCenterError) {
+  private static PluginManager.PluginResult emptyPluginResult(PluginManager.PluginResult.Status status) {
     return new PluginManager.PluginResult(
       emptyList(),
       emptyList(),
-      pluginCenterError
+      status
     );
   }
 }

--- a/scm-webapp/src/test/java/sonia/scm/api/v2/resources/PluginDtoCollectionMapperTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/api/v2/resources/PluginDtoCollectionMapperTest.java
@@ -44,11 +44,12 @@ import sonia.scm.plugin.InstalledPluginDescriptor;
 import sonia.scm.plugin.PluginInformation;
 import sonia.scm.plugin.PluginManager;
 
+import javax.annotation.Nonnull;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.lenient;
@@ -88,6 +89,15 @@ class PluginDtoCollectionMapperTest {
     ThreadContext.unbindSubject();
   }
 
+  @Test
+  void shouldMapErrorStatus() {
+    PluginDtoCollectionMapper mapper = new PluginDtoCollectionMapper(resourceLinks, pluginDtoMapper, manager);
+
+    assertThat(mapper.mapInstalled(emptyPluginResult(true)).isPluginCenterError()).isTrue();
+    assertThat(mapper.mapInstalled(emptyPluginResult(false)).isPluginCenterError()).isFalse();
+    assertThat(mapper.mapAvailable(emptyList(), true).isPluginCenterError()).isTrue();
+    assertThat(mapper.mapAvailable(emptyList(), false).isPluginCenterError()).isFalse();
+  }
 
   @Test
   void shouldMapInstalledPluginsWithoutUpdateWhenNoNewerVersionIsAvailable() {
@@ -106,7 +116,7 @@ class PluginDtoCollectionMapperTest {
 
   @Test
   void shouldSetNewVersionInInstalledPluginWhenAvailableVersionIsNewer() {
-    PluginDtoCollectionMapper mapper = new PluginDtoCollectionMapper(resourceLinks, pluginDtoMapper,manager);
+    PluginDtoCollectionMapper mapper = new PluginDtoCollectionMapper(resourceLinks, pluginDtoMapper, manager);
 
     HalRepresentation result = mapper.mapInstalled(new PluginManager.PluginResult(
       singletonList(createInstalledPlugin("scm-some-plugin", "1")),
@@ -222,5 +232,13 @@ class PluginDtoCollectionMapperTest {
     lenient().when(descriptor.getInformation()).thenReturn(information);
     lenient().when(plugin.getDescriptor()).thenReturn(descriptor);
     return plugin;
+  }
+
+  private static PluginManager.PluginResult emptyPluginResult(boolean pluginCenterError) {
+    return new PluginManager.PluginResult(
+      emptyList(),
+      emptyList(),
+      pluginCenterError
+    );
   }
 }

--- a/scm-webapp/src/test/java/sonia/scm/api/v2/resources/PluginDtoCollectionMapperTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/api/v2/resources/PluginDtoCollectionMapperTest.java
@@ -93,9 +93,9 @@ class PluginDtoCollectionMapperTest {
   void shouldMapInstalledPluginsWithoutUpdateWhenNoNewerVersionIsAvailable() {
     PluginDtoCollectionMapper mapper = new PluginDtoCollectionMapper(resourceLinks, pluginDtoMapper, manager);
 
-    HalRepresentation result = mapper.mapInstalled(
+    HalRepresentation result = mapper.mapInstalled(new PluginManager.PluginResult(
       singletonList(createInstalledPlugin("scm-some-plugin", "1")),
-      singletonList(createAvailablePlugin("scm-other-plugin", "2")));
+      singletonList(createAvailablePlugin("scm-other-plugin", "2"))));
 
     List<HalRepresentation> plugins = result.getEmbedded().getItemsBy("plugins");
     assertThat(plugins).hasSize(1);
@@ -108,9 +108,9 @@ class PluginDtoCollectionMapperTest {
   void shouldSetNewVersionInInstalledPluginWhenAvailableVersionIsNewer() {
     PluginDtoCollectionMapper mapper = new PluginDtoCollectionMapper(resourceLinks, pluginDtoMapper,manager);
 
-    HalRepresentation result = mapper.mapInstalled(
+    HalRepresentation result = mapper.mapInstalled(new PluginManager.PluginResult(
       singletonList(createInstalledPlugin("scm-some-plugin", "1")),
-      singletonList(createAvailablePlugin("scm-some-plugin", "2")));
+      singletonList(createAvailablePlugin("scm-some-plugin", "2"))));
 
     PluginDto plugin = getPluginDtoFromResult(result);
     assertThat(plugin.getVersion()).isEqualTo("1");
@@ -122,9 +122,9 @@ class PluginDtoCollectionMapperTest {
     when(subject.isPermitted("plugin:write")).thenReturn(false);
     PluginDtoCollectionMapper mapper = new PluginDtoCollectionMapper(resourceLinks, pluginDtoMapper, manager);
 
-    HalRepresentation result = mapper.mapInstalled(
+    HalRepresentation result = mapper.mapInstalled(new PluginManager.PluginResult(
       singletonList(createInstalledPlugin("scm-some-plugin", "1")),
-      singletonList(createAvailablePlugin("scm-some-plugin", "2")));
+      singletonList(createAvailablePlugin("scm-some-plugin", "2"))));
 
     PluginDto plugin = getPluginDtoFromResult(result);
     assertThat(plugin.getLinks().getLinkBy("update")).isEmpty();
@@ -137,9 +137,9 @@ class PluginDtoCollectionMapperTest {
 
     AvailablePlugin availablePlugin = createAvailablePlugin("scm-some-plugin", "2");
     when(availablePlugin.isPending()).thenReturn(true);
-    HalRepresentation result = mapper.mapInstalled(
+    HalRepresentation result = mapper.mapInstalled(new PluginManager.PluginResult(
       singletonList(createInstalledPlugin("scm-some-plugin", "1")),
-      singletonList(availablePlugin));
+      singletonList(availablePlugin)));
 
     PluginDto plugin = getPluginDtoFromResult(result);
     assertThat(plugin.getLinks().getLinkBy("update")).isEmpty();
@@ -150,9 +150,9 @@ class PluginDtoCollectionMapperTest {
     when(subject.isPermitted("plugin:write")).thenReturn(true);
     PluginDtoCollectionMapper mapper = new PluginDtoCollectionMapper(resourceLinks, pluginDtoMapper, manager);
 
-    HalRepresentation result = mapper.mapInstalled(
+    HalRepresentation result = mapper.mapInstalled(new PluginManager.PluginResult(
       singletonList(createInstalledPlugin("scm-some-plugin", "1")),
-      singletonList(createAvailablePlugin("scm-some-plugin", "2")));
+      singletonList(createAvailablePlugin("scm-some-plugin", "2"))));
 
     PluginDto plugin = getPluginDtoFromResult(result);
     assertThat(plugin.getLinks().getLinkBy("update")).isNotEmpty();
@@ -164,9 +164,9 @@ class PluginDtoCollectionMapperTest {
     when(subject.isPermitted("plugin:write")).thenReturn(true);
     PluginDtoCollectionMapper mapper = new PluginDtoCollectionMapper(resourceLinks, pluginDtoMapper, manager);
 
-    HalRepresentation result = mapper.mapInstalled(
+    HalRepresentation result = mapper.mapInstalled(new PluginManager.PluginResult(
       singletonList(createInstalledPlugin("scm-some-plugin", "1")),
-      singletonList(createAvailablePlugin("scm-some-plugin", "2")));
+      singletonList(createAvailablePlugin("scm-some-plugin", "2"))));
 
     PluginDto plugin = getPluginDtoFromResult(result);
     assertThat(plugin.getLinks().getLinkBy("update")).isNotEmpty();
@@ -180,9 +180,9 @@ class PluginDtoCollectionMapperTest {
 
     AvailablePlugin availablePlugin = createAvailablePlugin("scm-some-plugin", "2");
     when(availablePlugin.isPending()).thenReturn(true);
-    HalRepresentation result = mapper.mapInstalled(
+    HalRepresentation result = mapper.mapInstalled(new PluginManager.PluginResult(
       singletonList(createInstalledPlugin("scm-some-plugin", "1")),
-      singletonList(availablePlugin));
+      singletonList(availablePlugin)));
 
     PluginDto plugin = getPluginDtoFromResult(result);
     assertThat(plugin.isPending()).isTrue();

--- a/scm-webapp/src/test/java/sonia/scm/plugin/DefaultPluginManagerTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/plugin/DefaultPluginManagerTest.java
@@ -144,8 +144,7 @@ class DefaultPluginManagerTest {
 
       when(center.getPluginResult()).thenReturn(new PluginCenterResult(
         ImmutableSet.of(editor, jenkins),
-        emptySet(),
-        false)
+        emptySet())
       );
 
       when(loader.getInstalledPlugins()).thenReturn(ImmutableList.of(review, git));
@@ -154,7 +153,7 @@ class DefaultPluginManagerTest {
 
       assertThat(plugins.getAvailablePlugins()).containsOnly(editor, jenkins);
       assertThat(plugins.getInstalledPlugins()).containsOnly(review, git);
-      assertThat(plugins.isPluginCenterError()).isFalse();
+      assertThat(plugins.getStatus()).isEqualTo(PluginManager.PluginResult.Status.OK);
     }
 
     @Test

--- a/scm-webapp/src/test/java/sonia/scm/plugin/DefaultPluginManagerTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/plugin/DefaultPluginManagerTest.java
@@ -49,7 +49,6 @@ import sonia.scm.lifecycle.Restarter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -153,7 +152,7 @@ class DefaultPluginManagerTest {
 
       assertThat(plugins.getAvailablePlugins()).containsOnly(editor, jenkins);
       assertThat(plugins.getInstalledPlugins()).containsOnly(review, git);
-      assertThat(plugins.getStatus()).isEqualTo(PluginManager.PluginResult.Status.OK);
+      assertThat(plugins.getPluginCenterStatus()).isEqualTo(PluginCenterStatus.OK);
     }
 
     @Test

--- a/scm-webapp/src/test/java/sonia/scm/plugin/DefaultPluginManagerTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/plugin/DefaultPluginManagerTest.java
@@ -49,11 +49,13 @@ import sonia.scm.lifecycle.Restarter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -131,6 +133,28 @@ class DefaultPluginManagerTest {
     @AfterEach
     void clearThreadContext() {
       ThreadContext.unbindSubject();
+    }
+
+    @Test
+    void shouldReturnSuccessfulPluginResult() {
+      AvailablePlugin editor = createAvailable("scm-editor-plugin");
+      AvailablePlugin jenkins = createAvailable("scm-jenkins-plugin");
+      InstalledPlugin review = createInstalled("scm-review-plugin");
+      InstalledPlugin git = createInstalled("scm-git-plugin");
+
+      when(center.getPluginResult()).thenReturn(new PluginCenterResult(
+        ImmutableSet.of(editor, jenkins),
+        emptySet(),
+        false)
+      );
+
+      when(loader.getInstalledPlugins()).thenReturn(ImmutableList.of(review, git));
+
+      PluginManager.PluginResult plugins = manager.getPlugins();
+
+      assertThat(plugins.getAvailablePlugins()).containsOnly(editor, jenkins);
+      assertThat(plugins.getInstalledPlugins()).containsOnly(review, git);
+      assertThat(plugins.isPluginCenterError()).isFalse();
     }
 
     @Test

--- a/scm-webapp/src/test/java/sonia/scm/plugin/DefaultPluginManagerTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/plugin/DefaultPluginManagerTest.java
@@ -770,6 +770,7 @@ class DefaultPluginManagerTest {
       assertThrows(AuthorizationException.class, () -> manager.getAvailable());
       assertThrows(AuthorizationException.class, () -> manager.getAvailable("test"));
       assertThrows(AuthorizationException.class, () -> manager.getPluginSets());
+      assertThrows(AuthorizationException.class, () -> manager.getPlugins());
     }
 
   }

--- a/scm-webapp/src/test/java/sonia/scm/plugin/PluginCenterLoaderTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/plugin/PluginCenterLoaderTest.java
@@ -36,6 +36,7 @@ import sonia.scm.net.ahc.AdvancedHttpRequest;
 import sonia.scm.net.ahc.AdvancedHttpResponse;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
@@ -79,7 +80,7 @@ class PluginCenterLoaderTest {
     PluginCenterResult fetched = loader.load(PLUGIN_URL);
     assertThat(fetched.getPlugins()).isSameAs(plugins);
     assertThat(fetched.getPluginSets()).isSameAs(pluginSets);
-    assertThat(fetched.isError()).isFalse();
+    assertThat(fetched.getStatus()).isEqualTo(PluginManager.PluginResult.Status.OK);
   }
 
   private AdvancedHttpResponse request() throws IOException {
@@ -90,6 +91,14 @@ class PluginCenterLoaderTest {
   }
 
   @Test
+  void shouldReturnEmptySetIfPluginCenterIsDeactivated() {
+    PluginCenterResult fetch = loader.load("");
+    assertThat(fetch.getPlugins()).isEmpty();
+    assertThat(fetch.getPluginSets()).isEmpty();
+    assertThat(fetch.getStatus()).isSameAs(PluginManager.PluginResult.Status.DEACTIVATED);
+  }
+
+  @Test
   void shouldReturnEmptySetIfPluginCenterNotBeReached() throws IOException {
     when(client.get(PLUGIN_URL)).thenReturn(request);
     when(request.request()).thenThrow(new IOException("failed to fetch"));
@@ -97,7 +106,7 @@ class PluginCenterLoaderTest {
     PluginCenterResult fetch = loader.load(PLUGIN_URL);
     assertThat(fetch.getPlugins()).isEmpty();
     assertThat(fetch.getPluginSets()).isEmpty();
-    assertThat(fetch.isError()).isTrue();
+    assertThat(fetch.getStatus()).isSameAs(PluginManager.PluginResult.Status.ERROR);
   }
 
   @Test

--- a/scm-webapp/src/test/java/sonia/scm/plugin/PluginCenterLoaderTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/plugin/PluginCenterLoaderTest.java
@@ -36,7 +36,6 @@ import sonia.scm.net.ahc.AdvancedHttpRequest;
 import sonia.scm.net.ahc.AdvancedHttpResponse;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
@@ -80,7 +79,7 @@ class PluginCenterLoaderTest {
     PluginCenterResult fetched = loader.load(PLUGIN_URL);
     assertThat(fetched.getPlugins()).isSameAs(plugins);
     assertThat(fetched.getPluginSets()).isSameAs(pluginSets);
-    assertThat(fetched.getStatus()).isEqualTo(PluginManager.PluginResult.Status.OK);
+    assertThat(fetched.getStatus()).isEqualTo(PluginCenterStatus.OK);
   }
 
   private AdvancedHttpResponse request() throws IOException {
@@ -95,7 +94,7 @@ class PluginCenterLoaderTest {
     PluginCenterResult fetch = loader.load("");
     assertThat(fetch.getPlugins()).isEmpty();
     assertThat(fetch.getPluginSets()).isEmpty();
-    assertThat(fetch.getStatus()).isSameAs(PluginManager.PluginResult.Status.DEACTIVATED);
+    assertThat(fetch.getStatus()).isSameAs(PluginCenterStatus.DEACTIVATED);
   }
 
   @Test
@@ -106,7 +105,7 @@ class PluginCenterLoaderTest {
     PluginCenterResult fetch = loader.load(PLUGIN_URL);
     assertThat(fetch.getPlugins()).isEmpty();
     assertThat(fetch.getPluginSets()).isEmpty();
-    assertThat(fetch.getStatus()).isSameAs(PluginManager.PluginResult.Status.ERROR);
+    assertThat(fetch.getStatus()).isSameAs(PluginCenterStatus.ERROR);
   }
 
   @Test

--- a/scm-webapp/src/test/java/sonia/scm/plugin/PluginCenterLoaderTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/plugin/PluginCenterLoaderTest.java
@@ -79,6 +79,7 @@ class PluginCenterLoaderTest {
     PluginCenterResult fetched = loader.load(PLUGIN_URL);
     assertThat(fetched.getPlugins()).isSameAs(plugins);
     assertThat(fetched.getPluginSets()).isSameAs(pluginSets);
+    assertThat(fetched.isError()).isFalse();
   }
 
   private AdvancedHttpResponse request() throws IOException {
@@ -96,6 +97,7 @@ class PluginCenterLoaderTest {
     PluginCenterResult fetch = loader.load(PLUGIN_URL);
     assertThat(fetch.getPlugins()).isEmpty();
     assertThat(fetch.getPluginSets()).isEmpty();
+    assertThat(fetch.isError()).isTrue();
   }
 
   @Test

--- a/scm-webapp/src/test/java/sonia/scm/plugin/PluginCenterTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/plugin/PluginCenterTest.java
@@ -33,6 +33,7 @@ import sonia.scm.SCMContextProvider;
 import sonia.scm.cache.CacheManager;
 import sonia.scm.cache.MapCacheManager;
 import sonia.scm.config.ScmConfiguration;
+import sonia.scm.config.ScmConfigurationChangedEvent;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -101,7 +102,7 @@ class PluginCenterTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  void shouldClearCache() {
+  void shouldClearCacheOnPluginCenterLogin() {
     Set<AvailablePlugin> plugins = new HashSet<>();
     Set<PluginSet> pluginSets = new HashSet<>();
 
@@ -111,6 +112,22 @@ class PluginCenterTest {
     assertThat(pluginCenter.getAvailablePlugins()).isSameAs(plugins);
     assertThat(pluginCenter.getAvailablePluginSets()).isSameAs(pluginSets);
     pluginCenter.handle(new PluginCenterLoginEvent(null));
+    assertThat(pluginCenter.getAvailablePlugins()).isNotSameAs(plugins);
+    assertThat(pluginCenter.getAvailablePluginSets()).isNotSameAs(pluginSets);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldClearCacheOnConfigChange() {
+    Set<AvailablePlugin> plugins = new HashSet<>();
+    Set<PluginSet> pluginSets = new HashSet<>();
+
+    PluginCenterResult first = new PluginCenterResult(plugins, pluginSets);
+    when(loader.load(anyString())).thenReturn(first, new PluginCenterResult(Collections.emptySet(), Collections.emptySet()));
+
+    assertThat(pluginCenter.getAvailablePlugins()).isSameAs(plugins);
+    assertThat(pluginCenter.getAvailablePluginSets()).isSameAs(pluginSets);
+    pluginCenter.handle(new ScmConfigurationChangedEvent(null));
     assertThat(pluginCenter.getAvailablePlugins()).isNotSameAs(plugins);
     assertThat(pluginCenter.getAvailablePluginSets()).isNotSameAs(pluginSets);
   }

--- a/scm-webapp/src/test/java/sonia/scm/plugin/PluginCenterTest.java
+++ b/scm-webapp/src/test/java/sonia/scm/plugin/PluginCenterTest.java
@@ -35,7 +35,6 @@ import sonia.scm.cache.MapCacheManager;
 import sonia.scm.config.ScmConfiguration;
 import sonia.scm.config.ScmConfigurationChangedEvent;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -93,7 +92,7 @@ class PluginCenterTest {
     Set<PluginSet> pluginSets = new HashSet<>();
 
     PluginCenterResult first = new PluginCenterResult(plugins, pluginSets);
-    when(loader.load(anyString())).thenReturn(first, new PluginCenterResult(Collections.emptySet(), Collections.emptySet()));
+    when(loader.load(anyString())).thenReturn(first, new PluginCenterResult());
 
     assertThat(pluginCenter.getAvailablePlugins()).isSameAs(plugins);
     assertThat(pluginCenter.getAvailablePlugins()).isSameAs(plugins);
@@ -107,7 +106,7 @@ class PluginCenterTest {
     Set<PluginSet> pluginSets = new HashSet<>();
 
     PluginCenterResult first = new PluginCenterResult(plugins, pluginSets);
-    when(loader.load(anyString())).thenReturn(first, new PluginCenterResult(Collections.emptySet(), Collections.emptySet()));
+    when(loader.load(anyString())).thenReturn(first, new PluginCenterResult());
 
     assertThat(pluginCenter.getAvailablePlugins()).isSameAs(plugins);
     assertThat(pluginCenter.getAvailablePluginSets()).isSameAs(pluginSets);
@@ -123,7 +122,7 @@ class PluginCenterTest {
     Set<PluginSet> pluginSets = new HashSet<>();
 
     PluginCenterResult first = new PluginCenterResult(plugins, pluginSets);
-    when(loader.load(anyString())).thenReturn(first, new PluginCenterResult(Collections.emptySet(), Collections.emptySet()));
+    when(loader.load(anyString())).thenReturn(first, new PluginCenterResult());
 
     assertThat(pluginCenter.getAvailablePlugins()).isSameAs(plugins);
     assertThat(pluginCenter.getAvailablePluginSets()).isSameAs(pluginSets);


### PR DESCRIPTION
## Proposed changes

The plugin center cache was not invalidated when the proxy configuration was changed in the global settings. This caused stale and inconsistent state to be displayed to the user while there was no feedback that something was wrong.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [x] Feature has been tested with different permissions

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
