### PR TITLE
Implement sub-iterators for list navigation

### DIFF
--- a/scm-ui/ui-components/src/modals/activeModalCountContext.ts
+++ b/scm-ui/ui-components/src/modals/activeModalCountContext.ts
@@ -26,4 +26,15 @@ import React from "react";
 
 export type ModalStateContextType = { value: number; increment: () => void; decrement: () => void };
 
-export default React.createContext<ModalStateContextType>({} as ModalStateContextType);
+export default React.createContext<ModalStateContextType>({
+  value: 0,
+  increment: () => {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "Modals should be declared inside a ModalStateContext. Did you use the deprecated 'confirmAlert' function over the 'ConfirmAlert' component ?"
+    );
+  },
+  decrement: () => {
+    /* Do nothing */
+  },
+});

--- a/scm-ui/ui-shortcuts/package.json
+++ b/scm-ui/ui-shortcuts/package.json
@@ -30,7 +30,8 @@
     "@scm-manager/eslint-config": "^2.16.0",
     "@scm-manager/tsconfig": "^2.13.0",
     "@testing-library/react-hooks": "8.0.1",
-    "@testing-library/react": "12.1.5"
+    "@testing-library/react": "12.1.5",
+    "jest-extended": "3.1.0"
   },
   "babel": {
     "presets": [
@@ -43,5 +44,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "jest": {
+    "setupFilesAfterEnv": ["jest-extended/all"]
   }
 }

--- a/scm-ui/ui-shortcuts/src/index.ts
+++ b/scm-ui/ui-shortcuts/src/index.ts
@@ -25,4 +25,4 @@
 export { default as useShortcut } from "./useShortcut";
 export { default as useShortcutDocs, ShortcutDocsContextProvider } from "./useShortcutDocs";
 export { default as usePauseShortcuts } from "./usePauseShortcuts";
-export { useKeyboardIteratorTarget, KeyboardIterator } from "./iterator/keyboardIterator";
+export { useKeyboardIteratorTarget, KeyboardIterator, KeyboardSubIterator } from "./iterator/keyboardIterator";

--- a/scm-ui/ui-shortcuts/src/iterator/callbackIterator.ts
+++ b/scm-ui/ui-shortcuts/src/iterator/callbackIterator.ts
@@ -151,9 +151,7 @@ export class CallbackIterator implements CallbackRegistry {
       } else {
         nextIndex = this.firstAvailableIndex(direction, this.activeIndex + offset(direction));
       }
-      if (nextIndex !== null) {
-        this.setIndexAndActivateCurrentItem(nextIndex, direction);
-      }
+      this.setIndexAndActivateCurrentItem(nextIndex, direction);
     }
   };
 

--- a/scm-ui/ui-shortcuts/src/iterator/callbackIterator.ts
+++ b/scm-ui/ui-shortcuts/src/iterator/callbackIterator.ts
@@ -103,11 +103,11 @@ export class CallbackIterator implements CallbackRegistry {
     return this.items.length - 1;
   }
 
-  private firstIndex(direction: "forward" | "backward") {
+  private firstIndex = (direction: "forward" | "backward") => {
     return direction === "forward" ? 0 : this.lastIndex;
-  }
+  };
 
