### PR TITLE
Fix typo in the SCMM brand name

### DIFF
--- a/docs/en/user/repo/index.md
+++ b/docs/en/user/repo/index.md
@@ -40,7 +40,7 @@ Depending on the type of the new repository, there are different "ways" to impor
 - **Import via URL** (Git and Mercurial only): Here the repository is imported from a remote server specified by the
   remote repository's URL. In addition, a username and a password can be provided. Furthermore, for Git repositories
   LFS files can be excluded (if LFS is used in the remote repository).
-- **Import from dump without metadata**: Here a file can be uploaded. This may be a simple export from another SCN-Manager
+- **Import from dump without metadata**: Here a file can be uploaded. This may be a simple export from another SCM-Manager
   instance, or a dump file from another repository:
   - For Git and Mercurial, this has to be a tar packed file of the "internal" repository (the `.git` or the
     `.hg` directory).


### PR DESCRIPTION
## Proposed changes

This PR fixes the docs in which the SCM-Manager brand name contains a typo. It seems this is the only occurrence of `SCN-Manager`

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [x] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