-  private firstAvailableIndex(direction: Direction, fromIndex = this.firstIndex(direction)) {
+  private firstAvailableIndex = (direction: Direction, fromIndex = this.firstIndex(direction)) => {
     for (; direction === "forward" ? fromIndex < this.items.length : fromIndex >= 0; fromIndex += offset(direction)) {
       const callback = this.items[fromIndex];
       if (callback) {
@@ -117,28 +117,28 @@ export class CallbackIterator implements CallbackRegistry {
       }
     }
     return null;
-  }
+  };
 
-  private hasAvailableIndex(direction: Direction, fromIndex?: number) {
+  private hasAvailableIndex = (direction: Direction, fromIndex?: number) => {
     return this.firstAvailableIndex(direction, fromIndex) !== null;
-  }
+  };
 
-  private activateCurrentItem(direction: Direction) {
+  private activateCurrentItem = (direction: Direction) => {
     if (isSubiterator(this.currentItem)) {
       this.currentItem.move(direction);
     } else if (this.currentItem) {
       this.currentItem();
     }
-  }
+  };
 
-  private setIndexAndActivateCurrentItem(index: number | null, direction: Direction) {
+  private setIndexAndActivateCurrentItem = (index: number | null, direction: Direction) => {
     if (index !== null && index !== INACTIVE_INDEX) {
       this.activeIndex = index;
       this.activateCurrentItem(direction);
     }
-  }
+  };
 
-  private move(direction: Direction) {
+  private move = (direction: Direction) => {
     if (isSubiterator(this.currentItem) && this.currentItem.hasNext(direction)) {
       this.currentItem.move(direction);
     } else {
@@ -153,9 +153,9 @@ export class CallbackIterator implements CallbackRegistry {
       }
       this.setIndexAndActivateCurrentItem(nextIndex, direction);
     }
-  }
+  };
 
-  private hasNext(inDirection: Direction): boolean {
+  private hasNext = (inDirection: Direction): boolean => {
     if (this.isInactive) {
       return this.hasAvailableIndex(inDirection);
     }
@@ -163,37 +163,37 @@ export class CallbackIterator implements CallbackRegistry {
       return true;
     }
     return this.hasAvailableIndex(inDirection, this.activeIndex + offset(inDirection));
-  }
+  };
 
-  public next() {
+  public next = () => {
     if (this.hasNext("forward")) {
       return this.move("forward");
     }
-  }
+  };
 
-  public previous() {
+  public previous = () => {
     if (this.hasNext("backward")) {
       return this.move("backward");
     }
-  }
+  };
 
-  public reset() {
+  public reset = () => {
     this.activeIndex = INACTIVE_INDEX;
     for (const cb of this.items) {
       if (isSubiterator(cb)) {
         cb.reset();
       }
     }
-  }
+  };
 
-  public register(item: Callback | CallbackIterator) {
+  public register = (item: Callback | CallbackIterator) => {
     if (isSubiterator(item)) {
       item.parent = this;
     }
     return this.items.push(item) - 1;
-  }
+  };
 
-  public deregister(index: number) {
+  public deregister = (index: number) => {
     this.items.splice(index, 1);
     if (this.activeIndex === index || this.activeIndex >= this.items.length) {
       if (this.hasAvailableIndex("backward", index)) {
@@ -210,7 +210,7 @@ export class CallbackIterator implements CallbackRegistry {
         this.reset();
       }
     }
-  }
+  };
 }
 
 export const useCallbackIterator = (initialIndex = INACTIVE_INDEX) => {

--- a/scm-ui/ui-shortcuts/src/iterator/callbackIterator.ts
+++ b/scm-ui/ui-shortcuts/src/iterator/callbackIterator.ts
@@ -1,0 +1,132 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { MutableRefObject, useCallback, useMemo, useRef } from "react";
+
+const INITIAL_INDEX = -1;
+const SubiteratorSymbol = Symbol("Subiterator");
+
+export type Callback = () => void;
+type SubiteratorFunction = (forward: boolean, restart: boolean) => boolean;
+export type Subiterator = { [SubiteratorSymbol]: SubiteratorFunction };
+
+const isSubiterator = (input?: Callback | Subiterator): input is Subiterator =>
+  typeof input === "object" && SubiteratorSymbol in input;
+
+const executeCallback = (forward: boolean, currentCallback?: Callback | Subiterator) => {
+  if (isSubiterator(currentCallback)) {
+    return currentCallback[SubiteratorSymbol](forward, true);
+  } else if (currentCallback) {
+    currentCallback();
+    return true;
+  }
+  return false;
+};
+
+export const navigate = (
+  forward: boolean,
+  activeIndexRef: MutableRefObject<number>,
+  callbacks: Array<Callback | Subiterator>
+) => {
+  const activeIndex = activeIndexRef.current;
+  const currentCallback = callbacks[activeIndex];
+  if (!isSubiterator(currentCallback) || !currentCallback[SubiteratorSymbol](forward, false)) {
+    if (activeIndex === INITIAL_INDEX) {
+      let nextIndex = forward ? 0 : callbacks.length - 1;
+      let hasNext = forward ? nextIndex < callbacks.length : nextIndex >= 0;
+      while (hasNext && !executeCallback(forward, callbacks[nextIndex])) {
+        nextIndex += forward ? 1 : -1;
+        hasNext = forward ? nextIndex < callbacks.length : nextIndex >= 0;
+      }
+      if (hasNext) {
+        activeIndexRef.current = nextIndex;
+        return true;
+      } else {
+        return false;
+      }
+    } else if (forward ? activeIndex < callbacks.length - 1 : activeIndex > 0) {
+      const nextIndex = activeIndex + (forward ? 1 : -1);
+      if (executeCallback(forward, callbacks[nextIndex])) {
+        activeIndexRef.current = nextIndex;
+      }
+    } else {
+      return false;
+    }
+  }
+  return true;
+};
+
+const useIteratorRefs = (initialIndex: number) => {
+  const callbacks = useRef<Array<Callback | Subiterator>>([]);
+  const activeIndex = useRef<number>(initialIndex);
+  return useMemo(() => ({ activeIndex, callbacks } as const), []);
+};
+
+export type CallbackIterator = {
+  register: (item: Callback | Subiterator) => number;
+  deregister: (index: number) => void;
+};
+
+const createCallbackIterator = (
+  activeIndex: MutableRefObject<number>,
+  callbacks: MutableRefObject<Array<Callback | Subiterator>>
+): CallbackIterator => ({
+  register: (callback: Callback | Subiterator) => callbacks.current.push(callback) - 1,
+  deregister: (index: number) => {
+    callbacks.current.splice(index, 1);
+    if (callbacks.current.length === 0) {
+      activeIndex.current = INITIAL_INDEX;
+    } else if (activeIndex.current === index || activeIndex.current >= callbacks.current.length) {
+      if (activeIndex.current > 0) {
+        activeIndex.current -= 1;
+      }
+      executeCallback(false, callbacks.current[activeIndex.current]);
+    }
+  },
+});
+
+export const createSubiterator = (
+  activeIndex: MutableRefObject<number>,
+  callbacks: MutableRefObject<Array<Callback | Subiterator>>
+): Subiterator => ({
+  [SubiteratorSymbol]: (forward, restart) => {
+    if (restart) {
+      activeIndex.current = INITIAL_INDEX;
+    }
+    return navigate(forward, activeIndex, callbacks.current);
+  },
+});
+
+export const useCallbackIterator = (initialIndex: number) => {
+  const { activeIndex, callbacks } = useIteratorRefs(initialIndex);
+  const value = useMemo(() => createCallbackIterator(activeIndex, callbacks), [activeIndex, callbacks]);
+  const next = useCallback(() => navigate(true, activeIndex, callbacks.current), [activeIndex, callbacks]);
+  const previous = useCallback(() => navigate(false, activeIndex, callbacks.current), [activeIndex, callbacks]);
+  const reset = useCallback(() => (activeIndex.current = INITIAL_INDEX), [activeIndex]);
+
+  return useMemo(
+    () => ({ activeIndex, callbacks, value, next, previous, reset } as const),
+    [activeIndex, callbacks, next, previous, reset, value]
+  );
+};

--- a/scm-ui/ui-shortcuts/src/iterator/callbackIterator.ts
+++ b/scm-ui/ui-shortcuts/src/iterator/callbackIterator.ts
@@ -138,7 +138,7 @@ export class CallbackIterator implements CallbackRegistry {
     }
   }
 
-  private move = (direction: Direction) => {
+  private move(direction: Direction) {
     if (isSubiterator(this.currentItem) && this.currentItem.hasNext(direction)) {
       this.currentItem.move(direction);
     } else {
@@ -153,7 +153,7 @@ export class CallbackIterator implements CallbackRegistry {
       }
       this.setIndexAndActivateCurrentItem(nextIndex, direction);
     }
-  };
+  }
 
   private hasNext(inDirection: Direction): boolean {
     if (this.isInactive) {
@@ -186,14 +186,14 @@ export class CallbackIterator implements CallbackRegistry {
     }
   }
 
-  public register = (item: Callback | CallbackIterator) => {
+  public register(item: Callback | CallbackIterator) {
     if (isSubiterator(item)) {
       item.parent = this;
     }
     return this.items.push(item) - 1;
-  };
+  }
 
-  public deregister = (index: number) => {
+  public deregister(index: number) {
     this.items.splice(index, 1);
     if (this.activeIndex === index || this.activeIndex >= this.items.length) {
       if (this.hasAvailableIndex("backward", index)) {
@@ -210,7 +210,7 @@ export class CallbackIterator implements CallbackRegistry {
         this.reset();
       }
     }
-  };
+  }
 }
 
 export const useCallbackIterator = (initialIndex = INACTIVE_INDEX) => {

--- a/scm-ui/ui-shortcuts/src/iterator/keyboardIterator.test.tsx
+++ b/scm-ui/ui-shortcuts/src/iterator/keyboardIterator.test.tsx
@@ -204,6 +204,26 @@ describe("shortcutIterator", () => {
     expect(callback3).not.toHaveBeenCalled();
   });
 
+  it("should move to existing index when active index in the middle is deregistered", async () => {
+    const callback = jest.fn();
+    const callback2 = jest.fn();
+    const callback3 = jest.fn();
+
+    const { rerender } = render(<List callbacks={[callback, callback2, callback3]} />, {
+      wrapper: createWrapper(1),
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(callback2).not.toHaveBeenCalled();
+    expect(callback3).not.toHaveBeenCalled();
+
+    rerender(<List callbacks={[callback, callback3]} />);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback2).not.toHaveBeenCalled();
+    expect(callback3).not.toHaveBeenCalled();
+  });
+
   it("should not move on deregistration if iterator is not active", async () => {
     const callback = jest.fn();
     const callback2 = jest.fn();

--- a/scm-ui/ui-shortcuts/src/iterator/keyboardIterator.test.tsx
+++ b/scm-ui/ui-shortcuts/src/iterator/keyboardIterator.test.tsx
@@ -289,6 +289,33 @@ describe("shortcutIterator", () => {
       expect(callback3).not.toHaveBeenCalled();
     });
 
+    it("should skip empty sub-iterators during navigation", () => {
+      const callback = jest.fn();
+      const callback2 = jest.fn();
+      const callback3 = jest.fn();
+
+      render(
+        <Wrapper>
+          <List callbacks={[callback]} />
+          <KeyboardSubIterator>
+            <List callbacks={[]} />
+          </KeyboardSubIterator>
+          <KeyboardSubIterator>
+            <List callbacks={[]} />
+          </KeyboardSubIterator>
+          <List callbacks={[callback2, callback3]} />
+        </Wrapper>
+      );
+
+      Mousetrap.trigger("j");
+      Mousetrap.trigger("j");
+      Mousetrap.trigger("j");
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback2).toHaveBeenCalledTimes(1);
+      expect(callback3).toHaveBeenCalledTimes(1);
+    });
+
     it("should not enter subiterator if its empty", () => {
       const callback = jest.fn();
       const callback2 = jest.fn();
@@ -308,6 +335,34 @@ describe("shortcutIterator", () => {
       expect(callback).not.toHaveBeenCalled();
       expect(callback2).not.toHaveBeenCalled();
       expect(callback3).not.toHaveBeenCalled();
+    });
+
+    it("should not loop", () => {
+      const callback = jest.fn();
+      const callback2 = jest.fn();
+      const callback3 = jest.fn();
+
+      render(
+        <Wrapper initialIndex={1}>
+          <KeyboardSubIterator>
+            <List callbacks={[callback, callback2]} />
+          </KeyboardSubIterator>
+          <List callbacks={[callback3]} />
+        </Wrapper>
+      );
+
+      Mousetrap.trigger("k");
+      Mousetrap.trigger("k");
+      Mousetrap.trigger("k");
+      Mousetrap.trigger("k");
+      Mousetrap.trigger("k");
+      Mousetrap.trigger("k");
+
+      expect(callback3).not.toHaveBeenCalled();
+      expect(callback2).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      expect(callback2).toHaveBeenCalledBefore(callback);
     });
   });
 });

--- a/scm-ui/ui-shortcuts/src/iterator/keyboardIterator.test.tsx
+++ b/scm-ui/ui-shortcuts/src/iterator/keyboardIterator.test.tsx
@@ -24,7 +24,12 @@
 
 import { renderHook } from "@testing-library/react-hooks";
 import React, { FC } from "react";
-import { KeyboardIteratorContextProvider, KeyboardSubIterator, useKeyboardIteratorItem } from "./keyboardIterator";
+import {
+  KeyboardIteratorContextProvider,
+  KeyboardSubIterator,
+  KeyboardSubIteratorContextProvider,
+  useKeyboardIteratorItem,
+} from "./keyboardIterator";
 import { render } from "@testing-library/react";
 import { ShortcutDocsContextProvider } from "../useShortcutDocs";
 import Mousetrap from "mousetrap";
@@ -383,6 +388,44 @@ describe("shortcutIterator", () => {
       expect(callback).toHaveBeenCalledTimes(1);
 
       expect(callback2).toHaveBeenCalledBefore(callback);
+    });
+
+    it("should move subiterator if its active callback is de-registered", () => {
+      const callback = jest.fn();
+      const callback2 = jest.fn();
+      const callback3 = jest.fn();
+      const callback4 = jest.fn();
+
+      const { rerender } = render(
+        <>
+          <KeyboardSubIteratorContextProvider initialIndex={1}>
+            <List callbacks={[callback, callback2, callback3]} />
+          </KeyboardSubIteratorContextProvider>
+          <List callbacks={[callback4]} />
+        </>,
+        {
+          wrapper: createWrapper(0),
+        }
+      );
+
+      expect(callback).not.toHaveBeenCalled();
+      expect(callback2).not.toHaveBeenCalled();
+      expect(callback3).not.toHaveBeenCalled();
+      expect(callback4).not.toHaveBeenCalled();
+
+      rerender(
+        <>
+          <KeyboardSubIteratorContextProvider initialIndex={1}>
+            <List callbacks={[callback, callback3]} />
+          </KeyboardSubIteratorContextProvider>
+          <List callbacks={[callback4]} />
+        </>
+      );
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback2).not.toHaveBeenCalled();
+      expect(callback3).not.toHaveBeenCalled();
+      expect(callback4).not.toHaveBeenCalled();
     });
   });
 });

--- a/scm-ui/ui-shortcuts/src/iterator/keyboardIterator.test.tsx
+++ b/scm-ui/ui-shortcuts/src/iterator/keyboardIterator.test.tsx
@@ -24,7 +24,7 @@
 
 import { renderHook } from "@testing-library/react-hooks";
 import React, { FC } from "react";
-import { KeyboardIteratorContextProvider, useKeyboardIteratorCallback } from "./keyboardIterator";
+import { KeyboardIteratorContextProvider, useKeyboardIteratorItem } from "./keyboardIterator";
 import { render } from "@testing-library/react";
 import { ShortcutDocsContextProvider } from "../useShortcutDocs";
 import Mousetrap from "mousetrap";
@@ -49,7 +49,7 @@ const createWrapper =
     <Wrapper initialIndex={initialIndex}>{children}</Wrapper>;
 
 const Item: FC<{ callback: () => void }> = ({ callback }) => {
-  useKeyboardIteratorCallback(callback);
+  useKeyboardIteratorItem(callback);
   return <li>example</li>;
 };
 
@@ -69,7 +69,7 @@ describe("shortcutIterator", () => {
   it("should not call callback upon registration", () => {
     const callback = jest.fn();
 
-    renderHook(() => useKeyboardIteratorCallback(callback), {
+    renderHook(() => useKeyboardIteratorItem(callback), {
       wrapper: Wrapper,
     });
 
@@ -79,7 +79,7 @@ describe("shortcutIterator", () => {
   it("should not throw if not inside keyboard iterator context", () => {
     const callback = jest.fn();
 
-    const { result, unmount } = renderHook(() => useKeyboardIteratorCallback(callback), {
+    const { result, unmount } = renderHook(() => useKeyboardIteratorItem(callback), {
       wrapper: DocsWrapper,
     });
 

--- a/scm-ui/ui-shortcuts/src/iterator/keyboardIterator.tsx
+++ b/scm-ui/ui-shortcuts/src/iterator/keyboardIterator.tsx
@@ -25,7 +25,7 @@
 import React, { FC, useCallback, useContext, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useShortcut } from "../index";
-import { Callback, CallbackRegistry, Subiterator, useCallbackIterator } from "./callbackIterator";
+import { Callback, CallbackIterator, CallbackRegistry, useCallbackIterator } from "./callbackIterator";
 
 const KeyboardIteratorContext = React.createContext<CallbackRegistry>({
   register: () => {
@@ -43,7 +43,7 @@ const KeyboardIteratorContext = React.createContext<CallbackRegistry>({
   },
 });
 
-export const useKeyboardIteratorItem = (item: Callback | Subiterator) => {
+export const useKeyboardIteratorItem = (item: Callback | CallbackIterator) => {
   const { register, deregister } = useContext(KeyboardIteratorContext);
   useEffect(() => {
     const index = register(item);
@@ -51,8 +51,8 @@ export const useKeyboardIteratorItem = (item: Callback | Subiterator) => {
   }, [item, register, deregister]);
 };
 
-export const KeyboardSubIteratorContextProvider: FC = ({ children }) => {
-  const callbackIterator = useCallbackIterator();
+export const KeyboardSubIteratorContextProvider: FC<{ initialIndex?: number }> = ({ children, initialIndex }) => {
+  const callbackIterator = useCallbackIterator(initialIndex);
 
   useKeyboardIteratorItem(callbackIterator);
 

--- a/scm-ui/ui-webapp/src/repos/components/list/RepositoryList.tsx
+++ b/scm-ui/ui-webapp/src/repos/components/list/RepositoryList.tsx
@@ -28,7 +28,7 @@ import { NamespaceCollection, Repository } from "@scm-manager/ui-types";
 import groupByNamespace from "./groupByNamespace";
 import RepositoryGroupEntry from "./RepositoryGroupEntry";
 import { ExtensionPoint, extensionPoints } from "@scm-manager/ui-extensions";
-import { KeyboardIterator } from "@scm-manager/ui-shortcuts";
+import { KeyboardIterator, KeyboardSubIterator } from "@scm-manager/ui-shortcuts";
 
 type Props = {
   repositories: Repository[];
@@ -45,16 +45,18 @@ class RepositoryList extends React.Component<Props> {
     const groups = groupByNamespace(repositories, namespaces);
     return (
       <div className="content">
-        <ExtensionPoint<extensionPoints.RepositoryOverviewTop>
-          name="repository.overview.top"
-          renderAll={true}
-          props={{
-            page,
-            search,
-            namespace,
-          }}
-        />
         <KeyboardIterator>
+          <KeyboardSubIterator>
+            <ExtensionPoint<extensionPoints.RepositoryOverviewTop>
+              name="repository.overview.top"
+              renderAll={true}
+              props={{
+                page,
+                search,
+                namespace,
+              }}
+            />
+          </KeyboardSubIterator>
           {groups.map((group) => {
             return <RepositoryGroupEntry group={group} key={group.name} />;
           })}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,6 +1806,13 @@
   dependencies:
     "@sinclair/typebox" "^0.24.1"
 
+"@jest/schemas@^29.0.0":
+  version "29.0.0"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.0.0.tgz#5f47f5994dd4ef067fb7b4188ceac45f77fe952a"
+  integrity sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==
+  dependencies:
+    "@sinclair/typebox" "^0.24.1"
+
 "@jest/source-map@^24.3.0", "@jest/source-map@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-24.9.0.tgz#0e263a94430be4b41da683ccc1e6bffe2a191714"
@@ -7735,6 +7742,11 @@ diff-sequences@^28.1.1:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-28.1.1.tgz#9989dc731266dc2903457a70e996f3a041913ac6"
   integrity sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==
 
+diff-sequences@^29.3.1:
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.3.1.tgz#104b5b95fe725932421a9c6e5b4bef84c3f2249e"
+  integrity sha512-hlM3QR272NXCi4pq+N4Kok4kOp6EsgOM3ZSpJI7Da3UAs+Ttsi8MRmB6trM/lhyzUxGfOgnpkHtgqm5Q/CTcfQ==
+
 diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
@@ -11399,6 +11411,16 @@ jest-diff@^28.1.3:
     jest-get-type "^28.0.2"
     pretty-format "^28.1.3"
 
+jest-diff@^29.0.0:
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.3.1.tgz#d8215b72fed8f1e647aed2cae6c752a89e757527"
+  integrity sha512-vU8vyiO7568tmin2lA3r2DP8oRvzhvRcD4DjpXc6uGveQodyk7CKLhQlCSiwgx3g0pFaE88/KLZ0yaTWMc4Uiw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^29.3.1"
+    jest-get-type "^29.2.0"
+    pretty-format "^29.3.1"
+
 jest-docblock@^24.3.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-24.9.0.tgz#7970201802ba560e1c4092cc25cbedf5af5a8ce2"
@@ -11483,6 +11505,14 @@ jest-environment-node@^26.6.2:
     jest-mock "^26.6.2"
     jest-util "^26.6.2"
 
+jest-extended@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/jest-extended/-/jest-extended-3.1.0.tgz#7998699751f3b5d9207d212b39c1837f59c7fecc"
+  integrity sha512-BbuAVUb2dchgwm7euayVt/7hYlkKaknQItKyzie7Li8fmXCglgf21XJeRIdOITZ/cMOTTj5Oh5IjQOxQOe/hfQ==
+  dependencies:
+    jest-diff "^29.0.0"
+    jest-get-type "^29.0.0"
+
 jest-get-type@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
@@ -11497,6 +11527,11 @@ jest-get-type@^28.0.2:
   version "28.0.2"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-28.0.2.tgz#34622e628e4fdcd793d46db8a242227901fcf203"
   integrity sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==
+
+jest-get-type@^29.0.0, jest-get-type@^29.2.0:
+  version "29.2.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.2.0.tgz#726646f927ef61d583a3b3adb1ab13f3a5036408"
+  integrity sha512-uXNJlg8hKFEnDgFsrCjznB+sTxdkuqiCL6zMgA75qEbAJjJYTs9XPrvDctrEig2GDow22T/LvHgO57iJhXB/UA==
 
 jest-haste-map@^24.9.0:
   version "24.9.0"
@@ -15181,6 +15216,15 @@ pretty-format@^28.0.0, pretty-format@^28.1.3:
   dependencies:
     "@jest/schemas" "^28.1.3"
     ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
+
+pretty-format@^29.3.1:
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.3.1.tgz#1841cac822b02b4da8971dacb03e8a871b4722da"
+  integrity sha512-FyLnmb1cYJV8biEIiRyzRFvs2lry7PPIvOqKVe1GCUEYg4YGmlx1qG9EJNMxArYm7piII4qb8UV1Pncq5dxmcg==
+  dependencies:
+    "@jest/schemas" "^29.0.0"
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 


### PR DESCRIPTION
## Proposed changes

We recently introduced shortcut-based list navigation that ran into problems when the list contained items that were loaded asynchronously but had stand at the beginning of the list. As the system is based on render order, we had to introduce a new layer in-between the main iterator and the asynchronously loaded items. This new layer is called a "sub-iterator", which functions literally like the main iterator with the exception that it can also be used as an item of a parent-iterator. This allows for more complicated use-cases and the support of keyboard iterators around extension points. This pull request also fixes an unreleased regression where usages of the deprecated `confirmAlert` function caused a nullpointer exception.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
